### PR TITLE
fix(deploy): stage pages from output directory

### DIFF
--- a/scripts/deploy-pages.mjs
+++ b/scripts/deploy-pages.mjs
@@ -15,7 +15,7 @@ const COMMIT_MESSAGE =
 function run(command, args, options = {}) {
   console.log(`$ ${[command, ...args].join(' ')}`)
   const result = spawnSync(command, args, {
-    cwd: ROOT,
+    cwd: options.cwd ?? ROOT,
     env: options.env ?? process.env,
     stdio: 'inherit',
     shell: false,
@@ -27,7 +27,7 @@ function run(command, args, options = {}) {
 
 function output(command, args, options = {}) {
   const result = spawnSync(command, args, {
-    cwd: ROOT,
+    cwd: options.cwd ?? ROOT,
     encoding: 'utf8',
     env: options.env ?? process.env,
     maxBuffer: 1024 * 1024 * 20,
@@ -44,6 +44,9 @@ function currentRemoteBranchSha() {
   const [sha] = refs.split(/\s+/)
   return sha || null
 }
+
+const GIT_DIR = output('git', ['rev-parse', '--absolute-git-dir'])
+const outputTreeGitArgs = ['--git-dir', GIT_DIR, '--work-tree', OUT_DIR]
 
 if (!existsSync(OUT_DIR)) {
   console.error('[deploy-pages] missing out directory. Run `bun run build` first.')
@@ -67,11 +70,14 @@ const env = {
   GIT_INDEX_FILE: INDEX_FILE,
 }
 
-run('git', ['read-tree', '--empty'], { env })
-run('git', ['--work-tree', OUT_DIR, 'add', '-A', '.'], { env })
+run('git', [...outputTreeGitArgs, 'read-tree', '--empty'], { cwd: OUT_DIR, env })
+run('git', [...outputTreeGitArgs, 'add', '-A', '.'], { cwd: OUT_DIR, env })
 
-const tree = output('git', ['write-tree'], { env })
-const commit = output('git', ['commit-tree', tree, '-m', COMMIT_MESSAGE], { env })
+const tree = output('git', [...outputTreeGitArgs, 'write-tree'], { cwd: OUT_DIR, env })
+const commit = output('git', [...outputTreeGitArgs, 'commit-tree', tree, '-m', COMMIT_MESSAGE], {
+  cwd: OUT_DIR,
+  env,
+})
 const remoteSha = currentRemoteBranchSha()
 const pushArgs = ['push', REMOTE, `${commit}:refs/heads/${BRANCH}`]
 


### PR DESCRIPTION
## Summary

- Fix `deploy:out` staging by running the temporary-index Git commands from the `out` directory with an explicit `--git-dir` and `--work-tree`.
- Keep the direct snapshot publisher from PR #25, but avoid the pathspec/stat mismatch that caused `fatal: unable to stat ... No such file or directory`.

## Scope

- [ ] UI / UX
- [ ] Content / SEO
- [ ] Data / locale behavior
- [x] Build / deployment
- [x] Tests / tooling
- [ ] Documentation

## Verification

- [ ] `npm run typecheck`
- [ ] `npm run lint`
- [ ] `npm test`
- [x] `npm run build` or `npm run build:fast`
- [ ] Manual browser check

## Screenshots

Not applicable. This changes deployment tooling only.

## Risk And Rollback

- Risk level: low
- Rollback plan: revert this PR to restore the PR #25 deploy script.

## Notes For Reviewer

- Default assignee: `nguyenlephong`
- Deployment impact: verified `bun run deploy:out` successfully published `origin/gh-pages` at `39d5f11daeb8ee39616997a9dc01850ed977b337`.
