### PR TITLE
docs: add repository contribution rules

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/pull_request_template.md
+++ b/.github/PULL_REQUEST_TEMPLATE/pull_request_template.md
@@ -1,11 +1,34 @@
-## Changes
+## Summary
 
-*Please describe.*  
-*If this affects the frontend, include screenshots.*  
+Describe the change in 1-3 concise bullets.
 
-## Checklist
+## Scope
 
-- [ ] Check convention code
-- [ ] Make beautiful format code
-- [ ] Jest frontend tests
-- [ ] Cypress end-to-end tests
+- [ ] UI / UX
+- [ ] Content / SEO
+- [ ] Data / locale behavior
+- [ ] Build / deployment
+- [ ] Tests / tooling
+- [ ] Documentation
+
+## Verification
+
+- [ ] `npm run typecheck`
+- [ ] `npm run lint`
+- [ ] `npm test`
+- [ ] `npm run build` or `npm run build:fast`
+- [ ] Manual browser check
+
+## Screenshots
+
+Add before/after screenshots for UI changes, or write `Not applicable`.
+
+## Risk And Rollback
+
+- Risk level: low / medium / high
+- Rollback plan:
+
+## Notes For Reviewer
+
+- Default assignee: `nguyenlephong`
+- Deployment impact:

--- a/.github/workflows/auto-assign-pr.yml
+++ b/.github/workflows/auto-assign-pr.yml
@@ -1,0 +1,35 @@
+name: Auto-assign pull requests
+
+on:
+  pull_request_target:
+    types: [opened, reopened, ready_for_review]
+
+permissions:
+  issues: write
+  pull-requests: read
+
+jobs:
+  assign:
+    name: Assign repository owner
+    if: ${{ github.event.pull_request.draft == false }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Assign nguyenlephong
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const defaultAssignee = 'nguyenlephong'
+            const { owner, repo } = context.repo
+            const issue_number = context.payload.pull_request.number
+            const existingAssignees = context.payload.pull_request.assignees.map(
+              (assignee) => assignee.login,
+            )
+
+            if (!existingAssignees.includes(defaultAssignee)) {
+              await github.rest.issues.addAssignees({
+                owner,
+                repo,
+                issue_number,
+                assignees: [defaultAssignee],
+              })
+            }

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3,3 +3,25 @@
 When writing or editing public-facing content, blog posts, notes, book reflections, technical explainers, SEO summaries, article metadata, or copy for this repository, read and follow `AI/skills/calm-content-writer/SKILL.md`.
 
 Preserve the existing data model, locale behavior, SEO paths, and engagement/tracking behavior unless the user explicitly asks to change them.
+
+## Git Workflow
+
+- Work from `dev` for normal changes and open pull requests into `main`, unless the user explicitly requests another branch.
+- Before committing, run `git status --short` and review the staged diff so generated files, local build output, secrets, and unrelated user changes are not included.
+- Keep commits focused. Do not mix unrelated UI, content, build, and deployment changes in a single commit when they can be separated cleanly.
+- Use Conventional Commits for every commit and PR title:
+  - Format: `<type>(optional-scope): <imperative summary>`
+  - Common types: `feat`, `fix`, `docs`, `style`, `refactor`, `perf`, `test`, `build`, `ci`, `chore`, `revert`
+  - Keep the subject concise, lowercase after the type when natural, and without a trailing period.
+  - Use `!` or a `BREAKING CHANGE:` footer only for intentional breaking changes.
+  - Examples: `feat(studio): add layout density controls`, `fix(blog): preserve localized canonical paths`, `docs: tighten PR workflow rules`.
+
+## Pull Requests
+
+- Use the repository PR template and fill out the sections with concrete, reviewer-friendly details.
+- Default PR command for agent-created PRs:
+  `gh pr create --base main --head dev --assignee nguyenlephong`
+- If a PR already exists for the branch, update it instead of opening a duplicate.
+- PR descriptions must include what changed, how it was verified, and any deployment or content/SEO impact.
+- For UI changes, include screenshots or clearly state why screenshots were not captured.
+- Assign `nguyenlephong` by default. If GitHub rejects assignment, mention that explicitly in the handoff.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -3,3 +3,12 @@
 For content and copywriting tasks in this repository, use the project skill at `AI/skills/calm-content-writer/SKILL.md`.
 
 Apply it before drafting or editing blog posts, notes, book reflections, technical explainers, life-experience essays, SEO summaries, and article metadata.
+
+## Git and PR Rules
+
+- Commit with Conventional Commits: `<type>(optional-scope): <imperative summary>`.
+- Prefer these types: `feat`, `fix`, `docs`, `style`, `refactor`, `perf`, `test`, `build`, `ci`, `chore`, `revert`.
+- Keep commits focused and review `git status --short` plus the staged diff before committing.
+- Use `dev` as the normal working branch and open PRs into `main` unless instructed otherwise.
+- Use the repository PR template. Include summary, verification, risk/deploy notes, and screenshots for UI changes.
+- When creating PRs with GitHub CLI, include `--assignee nguyenlephong`.

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -3,3 +3,12 @@
 For content and copywriting tasks in this repository, use the project skill at `AI/skills/calm-content-writer/SKILL.md`.
 
 Apply it before drafting or editing blog posts, notes, book reflections, technical explainers, life-experience essays, SEO summaries, and article metadata.
+
+## Git and PR Rules
+
+- Commit with Conventional Commits: `<type>(optional-scope): <imperative summary>`.
+- Prefer these types: `feat`, `fix`, `docs`, `style`, `refactor`, `perf`, `test`, `build`, `ci`, `chore`, `revert`.
+- Keep commits focused and review `git status --short` plus the staged diff before committing.
+- Use `dev` as the normal working branch and open PRs into `main` unless instructed otherwise.
+- Use the repository PR template. Include summary, verification, risk/deploy notes, and screenshots for UI changes.
+- When creating PRs with GitHub CLI, include `--assignee nguyenlephong`.


### PR DESCRIPTION
## Summary

- Add repository-level agent rules for Conventional Commits, PR hygiene, branch usage, and default PR assignment.
- Expand Claude and Gemini instructions so non-Codex agents follow the same workflow.
- Replace the loose PR template with a reviewer-ready template and add an auto-assign workflow for pull requests.

## Scope

- [ ] UI / UX
- [ ] Content / SEO
- [ ] Data / locale behavior
- [ ] Build / deployment
- [ ] Tests / tooling
- [x] Documentation

## Verification

- [ ] `npm run typecheck`
- [ ] `npm run lint`
- [ ] `npm test`
- [ ] `npm run build` or `npm run build:fast`
- [x] `git diff --check`
- [x] YAML workflow parse check

## Screenshots

Not applicable.

## Risk And Rollback

- Risk level: low
- Rollback plan: revert `docs: add repository contribution rules`.

## Notes For Reviewer

- Default assignee: `nguyenlephong`
- Deployment impact: none; repository process/docs only.