### PR TITLE
Add day 29 roadmap blog posts

### DIFF
--- a/public/blog-data/_index.json
+++ b/public/blog-data/_index.json
@@ -43,6 +43,91 @@
   ],
   "posts": [
     {
+      "slug": "making-handoffs-honest-about-what-is-unknown",
+      "category": "ways-of-working",
+      "title": "Making Handoffs Honest About What Is Unknown",
+      "summary": "A practical note on writing handoffs that include open questions, assumptions, and risk instead of pretending the work is more certain than it is.",
+      "date": "2026-07-18",
+      "readingMinutes": 5,
+      "tags": [
+        "Ways of Working",
+        "Handoffs",
+        "Communication",
+        "Risk",
+        "Delivery",
+        "Teamwork"
+      ],
+      "author": "Nguyen Le Phong"
+    },
+    {
+      "slug": "the-quiet-discipline-of-finishing-properly",
+      "category": "perspectives",
+      "title": "The Quiet Discipline of Finishing Properly",
+      "summary": "A reflective note on the small discipline of closing work with evidence, cleanup, and context instead of only reaching the visible finish line.",
+      "date": "2026-07-17",
+      "readingMinutes": 5,
+      "tags": [
+        "Reflection",
+        "Craft",
+        "Follow Through",
+        "Sustainable Work",
+        "Quality",
+        "Clarity"
+      ],
+      "author": "Nguyen Le Phong"
+    },
+    {
+      "slug": "asking-ai-to-name-its-assumptions",
+      "category": "ai",
+      "title": "Asking AI to Name Its Assumptions",
+      "summary": "A practical reflection on making AI-assisted work safer by asking the model to expose assumptions before accepting its answer.",
+      "date": "2026-07-16",
+      "readingMinutes": 5,
+      "tags": [
+        "AI",
+        "LLM",
+        "Prompting",
+        "Verification",
+        "Developer Tools",
+        "Judgment"
+      ],
+      "author": "Nguyen Le Phong"
+    },
+    {
+      "slug": "noticing-friction-before-it-becomes-blame",
+      "category": "culture",
+      "title": "Noticing Friction Before It Becomes Blame",
+      "summary": "A calm note on treating repeated team friction as useful signal before it hardens into personal blame.",
+      "date": "2026-07-15",
+      "readingMinutes": 5,
+      "tags": [
+        "Engineering Culture",
+        "Teamwork",
+        "Feedback",
+        "Process",
+        "Leadership",
+        "Communication"
+      ],
+      "author": "Nguyen Le Phong"
+    },
+    {
+      "slug": "keeping-data-contracts-small-enough-to-trust",
+      "category": "architecture",
+      "title": "Keeping Data Contracts Small Enough to Trust",
+      "summary": "A practical reflection on designing data contracts that are narrow, testable, and stable enough for teams to rely on.",
+      "date": "2026-07-14",
+      "readingMinutes": 5,
+      "tags": [
+        "Software Architecture",
+        "Data Contracts",
+        "APIs",
+        "Reliability",
+        "Testing",
+        "Product Engineering"
+      ],
+      "author": "Nguyen Le Phong"
+    },
+    {
       "slug": "keeping-checklists-close-to-the-work",
       "category": "ways-of-working",
       "title": "Keeping Checklists Close to the Work",

--- a/public/blog-data/posts/asking-ai-to-name-its-assumptions.json
+++ b/public/blog-data/posts/asking-ai-to-name-its-assumptions.json
@@ -1,0 +1,18 @@
+{
+  "slug": "asking-ai-to-name-its-assumptions",
+  "category": "ai",
+  "title": "Asking AI to Name Its Assumptions",
+  "summary": "A practical reflection on making AI-assisted work safer by asking the model to expose assumptions before accepting its answer.",
+  "date": "2026-07-16",
+  "readingMinutes": 5,
+  "tags": [
+    "AI",
+    "LLM",
+    "Prompting",
+    "Verification",
+    "Developer Tools",
+    "Judgment"
+  ],
+  "author": "Nguyen Le Phong",
+  "html": "<p>The AI answer was useful, but it skipped the part where it guessed. It assumed the endpoint was internal, the user was authenticated, the data was already tenant-scoped, and the test fixture matched production shape. None of those assumptions were strange. That was exactly why they needed to be named.</p>\n<figure class='blog-figure blog-photo-panorama'>\n  <img src='https://nguyenlephong.github.io/dom-pub/icdn/blogs/asking-ai-to-name-its-assumptions/ai-assumption-cards.webp' width='1600' height='900' loading='lazy' decoding='async' alt='A developer reviews an AI-assisted workspace with abstract code blocks, assumption cards, evidence marks, and a handwritten checklist.' />\n  <figcaption>AI work is easier to verify when hidden assumptions are brought into the room.</figcaption>\n</figure>\n<p>Language models fill gaps. That is part of what makes them useful. They can keep moving when a human question is incomplete. But the filled gap can become dangerous when it looks like knowledge instead of assumption.</p>\n<p>One simple habit helps: ask the model to name what it is assuming. Not after the final answer, but as part of the answer. The assumption list becomes a map of where verification should go next.</p>\n<p>For code, assumptions often hide around runtime behavior. Is this server-side or client-side? Is the data trusted? Can the function be retried? Does the caller already hold authorization? Does the database guarantee uniqueness? These are not small details. They are often the difference between a clean suggestion and a bug.</p>\n<p>For product writing, assumptions hide around audience and intent. Is the reader technical? Are we trying to persuade, explain, warn, or document? Does the wording need to be calm, formal, local, or operational? A good draft depends on those answers.</p>\n<p>Once assumptions are visible, the human can decide. Some are safe. Some need a source check. Some are wrong. Some reveal that the original request was missing the most important context.</p>\n<p>This also makes collaboration less mysterious. Instead of arguing with a polished AI answer, the team can inspect the scaffolding beneath it. The conversation moves from whether the model is smart to whether the assumptions match reality.</p>\n<p>Before accepting an AI suggestion, ask for the assumption list. Then verify the load-bearing ones. The answer may still need editing, but it will be much clearer where responsibility belongs.</p>"
+}

--- a/public/blog-data/posts/keeping-data-contracts-small-enough-to-trust.json
+++ b/public/blog-data/posts/keeping-data-contracts-small-enough-to-trust.json
@@ -1,0 +1,18 @@
+{
+  "slug": "keeping-data-contracts-small-enough-to-trust",
+  "category": "architecture",
+  "title": "Keeping Data Contracts Small Enough to Trust",
+  "summary": "A practical reflection on designing data contracts that are narrow, testable, and stable enough for teams to rely on.",
+  "date": "2026-07-14",
+  "readingMinutes": 5,
+  "tags": [
+    "Software Architecture",
+    "Data Contracts",
+    "APIs",
+    "Reliability",
+    "Testing",
+    "Product Engineering"
+  ],
+  "author": "Nguyen Le Phong",
+  "html": "<p>The contract looked complete, which was part of the problem. It listed every field anyone might need, several optional shapes, and a few values whose meaning depended on where the data came from. It was generous, but hard to trust. The first useful improvement was not adding another field. It was making the promise smaller.</p>\n<figure class='blog-figure blog-photo-panorama'>\n  <img src='https://nguyenlephong.github.io/dom-pub/icdn/blogs/keeping-data-contracts-small-enough-to-trust/small-data-contracts.webp' width='1600' height='900' loading='lazy' decoding='async' alt='Engineers review compact data contract cards, abstract schema blocks, and simple test markers on a quiet architecture table.' />\n  <figcaption>A data contract becomes safer when the team can explain and test every promise inside it.</figcaption>\n</figure>\n<p>A data contract is not a place to store hope. It is a shared promise between producers and consumers. When the promise becomes too wide, everyone starts depending on different corners of it, and nobody is sure which parts are stable.</p>\n<p>Small contracts are easier to trust because they are easier to name. This field means this. This value is always present. This timestamp uses this clock. This identifier belongs to this owner. The language gets boring, and that is a good sign.</p>\n<p>Small contracts also make change visible. If a new consumer needs extra data, the team can decide whether the contract should grow, whether a separate read model is better, or whether the consumer is reaching across a boundary it should not cross.</p>\n<p>The opposite is the all-purpose payload. It feels convenient at first because nobody has to ask for a change. Later, every producer is afraid to remove anything and every consumer quietly depends on behavior that was never reviewed.</p>\n<p>Testing is a useful pressure test. If a contract is too vague to test clearly, it is probably too vague to rely on. A good contract should have examples, validation, and failure cases that a future teammate can run without knowing the whole history.</p>\n<p>Versioning also becomes less dramatic when contracts are small. A narrow promise is easier to keep compatible. A wide promise creates accidental API surface area, and accidental surface area ages badly.</p>\n<p>Before adding the next field, ask whether the contract is still small enough to explain. If the team can name its owner, test its meaning, and describe who depends on it, the contract is not just data passing through. It is architecture doing quiet work.</p>"
+}

--- a/public/blog-data/posts/making-handoffs-honest-about-what-is-unknown.json
+++ b/public/blog-data/posts/making-handoffs-honest-about-what-is-unknown.json
@@ -1,0 +1,18 @@
+{
+  "slug": "making-handoffs-honest-about-what-is-unknown",
+  "category": "ways-of-working",
+  "title": "Making Handoffs Honest About What Is Unknown",
+  "summary": "A practical note on writing handoffs that include open questions, assumptions, and risk instead of pretending the work is more certain than it is.",
+  "date": "2026-07-18",
+  "readingMinutes": 5,
+  "tags": [
+    "Ways of Working",
+    "Handoffs",
+    "Communication",
+    "Risk",
+    "Delivery",
+    "Teamwork"
+  ],
+  "author": "Nguyen Le Phong",
+  "html": "<p>The handoff looked clean. It listed the branch, the ticket, the test command, and the next owner. Then the next owner opened the work and found the real question: nobody knew whether one provider case had been confirmed. The handoff was neat, but not honest enough.</p>\n<figure class='blog-figure blog-photo-panorama'>\n  <img src='https://nguyenlephong.github.io/dom-pub/icdn/blogs/making-handoffs-honest-about-what-is-unknown/honest-handoff-notes.webp' width='1600' height='900' loading='lazy' decoding='async' alt='A calm handoff table with notebooks, task cards, question markers, known and unknown areas, and two people passing work context.' />\n  <figcaption>An honest handoff makes uncertainty visible before it becomes rework.</figcaption>\n</figure>\n<p>A handoff is not only a list of completed steps. It is a transfer of context. If the context includes uncertainty, the handoff should say so clearly. Otherwise the next person inherits a hidden guess.</p>\n<p>Unknowns are not embarrassing. They are part of real work. The problem is not that something is unknown. The problem is when the unknown is hidden behind confident wording, or spread across chat messages that the next person will never find.</p>\n<p>A useful handoff separates what is known, what is assumed, and what still needs confirmation. Known means verified. Assumed means reasonable but not proven. Needs confirmation means do not treat this as safe yet.</p>\n<p>This distinction saves time. The next person can continue from evidence instead of repeating discovery. They can also decide whether to proceed, test, escalate, or pause based on the real shape of the risk.</p>\n<p>Honest handoffs also reduce blame. If an assumption later turns out wrong, the team can inspect why it was reasonable and whether it should have been verified earlier. That is a much better conversation than discovering the assumption only after failure.</p>\n<p>The format can be simple. Changed, verified, not verified, risks, next action, owner. The important part is not the template. The important part is refusing to make uncertainty invisible.</p>\n<p>Before handing off work, read the note as the next person. Would they know what is solid? Would they know what is still soft? Would they know where to look first if something behaves strangely? If not, the handoff is tidy, but not finished.</p>"
+}

--- a/public/blog-data/posts/noticing-friction-before-it-becomes-blame.json
+++ b/public/blog-data/posts/noticing-friction-before-it-becomes-blame.json
@@ -1,0 +1,18 @@
+{
+  "slug": "noticing-friction-before-it-becomes-blame",
+  "category": "culture",
+  "title": "Noticing Friction Before It Becomes Blame",
+  "summary": "A calm note on treating repeated team friction as useful signal before it hardens into personal blame.",
+  "date": "2026-07-15",
+  "readingMinutes": 5,
+  "tags": [
+    "Engineering Culture",
+    "Teamwork",
+    "Feedback",
+    "Process",
+    "Leadership",
+    "Communication"
+  ],
+  "author": "Nguyen Le Phong",
+  "html": "<p>The team was not fighting. That made the friction easier to miss. A review waited two days. A handoff lost one small decision. A tester asked the same question for the third release in a row. Nobody had done anything terrible, but the system was starting to ask people to compensate quietly.</p>\n<figure class='blog-figure blog-photo-panorama'>\n  <img src='https://nguyenlephong.github.io/dom-pub/icdn/blogs/noticing-friction-before-it-becomes-blame/friction-before-blame.webp' width='1600' height='900' loading='lazy' decoding='async' alt='A small team studies a muted workflow board with sticky notes, simple friction markers, and a calm review table.' />\n  <figcaption>Friction is easier to fix while it is still a signal, not a story about someone.</figcaption>\n</figure>\n<p>Friction is not the same as failure. It is the small resistance people feel when the way work moves does not match the way decisions, context, or ownership are actually arranged. Left alone, friction becomes a story. The story often becomes blame.</p>\n<p>Early friction sounds ordinary. I did not know this was mine. I thought product had decided. I was waiting for review. I did not see the updated acceptance criteria. These sentences are not accusations yet. They are clues.</p>\n<p>The healthy move is to look at the path before judging the person. Where did context disappear? Where was ownership unclear? Which decision lived only in a meeting? Which tool made the next action invisible?</p>\n<p>This does not remove accountability. People still need to follow through. But accountability works better when the process is not forcing good people to guess. A team should not need hero memory for routine delivery.</p>\n<p>Friction becomes dangerous when people normalize it. A little delay is fine. A little repeated confusion is not. Repetition is what turns a small inconvenience into a team tax.</p>\n<p>I like naming friction in low-drama language. We are losing context between planning and QA. Reviews are waiting because ownership is implicit. Release notes are too late for support. The sentence should point at the system first.</p>\n<p>If the team can notice friction early, it can fix something small: a template, a checklist, a clearer owner, a decision log, a better handoff. That is much cheaper than waiting until people are tired enough to explain the problem as someone else's character.</p>"
+}

--- a/public/blog-data/posts/the-quiet-discipline-of-finishing-properly.json
+++ b/public/blog-data/posts/the-quiet-discipline-of-finishing-properly.json
@@ -1,0 +1,18 @@
+{
+  "slug": "the-quiet-discipline-of-finishing-properly",
+  "category": "perspectives",
+  "title": "The Quiet Discipline of Finishing Properly",
+  "summary": "A reflective note on the small discipline of closing work with evidence, cleanup, and context instead of only reaching the visible finish line.",
+  "date": "2026-07-17",
+  "readingMinutes": 5,
+  "tags": [
+    "Reflection",
+    "Craft",
+    "Follow Through",
+    "Sustainable Work",
+    "Quality",
+    "Clarity"
+  ],
+  "author": "Nguyen Le Phong",
+  "html": "<p>The work was basically done. That is always the dangerous sentence. The main change worked, the demo looked fine, and the next task was waiting. But the notes were thin, the rollback was not written, and the final check still lived in someone's memory. The visible finish line had arrived before the real finish.</p>\n<figure class='blog-figure blog-photo-panorama'>\n  <img src='https://nguyenlephong.github.io/dom-pub/icdn/blogs/the-quiet-discipline-of-finishing-properly/finishing-properly-desk.webp' width='1600' height='900' loading='lazy' decoding='async' alt='A tidy desk at the end of a workday with a closed laptop, icon-only checklist, notes, warm lamp, and dusk light.' />\n  <figcaption>Finishing properly is often quiet work done after the exciting part is over.</figcaption>\n</figure>\n<p>Finishing properly is not glamorous. It is checking the edge case, updating the note, removing the temporary flag, writing the handoff, linking the evidence, and making sure the next person does not have to ask what happened.</p>\n<p>This discipline matters because unfinished edges become future interruptions. The code may run, but the team still pays if nobody knows how to verify it, operate it, or explain why a trade-off was made.</p>\n<p>I have learned to respect the last ten percent of work. It is where confidence becomes inspectable. A passing test is useful. A passing test plus the reason it matters is better. A deployed feature is useful. A deployed feature plus rollback criteria is calmer.</p>\n<p>The temptation is to rush away once the visible problem is solved. That temptation is understandable. Teams have pressure, queues, and deadlines. But moving too quickly can create a trail of almost-finished work that slows everyone later.</p>\n<p>Finishing properly also protects pride from becoming performance. The point is not to prove that every detail is perfect. The point is to leave the work in a state where someone else can continue without guessing.</p>\n<p>A small closing ritual helps. What changed? How was it verified? What remains risky? What should someone do if it fails? Where is the evidence? These questions turn done from a feeling into a shared state.</p>\n<p>The quiet discipline of finishing properly is a form of care. It cares for the next teammate, the future incident, and your own attention tomorrow. The task is not really done when it works once. It is done when the work can stand without you holding it up.</p>"
+}

--- a/public/blog-data/vi/_index.json
+++ b/public/blog-data/vi/_index.json
@@ -43,6 +43,91 @@
   ],
   "posts": [
     {
+      "slug": "making-handoffs-honest-about-what-is-unknown",
+      "category": "ways-of-working",
+      "title": "Làm handoff thành thật về điều chưa biết",
+      "summary": "Một ghi chú thực tế về cách viết handoff có open questions, assumptions và risk thay vì giả vờ work chắc chắn hơn thực tế.",
+      "date": "2026-07-18",
+      "readingMinutes": 6,
+      "tags": [
+        "Ways of Working",
+        "Handoffs",
+        "Communication",
+        "Risk",
+        "Delivery",
+        "Teamwork"
+      ],
+      "author": "Nguyen Le Phong"
+    },
+    {
+      "slug": "the-quiet-discipline-of-finishing-properly",
+      "category": "perspectives",
+      "title": "Kỷ luật thầm lặng của việc hoàn tất đúng cách",
+      "summary": "Một ghi chú phản chiếu về kỷ luật nhỏ khi đóng work bằng evidence, cleanup và context thay vì chỉ chạm tới finish line nhìn thấy được.",
+      "date": "2026-07-17",
+      "readingMinutes": 6,
+      "tags": [
+        "Reflection",
+        "Craft",
+        "Follow Through",
+        "Sustainable Work",
+        "Quality",
+        "Clarity"
+      ],
+      "author": "Nguyen Le Phong"
+    },
+    {
+      "slug": "asking-ai-to-name-its-assumptions",
+      "category": "ai",
+      "title": "Yêu cầu AI gọi tên assumption của nó",
+      "summary": "Một reflection thực tế về cách làm AI-assisted work an toàn hơn bằng cách yêu cầu model bộc lộ assumption trước khi chấp nhận answer.",
+      "date": "2026-07-16",
+      "readingMinutes": 6,
+      "tags": [
+        "AI",
+        "LLM",
+        "Prompting",
+        "Verification",
+        "Developer Tools",
+        "Judgment"
+      ],
+      "author": "Nguyen Le Phong"
+    },
+    {
+      "slug": "noticing-friction-before-it-becomes-blame",
+      "category": "culture",
+      "title": "Nhận ra friction trước khi nó thành blame",
+      "summary": "Một ghi chú bình tĩnh về việc xem friction lặp lại trong team như tín hiệu hữu ích trước khi nó đông cứng thành blame cá nhân.",
+      "date": "2026-07-15",
+      "readingMinutes": 6,
+      "tags": [
+        "Engineering Culture",
+        "Teamwork",
+        "Feedback",
+        "Process",
+        "Leadership",
+        "Communication"
+      ],
+      "author": "Nguyen Le Phong"
+    },
+    {
+      "slug": "keeping-data-contracts-small-enough-to-trust",
+      "category": "architecture",
+      "title": "Giữ data contract đủ nhỏ để tin được",
+      "summary": "Một reflection thực tế về cách thiết kế data contract hẹp, testable và đủ ổn định để team có thể dựa vào.",
+      "date": "2026-07-14",
+      "readingMinutes": 6,
+      "tags": [
+        "Software Architecture",
+        "Data Contracts",
+        "APIs",
+        "Reliability",
+        "Testing",
+        "Product Engineering"
+      ],
+      "author": "Nguyen Le Phong"
+    },
+    {
       "slug": "keeping-checklists-close-to-the-work",
       "category": "ways-of-working",
       "title": "Giữ checklist ở gần nơi công việc diễn ra",

--- a/public/blog-data/vi/posts/asking-ai-to-name-its-assumptions.json
+++ b/public/blog-data/vi/posts/asking-ai-to-name-its-assumptions.json
@@ -1,0 +1,14 @@
+{
+  "title": "Yêu cầu AI gọi tên assumption của nó",
+  "summary": "Một reflection thực tế về cách làm AI-assisted work an toàn hơn bằng cách yêu cầu model bộc lộ assumption trước khi chấp nhận answer.",
+  "readingMinutes": 6,
+  "tags": [
+    "AI",
+    "LLM",
+    "Prompting",
+    "Verification",
+    "Developer Tools",
+    "Judgment"
+  ],
+  "html": "<p>Câu trả lời của AI hữu ích, nhưng nó bỏ qua phần nó đã đoán. Nó assume endpoint là internal, user đã authenticated, data đã tenant-scoped, và test fixture giống production shape. Không assumption nào lạ. Chính vì vậy chúng cần được gọi tên.</p>\n<figure class='blog-figure blog-photo-panorama'>\n  <img src='https://nguyenlephong.github.io/dom-pub/icdn/blogs/asking-ai-to-name-its-assumptions/ai-assumption-cards.webp' width='1600' height='900' loading='lazy' decoding='async' alt='Một developer review workspace có AI hỗ trợ với code block trừu tượng, assumption cards, evidence marks và checklist viết tay.' />\n  <figcaption>AI work dễ verify hơn khi hidden assumptions được đưa vào cùng căn phòng.</figcaption>\n</figure>\n<p>Language model lấp khoảng trống. Đó là một phần khiến chúng hữu ích. Chúng có thể tiếp tục khi câu hỏi của con người chưa đầy đủ. Nhưng khoảng trống được lấp có thể nguy hiểm khi nó trông như knowledge thay vì assumption.</p>\n<p>Một thói quen đơn giản giúp nhiều: yêu cầu model gọi tên những điều nó đang assume. Không phải sau final answer, mà là một phần của answer. Assumption list trở thành bản đồ cho verification tiếp theo.</p>\n<p>Với code, assumption thường ẩn quanh runtime behavior. Đây là server-side hay client-side? Data có trusted không? Function có thể retry không? Caller đã có authorization chưa? Database có guarantee uniqueness không? Đây không phải chi tiết nhỏ. Chúng thường là khác biệt giữa suggestion sạch và bug.</p>\n<p>Với product writing, assumption ẩn quanh audience và intent. Reader có technical không? Mình đang persuade, explain, warn hay document? Wording cần calm, formal, local hay operational? Draft tốt phụ thuộc vào những câu trả lời đó.</p>\n<p>Khi assumption visible, con người có thể decide. Một số assumption an toàn. Một số cần source check. Một số sai. Một số cho thấy request ban đầu thiếu context quan trọng nhất.</p>\n<p>Điều này cũng làm collaboration bớt bí ẩn. Thay vì tranh luận với AI answer bóng bẩy, team có thể inspect scaffolding bên dưới nó. Conversation chuyển từ model có thông minh không sang assumptions có khớp reality không.</p>\n<p>Trước khi chấp nhận AI suggestion, hãy hỏi assumption list. Rồi verify những assumption load-bearing. Answer vẫn có thể cần sửa, nhưng sẽ rõ hơn rất nhiều responsibility nằm ở đâu.</p>"
+}

--- a/public/blog-data/vi/posts/keeping-data-contracts-small-enough-to-trust.json
+++ b/public/blog-data/vi/posts/keeping-data-contracts-small-enough-to-trust.json
@@ -1,0 +1,14 @@
+{
+  "title": "Giữ data contract đủ nhỏ để tin được",
+  "summary": "Một reflection thực tế về cách thiết kế data contract hẹp, testable và đủ ổn định để team có thể dựa vào.",
+  "readingMinutes": 6,
+  "tags": [
+    "Software Architecture",
+    "Data Contracts",
+    "APIs",
+    "Reliability",
+    "Testing",
+    "Product Engineering"
+  ],
+  "html": "<p>Contract đó trông rất đầy đủ, và đó lại là một phần của vấn đề. Nó liệt kê mọi field có thể có người cần, vài optional shape, và vài value mà meaning phụ thuộc vào data đến từ đâu. Nó rộng rãi, nhưng khó tin. Cải thiện hữu ích đầu tiên không phải thêm field nữa. Đó là làm lời hứa nhỏ lại.</p>\n<figure class='blog-figure blog-photo-panorama'>\n  <img src='https://nguyenlephong.github.io/dom-pub/icdn/blogs/keeping-data-contracts-small-enough-to-trust/small-data-contracts.webp' width='1600' height='900' loading='lazy' decoding='async' alt='Các engineer review những data contract card gọn, schema block trừu tượng và test marker đơn giản trên một bàn architecture yên tĩnh.' />\n  <figcaption>Data contract an toàn hơn khi team giải thích và test được từng lời hứa bên trong nó.</figcaption>\n</figure>\n<p>Data contract không phải nơi để cất hy vọng. Nó là shared promise giữa producer và consumer. Khi promise quá rộng, mỗi người bắt đầu phụ thuộc vào một góc khác nhau của nó, và không ai chắc phần nào thật sự stable.</p>\n<p>Contract nhỏ dễ tin hơn vì dễ gọi tên hơn. Field này nghĩa là điều này. Value này luôn có mặt. Timestamp này dùng clock này. Identifier này thuộc owner này. Ngôn ngữ trở nên boring, và đó là dấu hiệu tốt.</p>\n<p>Contract nhỏ cũng làm change visible hơn. Nếu một consumer mới cần thêm data, team có thể decide contract có nên lớn lên không, một read model riêng có tốt hơn không, hay consumer đó đang với tay qua boundary không nên vượt.</p>\n<p>Ngược lại là all-purpose payload. Ban đầu nó tiện vì không ai cần request change. Về sau, producer sợ remove bất cứ thứ gì, còn consumer âm thầm phụ thuộc vào behavior chưa từng được review.</p>\n<p>Testing là pressure test hữu ích. Nếu contract quá mơ hồ để test rõ, nó có lẽ cũng quá mơ hồ để dựa vào. Contract tốt nên có example, validation và failure case mà teammate tương lai chạy được mà không cần biết toàn bộ lịch sử.</p>\n<p>Versioning cũng bớt kịch tính khi contract nhỏ. Promise hẹp dễ giữ compatible hơn. Promise rộng tạo accidental API surface area, và surface area vô tình thì già đi rất tệ.</p>\n<p>Trước khi thêm field tiếp theo, hãy hỏi contract còn đủ nhỏ để giải thích không. Nếu team gọi được owner của nó, test được meaning của nó, và mô tả được ai đang depend vào nó, contract không chỉ là data đi qua. Nó là architecture đang làm việc âm thầm.</p>"
+}

--- a/public/blog-data/vi/posts/making-handoffs-honest-about-what-is-unknown.json
+++ b/public/blog-data/vi/posts/making-handoffs-honest-about-what-is-unknown.json
@@ -1,0 +1,14 @@
+{
+  "title": "Làm handoff thành thật về điều chưa biết",
+  "summary": "Một ghi chú thực tế về cách viết handoff có open questions, assumptions và risk thay vì giả vờ work chắc chắn hơn thực tế.",
+  "readingMinutes": 6,
+  "tags": [
+    "Ways of Working",
+    "Handoffs",
+    "Communication",
+    "Risk",
+    "Delivery",
+    "Teamwork"
+  ],
+  "html": "<p>Handoff đó nhìn sạch. Nó liệt kê branch, ticket, test command và next owner. Rồi next owner mở work ra và tìm thấy câu hỏi thật: chưa ai biết một provider case đã được confirm chưa. Handoff gọn, nhưng chưa đủ thành thật.</p>\n<figure class='blog-figure blog-photo-panorama'>\n  <img src='https://nguyenlephong.github.io/dom-pub/icdn/blogs/making-handoffs-honest-about-what-is-unknown/honest-handoff-notes.webp' width='1600' height='900' loading='lazy' decoding='async' alt='Một bàn handoff bình tĩnh với notebooks, task cards, question markers, vùng known và unknown, và hai người chuyển context công việc.' />\n  <figcaption>Handoff thành thật làm uncertainty visible trước khi nó trở thành rework.</figcaption>\n</figure>\n<p>Handoff không chỉ là list những step đã xong. Nó là transfer context. Nếu context có uncertainty, handoff nên nói rõ. Nếu không, người tiếp theo thừa hưởng một hidden guess.</p>\n<p>Unknown không có gì đáng xấu hổ. Nó là một phần của work thật. Vấn đề không phải có thứ chưa biết. Vấn đề là unknown bị giấu sau wording tự tin, hoặc nằm rải rác trong chat message mà người tiếp theo sẽ không bao giờ tìm thấy.</p>\n<p>Handoff hữu ích tách riêng what is known, what is assumed và what still needs confirmation. Known nghĩa là đã verified. Assumed nghĩa là hợp lý nhưng chưa proven. Needs confirmation nghĩa là đừng xem nó đã safe.</p>\n<p>Phân biệt này tiết kiệm thời gian. Người tiếp theo có thể tiếp tục từ evidence thay vì lặp lại discovery. Họ cũng có thể decide proceed, test, escalate hoặc pause dựa trên shape thật của risk.</p>\n<p>Handoff thành thật cũng giảm blame. Nếu một assumption sau này sai, team có thể inspect vì sao nó từng hợp lý và liệu nó nên được verify sớm hơn không. Đó là cuộc nói chuyện tốt hơn nhiều so với chỉ phát hiện assumption sau failure.</p>\n<p>Format có thể đơn giản. Changed, verified, not verified, risks, next action, owner. Quan trọng không phải template. Quan trọng là từ chối làm uncertainty invisible.</p>\n<p>Trước khi hand off work, hãy đọc note như người tiếp theo. Họ có biết điều gì solid không? Họ có biết điều gì còn soft không? Họ có biết nhìn đâu trước nếu có thứ behave lạ không? Nếu chưa, handoff có thể tidy, nhưng chưa finished.</p>"
+}

--- a/public/blog-data/vi/posts/noticing-friction-before-it-becomes-blame.json
+++ b/public/blog-data/vi/posts/noticing-friction-before-it-becomes-blame.json
@@ -1,0 +1,14 @@
+{
+  "title": "Nhận ra friction trước khi nó thành blame",
+  "summary": "Một ghi chú bình tĩnh về việc xem friction lặp lại trong team như tín hiệu hữu ích trước khi nó đông cứng thành blame cá nhân.",
+  "readingMinutes": 6,
+  "tags": [
+    "Engineering Culture",
+    "Teamwork",
+    "Feedback",
+    "Process",
+    "Leadership",
+    "Communication"
+  ],
+  "html": "<p>Team không hề cãi nhau. Chính vì vậy friction càng dễ bị bỏ qua. Một review chờ hai ngày. Một handoff mất một decision nhỏ. Tester hỏi cùng một câu cho release thứ ba liên tiếp. Không ai làm điều gì quá tệ, nhưng system đang bắt mọi người âm thầm bù trừ.</p>\n<figure class='blog-figure blog-photo-panorama'>\n  <img src='https://nguyenlephong.github.io/dom-pub/icdn/blogs/noticing-friction-before-it-becomes-blame/friction-before-blame.webp' width='1600' height='900' loading='lazy' decoding='async' alt='Một team nhỏ nhìn workflow board màu nhẹ với sticky notes, friction marker đơn giản và một bàn review bình tĩnh.' />\n  <figcaption>Friction dễ sửa hơn khi nó còn là tín hiệu, chưa thành câu chuyện về một người.</figcaption>\n</figure>\n<p>Friction không giống failure. Nó là lực cản nhỏ mọi người cảm thấy khi cách work di chuyển không khớp với cách decision, context hoặc ownership thật sự được sắp xếp. Nếu để yên, friction thành story. Story thường thành blame.</p>\n<p>Friction sớm nghe rất bình thường. Tôi không biết việc này là của tôi. Tôi tưởng product đã decide. Tôi đang chờ review. Tôi không thấy acceptance criteria mới. Những câu này chưa phải accusation. Chúng là clue.</p>\n<p>Động tác lành mạnh là nhìn path trước khi đánh giá person. Context biến mất ở đâu? Ownership mơ hồ ở đâu? Decision nào chỉ sống trong meeting? Tool nào làm next action trở nên invisible?</p>\n<p>Điều này không bỏ accountability. Mọi người vẫn cần follow through. Nhưng accountability hoạt động tốt hơn khi process không bắt người tốt phải đoán. Một team không nên cần hero memory cho routine delivery.</p>\n<p>Friction nguy hiểm khi mọi người normalize nó. Một chút delay có thể ổn. Một chút confusion lặp lại thì không. Repetition biến inconvenience nhỏ thành team tax.</p>\n<p>Tôi thích gọi tên friction bằng ngôn ngữ ít drama. Chúng ta đang mất context giữa planning và QA. Review đang chờ vì ownership implicit. Release notes quá trễ cho support. Câu nói nên chỉ vào system trước.</p>\n<p>Nếu team nhận ra friction sớm, team có thể sửa một thứ nhỏ: template, checklist, owner rõ hơn, decision log, handoff tốt hơn. Rẻ hơn rất nhiều so với chờ đến khi mọi người mệt đủ để giải thích vấn đề như character của ai đó.</p>"
+}

--- a/public/blog-data/vi/posts/the-quiet-discipline-of-finishing-properly.json
+++ b/public/blog-data/vi/posts/the-quiet-discipline-of-finishing-properly.json
@@ -1,0 +1,14 @@
+{
+  "title": "Kỷ luật thầm lặng của việc hoàn tất đúng cách",
+  "summary": "Một ghi chú phản chiếu về kỷ luật nhỏ khi đóng work bằng evidence, cleanup và context thay vì chỉ chạm tới finish line nhìn thấy được.",
+  "readingMinutes": 6,
+  "tags": [
+    "Reflection",
+    "Craft",
+    "Follow Through",
+    "Sustainable Work",
+    "Quality",
+    "Clarity"
+  ],
+  "html": "<p>Việc đó basically done. Đây luôn là câu nguy hiểm. Main change đã chạy, demo nhìn ổn, và task tiếp theo đang đợi. Nhưng note còn mỏng, rollback chưa viết, và final check vẫn nằm trong trí nhớ của một người. Finish line nhìn thấy được đã đến trước finish thật.</p>\n<figure class='blog-figure blog-photo-panorama'>\n  <img src='https://nguyenlephong.github.io/dom-pub/icdn/blogs/the-quiet-discipline-of-finishing-properly/finishing-properly-desk.webp' width='1600' height='900' loading='lazy' decoding='async' alt='Một bàn làm việc gọn cuối ngày với laptop đóng lại, checklist chỉ có icon, notes, đèn bàn ấm và ánh dusk ngoài cửa.' />\n  <figcaption>Hoàn tất đúng cách thường là phần việc yên tĩnh sau khi phần thú vị đã qua.</figcaption>\n</figure>\n<p>Finishing properly không hào nhoáng. Nó là check edge case, update note, remove temporary flag, viết handoff, link evidence, và chắc rằng người tiếp theo không cần hỏi lại chuyện gì đã xảy ra.</p>\n<p>Kỷ luật này quan trọng vì những mép chưa xong trở thành interruption tương lai. Code có thể chạy, nhưng team vẫn trả giá nếu không ai biết verify nó, operate nó, hoặc giải thích vì sao trade-off được chọn.</p>\n<p>Tôi học cách tôn trọng mười phần trăm cuối của công việc. Đó là nơi confidence trở nên inspectable. Passing test hữu ích. Passing test cộng với lý do nó matter còn tốt hơn. Deployed feature hữu ích. Deployed feature cộng rollback criteria thì bình tĩnh hơn.</p>\n<p>Cám dỗ là chạy ngay khi visible problem đã được solve. Cám dỗ đó dễ hiểu. Team có pressure, queue và deadline. Nhưng đi quá nhanh có thể để lại một vệt almost-finished work làm mọi người chậm lại sau này.</p>\n<p>Finishing properly cũng bảo vệ pride khỏi biến thành performance. Mục tiêu không phải chứng minh mọi chi tiết hoàn hảo. Mục tiêu là để work ở trạng thái người khác tiếp tục được mà không phải đoán.</p>\n<p>Một closing ritual nhỏ có ích. What changed? Verified bằng gì? Còn risk nào? Nếu fail thì làm gì? Evidence ở đâu? Những câu hỏi này biến done từ cảm giác thành shared state.</p>\n<p>Kỷ luật thầm lặng của việc hoàn tất đúng cách là một dạng care. Nó care cho teammate tiếp theo, incident tương lai và attention của chính bạn ngày mai. Task không thật sự done khi nó chạy một lần. Nó done khi work đứng được mà không cần bạn giữ nó lên.</p>"
+}


### PR DESCRIPTION
Adds Day 29 daily roadmap posts for 2026-07-14 through 2026-07-18 in English and Vietnamese, referencing GPT Image generated assets hosted in dom-pub/icdn.\n\nVerification:\n- jq empty for new blog JSON and indexes\n- custom Node continuity/locale/image check\n- placeholder/debug scan\n- npm run check\n- npm run build:fast\n- npm run verify:offline\n- local out route HTML title/image check