### PR TITLE
feat(studio): revamp bilingual workspace content

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -266,9 +266,9 @@
       "heading": "Apps"
     },
     "studio": {
-      "eyebrow": "Learning workbench",
+      "eyebrow": "Engineering workbench",
       "title": "Studio",
-      "intro": "A public shelf for learning notes, machine setup, AI tooling, and the small checklists that make a new engineering laptop feel ready."
+      "intro": "A public workspace for the notes, checklists, and visual flows I use to review architecture, prepare releases, set up tools, and work with AI responsibly."
     },
     "gallery": {
       "eyebrow": "Gallery",

--- a/messages/vi.json
+++ b/messages/vi.json
@@ -266,9 +266,9 @@
       "heading": "Ứng dụng"
     },
     "studio": {
-      "eyebrow": "Góc học tập",
+      "eyebrow": "Bàn làm việc kỹ thuật",
       "title": "Studio",
-      "intro": "Một kệ public cho ghi chú học tập, setup máy, AI tooling và những checklist nhỏ để một laptop engineering mới sẵn sàng làm việc."
+      "intro": "Không gian công khai tập hợp ghi chú, checklists và system flows tôi dùng để review architecture, chuẩn bị release, setup công cụ và làm việc với AI có trách nhiệm."
     },
     "gallery": {
       "eyebrow": "Bộ sưu tập",

--- a/src/app/[locale]/studio/StudioWorkspace.tsx
+++ b/src/app/[locale]/studio/StudioWorkspace.tsx
@@ -15,8 +15,12 @@ export default function StudioWorkspace({ locale }: StudioWorkspaceProps) {
     return () => document.body.classList.remove("studio-app-shell-active");
   }, []);
 
+  const workspaceLabel = locale === "vi"
+    ? "Không gian làm việc Studio của Nguyễn Lê Phong"
+    : "Nguyen Le Phong's personal Studio workspace";
+
   return (
-    <ShadowIsland styles={studioShadowStyles} label="Studio Admin dashboard">
+    <ShadowIsland styles={studioShadowStyles} label={workspaceLabel}>
       <StudioAdminShell locale={locale} />
     </ShadowIsland>
   );

--- a/src/app/[locale]/studio/page.tsx
+++ b/src/app/[locale]/studio/page.tsx
@@ -1,15 +1,35 @@
 import type { Metadata } from "next";
 import { notFound } from "next/navigation";
 import { hasLocale } from "next-intl";
-import { getTranslations, setRequestLocale } from "next-intl/server";
+import { setRequestLocale } from "next-intl/server";
 import { PAGE_SEO, SITE, SITE_URL, absoluteUrl } from "@/app/seo.config";
 import PageTracker from "@/components/analytics/PageTracker";
 import { routing, type Locale } from "@/i18n/routing";
 import StudioWorkspace from "./StudioWorkspace";
-import { studioNotes } from "./studio.data";
-import { getLocalizedStudioFlows } from "./studio.localized-content";
 
 const seo = PAGE_SEO.studio;
+
+const studioSeoByLocale: Record<string, { title: string; description: string; keywords: string[] }> = {
+  en: {
+    title: "Studio — Engineering Notes, Checklists, and System Flows",
+    description:
+      "A public workspace for the notes, checklists, and visual flows I use to review architecture, prepare releases, set up tools, and work with AI responsibly.",
+    keywords: ["engineering notes", "software checklists", "system design flows", "AI-assisted engineering"]
+  },
+  vi: {
+    title: "Studio — Ghi chú kỹ thuật, Checklists và System Flows",
+    description:
+      "Không gian công khai tập hợp ghi chú, checklists và system flows tôi dùng để review architecture, chuẩn bị release, setup công cụ và làm việc với AI có trách nhiệm.",
+    keywords: ["ghi chú kỹ thuật", "engineering checklists", "system design flows", "AI-assisted engineering"]
+  }
+};
+
+function getStudioSeo(locale: string) {
+  const localized = studioSeoByLocale[locale];
+  return localized
+    ? { ...localized, keywords: [...(seo.keywords ?? []), ...localized.keywords] }
+    : { title: seo.title, description: seo.description, keywords: seo.keywords ?? [] };
+}
 
 type Props = { params: Promise<{ locale: string }> };
 
@@ -29,24 +49,25 @@ function localeAlternates(path: string): Record<string, string> {
 export async function generateMetadata({ params }: Props): Promise<Metadata> {
   const { locale } = await params;
   const canonical = `/${locale}${seo.path}`;
+  const localizedSeo = getStudioSeo(locale);
 
   return {
-    title: seo.title,
-    description: seo.description,
-    keywords: seo.keywords,
+    title: localizedSeo.title,
+    description: localizedSeo.description,
+    keywords: localizedSeo.keywords,
     alternates: { canonical, languages: localeAlternates(seo.path) },
     openGraph: {
       type: "website",
       url: absoluteUrl(canonical),
-      title: seo.title,
-      description: seo.description,
+      title: localizedSeo.title,
+      description: localizedSeo.description,
       siteName: SITE.name,
-      locale: locale.replace("-", "_")
+      locale: locale === "vi" ? "vi_VN" : locale === "en" ? "en_US" : locale.replace("-", "_")
     },
     twitter: {
       card: "summary_large_image",
-      title: seo.title,
-      description: seo.description,
+      title: localizedSeo.title,
+      description: localizedSeo.description,
       site: SITE.twitter,
       creator: SITE.twitter
     },
@@ -62,46 +83,22 @@ export default async function StudioPage({ params }: Props) {
   const { locale } = await params;
   if (!hasLocale(routing.locales, locale)) notFound();
   setRequestLocale(locale);
-  await getTranslations({ locale, namespace: "Pages.studio" });
-  const localizedFlows = getLocalizedStudioFlows(locale);
+  const localizedSeo = getStudioSeo(locale);
 
   const collectionLd = {
     "@context": "https://schema.org",
     "@type": "CollectionPage",
     "@id": `${SITE_URL}/${locale}/studio#studio`,
-    name: seo.title,
-    description: seo.description,
+    name: localizedSeo.title,
+    description: localizedSeo.description,
     url: `${SITE_URL}/${locale}/studio`,
     inLanguage: locale as Locale,
     isPartOf: { "@type": "WebSite", "@id": `${SITE_URL}/#website` },
-    author: { "@type": "Person", "@id": `${SITE_URL}/#person` },
-    hasPart: [
-      ...studioNotes.map((note) => ({
-        "@type": "TechArticle",
-        headline: note.title,
-        description: note.summary,
-        url: `${SITE_URL}/${locale}/studio#${note.id}`,
-        dateModified: note.updatedAt,
-        keywords: note.tags.join(", ")
-      })),
-      ...localizedFlows.map((flow) => ({
-        "@type": "HowTo",
-        name: flow.seoTitle,
-        description: flow.seoDescription,
-        url: `${SITE_URL}/${locale}/studio?route=flow-${flow.id}&flow=${flow.id}#flow-${flow.id}`,
-        keywords: flow.tags.join(", "),
-        step: flow.steps.map((step, index) => ({
-          "@type": "HowToStep",
-          position: index + 1,
-          name: step.title,
-          text: `${step.detail} ${step.output}`
-        }))
-      }))
-    ]
+    author: { "@type": "Person", "@id": `${SITE_URL}/#person` }
   };
 
   return (
-    <main className="studio-route-shell">
+    <div className="studio-route-shell">
       <style
         dangerouslySetInnerHTML={{
           __html: `
@@ -111,8 +108,8 @@ export default async function StudioPage({ params }: Props) {
               background: var(--bg, #fafafa) !important;
             }
 
-            body:has(.studio-route-shell) main.studio-route-shell,
-            body.studio-app-shell-active main.studio-route-shell {
+            body:has(.studio-route-shell) .studio-route-shell,
+            body.studio-app-shell-active .studio-route-shell {
               height: 100vh !important;
               min-height: 100vh !important;
               overflow: hidden !important;
@@ -154,6 +151,6 @@ export default async function StudioPage({ params }: Props) {
       />
       <PageTracker page="studio" eventName="studio_view" section="notes_admin" />
       <StudioWorkspace locale={locale} />
-    </main>
+    </div>
   );
 }

--- a/src/app/[locale]/studio/studio-admin-shell.tsx
+++ b/src/app/[locale]/studio/studio-admin-shell.tsx
@@ -20,6 +20,8 @@ import {
   getLocalizedStudioAiSkills,
   getLocalizedStudioWorkflowChecklists
 } from "./studio.localized-content";
+import { getLocalizedStudioFolders, getLocalizedStudioNotes } from "./studio.localized-workspace";
+import { getLocalizedStudioDemoFlows } from "./studio.localized-demos";
 import type {
   StudioAiSkill,
   StudioChecklistStep,
@@ -354,6 +356,10 @@ type StudioFlowCanvasNodeData = {
   detail: string;
   badge?: string;
   tone: StudioFlowCanvasTone;
+  kindLabel?: string;
+  toneLabel?: string;
+  scratchLabel?: string;
+  hiddenLabel?: string;
   active?: boolean;
   compact?: boolean;
   collapsed?: boolean;
@@ -520,6 +526,7 @@ type StudioUiCopy = {
     chartOutcome: string;
     exampleFamily: string;
     exampleView: string;
+    exampleSelectorLabel: string;
     boardTools: string;
     viewNotes: string;
     useWhen: string;
@@ -575,6 +582,13 @@ type StudioUiCopy = {
     edgeCount: string;
     groupCount: string;
     hiddenCount: string;
+    tags: string;
+    details: string;
+    scratch: string;
+    reviewNote: string;
+    temporaryAnnotation: string;
+    nodeLabels: Record<string, string>;
+    familyLabels: Record<string, string>;
     collapseGroup: string;
     expandGroup: string;
     boardSandbox: string;
@@ -632,6 +646,7 @@ type StudioUiCopy = {
     structureDetail: (sections: number, steps: number) => string;
     markdownCopy: string;
     markdownUseWhen: string;
+    detailsLabel: string;
   };
   preferences: {
     title: string;
@@ -659,9 +674,9 @@ type StudioUiCopy = {
 
 const englishStudioCopy: StudioUiCopy = {
   brand: "Studio",
-  navLabel: "Personal Studio",
+  navLabel: "Nguyen Le Phong's personal Studio",
   navItems: {
-    welcome: "Welcome",
+    welcome: "Start here",
     "ai-agent-setup": "AI Setup",
     "ai-skills": "AI Skills",
     "delivery-checklists": "Checklists",
@@ -672,8 +687,8 @@ const englishStudioCopy: StudioUiCopy = {
     "flow-release-readiness": "Release Readiness",
     "flow-ai-delivery": "AI Delivery",
     "flow-portfolio-story": "Portfolio Story",
-    "flow-react-flow-architecture-demo": "Example",
-    "flow-react-flow-system-blueprint": "Blueprint"
+    "flow-react-flow-architecture-demo": "Flow examples",
+    "flow-react-flow-system-blueprint": "System blueprint"
   },
   profileItems: {
     home: { label: "Home", detail: "Profile overview." },
@@ -686,12 +701,12 @@ const englishStudioCopy: StudioUiCopy = {
   },
   profileMenuTitle: "Profile menu",
   profileNavigationTitle: "Profile navigation",
-  profileNavigationDetail: "Move between the public profile sections from this Studio workspace.",
+  profileNavigationDetail: "Open any public profile section without leaving the Studio workspace.",
   openProfileHome: "Open profile home",
-  findSetupNote: "Find setup note",
+  findSetupNote: "Search Studio",
   search: "Search",
-  searchPlaceholder: "Search AI setup...",
-  commandPaletteLabel: "Search Studio routes",
+  searchPlaceholder: "Search Studio pages...",
+  commandPaletteLabel: "Search Studio pages",
   closeSearch: "Close search",
   openStudio: "Open Studio",
   closeNavigation: "Close navigation",
@@ -701,13 +716,13 @@ const englishStudioCopy: StudioUiCopy = {
   openAccountMenu: "Open account menu",
   routeKicker: {
     legacy: "Legacy",
-    studio: "Studio route"
+    studio: "Studio"
   },
-  routeMetricsLabel: "Route metrics",
+  routeMetricsLabel: "Page summary",
   status: {
     ready: "Ready",
     draft: "Draft",
-    next: "Next"
+    next: "Planned"
   },
   categories: {
     all: "All",
@@ -720,26 +735,26 @@ const englishStudioCopy: StudioUiCopy = {
   },
   routes: {
     welcome: {
-      title: "Welcome",
-      description: "A quiet starting point for the personal Studio: working notes, reusable workflows, and the public profile links I reach for most.",
-      panels: ["Start here", "Useful links", "Studio routes"],
-      timeline: ["Open the right workspace", "Keep context close", "Move from idea to proof"]
+      title: "Start here",
+      description: "A practical index of my setup notes, reusable workflows, delivery checklists, and visual system maps.",
+      panels: ["Choose a workspace", "Useful links", "Studio pages"],
+      timeline: ["Choose the right workspace", "Keep the source material close", "Finish with something concrete"]
     },
     "ai-agent-setup": {
-      title: "AI Agent Setup",
-      description: "Personal setup notes for my AI agent tools, MCP paths, and safe machine bootstrap.",
+      title: "AI Setup",
+      description: "Working notes for AI tools, MCP integrations, and a safe new-machine setup.",
       panels: ["Setup library", "Agent workflow", "Command runbook"],
       timeline: ["Skill library reviewed", "MCP install path captured", "Credential guardrail checked"]
     },
     "ai-skills": {
       title: "AI Skills",
-      description: "Reusable agent skills distilled from installed Codex, Claude, Gemini, Antigravity, and local skill libraries.",
+      description: "Reusable instructions for focused work with Codex, Claude, Gemini, Antigravity, and other AI tools.",
       panels: ["Skill taxonomy", "Markdown preview", "Copy-ready prompt"],
       timeline: ["Installed skills inventoried", "Capability gaps mapped", "English and Vietnamese prompts prepared"]
     },
     "delivery-checklists": {
-      title: "Delivery Checklists",
-      description: "Operating checklists from task intake through module work, release readiness, and rollout.",
+      title: "Engineering Checklists",
+      description: "Practical checklists for understanding a task, making a change, reviewing it, and releasing it safely.",
       panels: ["Task intake", "Module creation", "Release and rollout"],
       timeline: ["Ticket intake path mapped", "Module checklist nested", "Rollout phases captured"]
     },
@@ -780,31 +795,31 @@ const englishStudioCopy: StudioUiCopy = {
       timeline: ["Context captured", "Impact evidence selected", "Story draft shaped"]
     },
     "flow-react-flow-architecture-demo": {
-      title: "Example",
-      description: "A library-style React Flow canvas with dropdown views for overview, interaction, grouping, layout, styling, whiteboard, and software architecture examples.",
-      panels: ["Example selector", "Canvas gallery", "Architecture zones"],
-      timeline: ["Example families mapped", "Dropdown views wired", "Canvas controls enabled"]
+      title: "React Flow Examples",
+      description: "An interactive collection of React Flow patterns for navigation, grouping, layout, whiteboarding, and software architecture.",
+      panels: ["Choose an example", "Explore the canvas", "Inspect architecture zones"],
+      timeline: ["Choose a pattern", "Inspect its relationships", "Try the canvas controls"]
     },
     "flow-react-flow-system-blueprint": {
       title: "System Design Blueprint",
-      description: "A dense React Flow blueprint that maps DNS, edge policy, load balancing, storage, media processing, queues, and fan-out services.",
-      panels: ["Full blueprint", "Focused views", "Production vocabulary"],
-      timeline: ["DNS path mapped", "Runtime and storage linked", "Media fan-out modeled"]
+      description: "A detailed system map covering DNS, edge policy, load balancing, storage, media processing, queues, and fan-out services.",
+      panels: ["Full system map", "Focused views", "Production components"],
+      timeline: ["Trace the request path", "Inspect runtime and storage", "Follow media processing and fan-out"]
     }
   },
   welcome: {
-    eyebrow: "Studio home",
-    lead: "This space is where I keep the practical parts of my work close together: setup notes, reusable AI skills, delivery checklists, and visual flows that help turn rough context into something I can ship or explain.",
-    note: "Use it as a calm control room. Start with the route that matches the job, keep the source material honest, then leave with a concrete artifact instead of another open tab.",
+    eyebrow: "Personal workbench",
+    lead: "I keep the practical parts of my engineering work here: setup notes, reusable AI instructions, delivery checklists, and visual system maps.",
+    note: "Choose the page that matches the job, check the source material, and finish with a useful decision, checklist, diagram, or verified change.",
     studioLinks: "Studio shortcuts",
     publicLinks: "Useful profile links",
     open: "Open",
     routeCards: {
-      "ai-agent-setup": { label: "AI Setup", detail: "Machine notes, MCP paths, and personal agent setup references." },
-      "ai-skills": { label: "AI Skills", detail: "Reusable prompts and operating rules for focused agent sessions." },
-      "delivery-checklists": { label: "Checklists", detail: "Working checklists for task intake, release readiness, and rollout." },
-      "flow-react-flow-architecture-demo": { label: "Example", detail: "React Flow examples for architecture, layout, grouping, styling, and interactions." },
-      "flow-react-flow-system-blueprint": { label: "Blueprint", detail: "A poster-scale system design canvas with DNS, runtime, storage, media, and fan-out zones." }
+      "ai-agent-setup": { label: "AI Setup", detail: "Tool roles, MCP integrations, and new-machine setup notes." },
+      "ai-skills": { label: "AI Skills", detail: "Reusable instructions for focused research, review, and implementation." },
+      "delivery-checklists": { label: "Checklists", detail: "Step-by-step checks for task intake, implementation, review, and release." },
+      "flow-react-flow-architecture-demo": { label: "Flow examples", detail: "Interactive patterns for architecture, layout, grouping, styling, and navigation." },
+      "flow-react-flow-system-blueprint": { label: "System blueprint", detail: "A detailed map of DNS, runtime, storage, media processing, and fan-out." }
     },
     linkCards: {
       home: { label: "Home", detail: "Public profile overview." },
@@ -815,25 +830,26 @@ const englishStudioCopy: StudioUiCopy = {
     }
   },
   flows: {
-    emptyTitle: "Flow library is empty",
-    emptyDescription: "Add studio flows before opening this menu.",
+    emptyTitle: "No flows are available yet",
+    emptyDescription: "Published flows will appear here when they are ready.",
     menu: "Flow menu",
-    menuDetail: "Reusable work paths for system design, production delivery, AI-assisted coding, and career proof.",
+    menuDetail: "Reusable paths for system design, production delivery, AI-assisted engineering, and portfolio writing.",
     groupMenuLabel: "Flow groups",
     flowListLabel: "Shareable Studio flows",
     selectedFlow: "Selected Studio flow",
     chartLabel: "Flow chart",
-    chartHint: "Read the path from left to right: each node is a decision point, not a long note.",
+    chartHint: "Read from left to right. Each node marks an action or decision, with evidence and output kept nearby.",
     chartOutcome: "Target outcome",
     exampleFamily: "Example family",
     exampleView: "View",
+    exampleSelectorLabel: "React Flow example selector",
     boardTools: "Board tools",
     viewNotes: "View notes",
     useWhen: "Use when",
     outcome: "Outcome",
-    officeExample: "Office example",
-    artifacts: "Artifacts",
-    cvSignals: "CV signals",
+    officeExample: "Practical example",
+    artifacts: "Working artifacts",
+    cvSignals: "Portfolio evidence",
     evidence: "Evidence",
     output: "Output",
     shareFlow: "Share flow",
@@ -882,9 +898,50 @@ const englishStudioCopy: StudioUiCopy = {
     edgeCount: "Edges",
     groupCount: "Groups",
     hiddenCount: "Hidden",
+    tags: "Flow tags",
+    details: "Flow details",
+    scratch: "Scratch",
+    reviewNote: "Review note",
+    temporaryAnnotation: "Temporary annotation for this Studio session.",
+    nodeLabels: {
+      hub: "Hub",
+      step: "Step",
+      detail: "Detail",
+      input: "Input",
+      default: "Default",
+      output: "Output",
+      group: "Group",
+      service: "Service",
+      gateway: "Gateway",
+      database: "Database",
+      queue: "Queue",
+      topic: "Topic",
+      cache: "Cache",
+      worker: "Worker",
+      external: "External",
+      decision: "Decision",
+      risk: "Risk",
+      note: "Note",
+      system: "System",
+      source: "Source",
+      process: "Process",
+      agent: "Agent",
+      review: "Review",
+      storage: "Storage",
+      event: "Event"
+    },
+    familyLabels: {
+      overview: "Overview",
+      interaction: "Interaction",
+      grouping: "Subflows & Grouping",
+      layout: "Layout",
+      styling: "Styling",
+      whiteboard: "Whiteboard",
+      architecture: "Software Architecture"
+    },
     collapseGroup: "Collapse group",
     expandGroup: "Expand group",
-    boardSandbox: "Session sandbox: edits can be undone or reset and do not change the source diagram."
+    boardSandbox: "Your edits stay in this browser session. Undo or reset them at any time; the source diagram is unchanged."
   },
   aiSetup: {
     addNote: "Add note",
@@ -899,36 +956,36 @@ const englishStudioCopy: StudioUiCopy = {
     setupCommands: "Setup commands",
     referenceLinks: "Reference links",
     aiWorkflow: "AI workflow",
-    aiWorkflowDetail: "First container for research and operating notes.",
+    aiWorkflowDetail: "A simple path from source material to a checked, reusable result.",
     setupChecklist: "Setup checklist",
     researchQueue: "Research queue"
   },
   aiSkills: {
-    emptyTitle: "Skill library is empty",
-    emptyDescription: "Add markdown skills to Studio data before opening this menu.",
+    emptyTitle: "No AI skills are available yet",
+    emptyDescription: "Published skills will appear here when they are ready.",
     copyMarkdown: "Copy markdown",
     copied: "Copied",
     copy: "Copy",
     skillLibrary: "Skill library",
-    skillLibraryDetail: "Markdown prompts that can be copied into an agent session.",
+    skillLibraryDetail: "Reusable instructions you can copy into an AI work session.",
     categoriesLabel: "Skill categories",
     skillCountLabel: (count) => `${count} skills`,
     selectedSkill: "Selected AI skill markdown",
     skillTags: "Skill tags",
     useThisWhen: "Use this when",
     copyBehavior: "Copy behavior",
-    copyBehaviorDetail: "The button copies the raw markdown block, including headings, process, output format, and guardrails.",
+    copyBehaviorDetail: "The button copies the complete markdown instruction, including its process, expected output, and guardrails.",
     operatingRule: "Operating rule",
-    operatingRuleDetail: "Keep the skill specific enough to be useful, but short enough to paste into Codex, Claude, Gemini, or another agent tool."
+    operatingRuleDetail: "Use the instruction as a starting point. Keep the task boundaries, source material, and final judgment explicit."
   },
   checklists: {
-    emptyTitle: "Checklist library is empty",
-    emptyDescription: "Add workflow checklists to Studio data before opening this menu.",
+    emptyTitle: "No checklists are available yet",
+    emptyDescription: "Published checklists will appear here when they are ready.",
     copyChecklist: "Copy checklist",
     copied: "Copied",
     copy: "Copy",
     menu: "Checklist menu",
-    menuDetail: "Operating lists from ticket intake to rollout.",
+    menuDetail: "Step-by-step checks from task intake through release and rollout.",
     workflowListLabel: "Workflow checklists",
     selectedChecklist: "Selected workflow checklist",
     checklistTags: "Checklist tags",
@@ -938,23 +995,24 @@ const englishStudioCopy: StudioUiCopy = {
     structure: "Structure",
     structureDetail: (sections, steps) => `${sections} sections, ${steps} nested steps, copy-ready as markdown.`,
     markdownCopy: "Markdown copy",
-    markdownUseWhen: "Use when"
+    markdownUseWhen: "Use when",
+    detailsLabel: "Checklist details"
   },
   preferences: {
     title: "Preferences",
     description: "Theme, font, and layout for this Studio workspace.",
-    palette: "CV palette",
+    palette: "Appearance",
     themeMode: "Theme mode",
-    resolvedNow: "Resolved now",
+    resolvedNow: "Currently using",
     font: "Font",
     pageLayout: "Page layout",
-    pageLayoutHelp: "Centered keeps reading calm. Full width gives wider operations surfaces.",
+    pageLayoutHelp: "Centered is easier to read. Full width gives diagrams and workspaces more room.",
     navbarBehavior: "Navbar behavior",
-    navbarHelp: "Sticky keeps controls visible. Scroll lets the whole workspace move together.",
+    navbarHelp: "Sticky keeps the controls visible. Scroll moves them with the page.",
     sidebarStyle: "Sidebar style",
-    sidebarStyleHelp: "Choose the density that matches the current setup work.",
+    sidebarStyleHelp: "Choose how closely the navigation sits beside the workspace.",
     collapseMode: "Collapse mode",
-    collapseModeHelp: "Icon keeps the rail visible. Offcanvas hides it completely on desktop.",
+    collapseModeHelp: "Icon leaves a narrow navigation rail. Offcanvas hides the sidebar completely on desktop.",
     restoreDefaults: "Restore layout defaults",
     themeOptions: { light: "Light", system: "System", dark: "Dark" },
     contentLayoutOptions: { centered: "Centered", "full-width": "Full width" },
@@ -1016,49 +1074,49 @@ const studioCopyByLocale: Record<string, StudioUiCopy> = {
   en: englishStudioCopy,
   vi: {
     ...englishStudioCopy,
-    navLabel: "Studio cá nhân",
+    navLabel: "Studio cá nhân của Nguyễn Lê Phong",
     navItems: {
-      welcome: "Welcome",
+      welcome: "Bắt đầu",
       "ai-agent-setup": "AI Setup",
-      "ai-skills": "AI Skill",
-      "delivery-checklists": "Checklist",
+      "ai-skills": "AI Skills",
+      "delivery-checklists": "Checklists",
       "flow-menu": "Flow",
       "flow-system-design": "System Design",
-      "flow-architecture-decision": "Quyết định kiến trúc",
-      "flow-incident-response": "Xử lý incident",
-      "flow-release-readiness": "Release readiness",
-      "flow-ai-delivery": "AI delivery",
-      "flow-portfolio-story": "Portfolio story",
-      "flow-react-flow-architecture-demo": "Example",
-      "flow-react-flow-system-blueprint": "Blueprint"
+      "flow-architecture-decision": "Architecture Decision",
+      "flow-incident-response": "Incident Response",
+      "flow-release-readiness": "Release Readiness",
+      "flow-ai-delivery": "AI-assisted Delivery",
+      "flow-portfolio-story": "Portfolio Story",
+      "flow-react-flow-architecture-demo": "React Flow Examples",
+      "flow-react-flow-system-blueprint": "System Blueprint"
     },
     profileItems: {
-      home: { label: "Trang chủ", detail: "Tổng quan profile." },
+      home: { label: "Trang chủ", detail: "Tổng quan hồ sơ cá nhân." },
       about: { label: "Giới thiệu", detail: "Kinh nghiệm và nền tảng." },
-      gallery: { label: "Gallery", detail: "Một số hình ảnh chọn lọc." },
+      gallery: { label: "Hình ảnh", detail: "Những dấu mốc và hình ảnh chọn lọc." },
       blog: { label: "Blog", detail: "Bài viết dài." },
-      notes: { label: "Note", detail: "Ghi chú làm việc ngắn." },
-      apps: { label: "Apps", detail: "Công cụ và thử nghiệm nhỏ." },
-      resume: { label: "Resume", detail: "Mở CV PDF." }
+      notes: { label: "Ghi chép", detail: "Ghi chép ngắn từ công việc và đời sống." },
+      apps: { label: "Ứng dụng", detail: "Công cụ nhỏ và những thử nghiệm cá nhân." },
+      resume: { label: "CV", detail: "Mở bản CV dạng PDF." }
     },
-    profileMenuTitle: "Menu profile",
-    profileNavigationTitle: "Menu profile",
-    profileNavigationDetail: "Đi tới các phần public profile ngay trong Studio.",
-    openProfileHome: "Mở trang chủ profile",
-    findSetupNote: "Tìm setup note",
+    profileMenuTitle: "Hồ sơ cá nhân",
+    profileNavigationTitle: "Đi tới trang khác",
+    profileNavigationDetail: "Mở các phần trong hồ sơ công khai mà không phải rời Studio.",
+    openProfileHome: "Mở trang hồ sơ chính",
+    findSetupNote: "Tìm trong Studio",
     search: "Tìm kiếm",
-    searchPlaceholder: "Tìm AI setup...",
-    commandPaletteLabel: "Tìm route Studio",
+    searchPlaceholder: "Tìm một trang trong Studio...",
+    commandPaletteLabel: "Tìm trang trong Studio",
     closeSearch: "Đóng tìm kiếm",
     openStudio: "Mở Studio",
     closeNavigation: "Đóng menu",
     toggleNavigation: "Ẩn/hiện menu",
     openPreferences: "Mở tùy chỉnh Studio",
-    openGithubProfile: "Mở GitHub profile",
+    openGithubProfile: "Mở hồ sơ GitHub",
     openAccountMenu: "Mở menu tài khoản",
-    routeKicker: { legacy: "Legacy", studio: "Studio route" },
-    routeMetricsLabel: "Chỉ số route",
-    status: { ready: "Sẵn sàng", draft: "Nháp", next: "Tiếp theo" },
+    routeKicker: { legacy: "Bản cũ", studio: "Studio" },
+    routeMetricsLabel: "Tóm tắt trang",
+    status: { ready: "Dùng được", draft: "Đang viết", next: "Dự kiến" },
     categories: {
       all: "Tất cả",
       engineering: "Kỹ thuật",
@@ -1070,253 +1128,296 @@ const studioCopyByLocale: Record<string, StudioUiCopy> = {
     },
     routes: {
       welcome: {
-        title: "Welcome",
-        description: "Điểm bắt đầu nhẹ nhàng của Studio cá nhân: ghi chú làm việc, workflow tái dùng và các link profile cần mở thường xuyên.",
-        panels: ["Bắt đầu", "Link tiện ích", "Route Studio"],
-        timeline: ["Mở đúng workspace", "Giữ context gần", "Rời đi với artifact rõ"]
+        title: "Bắt đầu",
+        description: "Mục lục gọn cho các ghi chú thiết lập, hướng dẫn dùng AI, danh sách kiểm tra và sơ đồ hệ thống tôi thường dùng.",
+        panels: ["Chọn nơi cần mở", "Liên kết hữu ích", "Các trang trong Studio"],
+        timeline: ["Chọn đúng chỗ làm việc", "Giữ tài liệu gốc bên cạnh", "Kết thúc bằng một kết quả cụ thể"]
       },
       "ai-agent-setup": {
-        title: "AI Agent Setup",
-        description: "Ghi chú setup cá nhân cho công cụ AI agent, MCP path và bootstrap máy an toàn.",
-        panels: ["Thư viện setup", "Luồng agent", "Runbook lệnh"],
-        timeline: ["Đã review skill library", "Đã lưu MCP install path", "Đã kiểm tra guardrail credential"]
+        title: "AI Setup",
+        description: "Ghi chú về vai trò của từng công cụ AI, cách nối MCP và cách chuẩn bị máy mới an toàn.",
+        panels: ["Ghi chú thiết lập", "Cách phối hợp công cụ", "Lệnh cần dùng"],
+        timeline: ["Kiểm lại thư viện hướng dẫn", "Lưu đúng đường cài MCP", "Không mang theo thông tin đăng nhập từ máy cũ"]
       },
       "ai-skills": {
-        title: "AI Skill",
-        description: "Bộ agent skill cô đọng từ các skill đã cài trong Codex, Claude, Gemini, Antigravity và local workspace.",
-        panels: ["Taxonomy skill", "Markdown preview", "Prompt copy-ready"],
-        timeline: ["Đã inventory skill đã cài", "Đã map capability gaps", "Đã chuẩn bị prompt tiếng Anh và tiếng Việt"]
+        title: "AI Skills",
+        description: "Những hướng dẫn có thể dùng lại khi nghiên cứu, phản biện, viết và làm việc với mã nguồn bằng các công cụ AI.",
+        panels: ["Nhóm công việc", "Nội dung Markdown", "Bản có thể sao chép"],
+        timeline: ["Kiểm kê hướng dẫn đang có", "Nhìn ra phần còn thiếu", "Chuẩn bị bản tiếng Anh và tiếng Việt"]
       },
       "delivery-checklists": {
-        title: "Checklist làm việc",
-        description: "Checklist vận hành từ nhận task, tạo module, chuẩn bị release đến rollout.",
-        panels: ["Nhận task", "Tạo module", "Release và rollout"],
-        timeline: ["Đã map intake ticket", "Checklist module có bước con", "Đã ghi lại phase rollout"]
+        title: "Engineering Checklists",
+        description: "Các bước cần kiểm từ lúc hiểu yêu cầu, sửa code, tự review đến khi release an toàn.",
+        panels: ["Nhận việc", "Thực hiện thay đổi", "Release và theo dõi"],
+        timeline: ["Làm rõ yêu cầu", "Review từng phần thay đổi", "Ghi rõ kế hoạch release và rollback"]
       },
       "flow-system-design": {
-        title: "Flow System Design",
-        description: "Luồng share được từ đề bài còn mơ hồ tới trade-off kiến trúc, failure modes và hướng tiến hóa.",
-        panels: ["Problem frame", "Runtime map", "Failure modes"],
-        timeline: ["Requirement đã đóng khung", "Data ownership đã map", "Evolution path đã ghi lại"]
+        title: "System Design Flow",
+        description: "Cách đi từ một đề bài còn mơ hồ tới kiến trúc có ranh giới rõ, biết đánh đổi gì và sẽ hỏng ở đâu.",
+        panels: ["Đóng khung bài toán", "Sơ đồ khi vận hành", "Tình huống hỏng hóc"],
+        timeline: ["Làm rõ yêu cầu", "Chỉ ra nơi sở hữu dữ liệu", "Ghi lại hướng mở rộng về sau"]
       },
       "flow-architecture-decision": {
-        title: "Flow quyết định kiến trúc",
-        description: "Luồng RFC/ADR gọn để chọn giữa các option với trade-off, risk gate và rollback rõ.",
-        panels: ["Scope quyết định", "Option matrix", "Risk gates"],
-        timeline: ["Invariant đã liệt kê", "Option đã so sánh", "Decision note sẵn sàng"]
+        title: "Architecture Decision Flow",
+        description: "Khung RFC/ADR gọn để so sánh phương án, nêu rõ đánh đổi, ngưỡng rủi ro và đường quay lui.",
+        panels: ["Phạm vi quyết định", "Bảng so sánh phương án", "Ngưỡng rủi ro"],
+        timeline: ["Liệt kê điều không được phá vỡ", "So sánh các phương án", "Hoàn tất biên bản quyết định"]
       },
       "flow-incident-response": {
-        title: "Flow xử lý incident",
-        description: "Luồng production incident cho triage, mitigation, communication, recovery và follow-up.",
-        panels: ["Signal", "Mitigation", "Postmortem"],
-        timeline: ["Signal đã xác nhận", "Blast radius đã giới hạn", "Follow-up có owner"]
+        title: "Incident Response Flow",
+        description: "Các bước xác minh, giảm thiệt hại, thông báo, khôi phục và rút kinh nghiệm sau sự cố thật.",
+        panels: ["Dấu hiệu", "Giảm thiệt hại", "Rút kinh nghiệm"],
+        timeline: ["Xác nhận sự cố", "Khoanh vùng ảnh hưởng", "Giao rõ người xử lý việc còn lại"]
       },
       "flow-release-readiness": {
-        title: "Flow release readiness",
-        description: "Rollout gate để kiểm scope, verification, data, observability và rollback trước production.",
-        panels: ["Scope", "Verification", "Rollout decision"],
-        timeline: ["Scope đã kiểm", "Analytics và SEO đã review", "Rollback trigger đã gọi tên"]
+        title: "Release Readiness Flow",
+        description: "Cửa kiểm cuối cho scope, dữ liệu, testing, observability và rollback trước khi lên production.",
+        panels: ["Phạm vi", "Bằng chứng kiểm tra", "Quyết định phát hành"],
+        timeline: ["Rà lại scope", "Kiểm tra analytics và SEO", "Nêu rõ lúc nào phải rollback"]
       },
       "flow-ai-delivery": {
-        title: "Flow delivery có AI hỗ trợ",
-        description: "Luồng delivery có kiểm soát để dùng AI agent mà vẫn giữ scope, privacy, test và judgment.",
-        panels: ["Task brief", "Context pack", "Verification"],
-        timeline: ["Boundary đã chốt", "Focused diff đã review", "Handoff đã chuẩn bị"]
+        title: "AI-assisted Delivery Flow",
+        description: "Cách dùng AI mà vẫn giữ đúng phạm vi, bảo vệ dữ liệu, kiểm thử đầy đủ và để con người chịu trách nhiệm quyết định.",
+        panels: ["Đề bài", "Tài liệu cần thiết", "Kiểm chứng"],
+        timeline: ["Chốt ranh giới", "Rà đúng phần thay đổi", "Chuẩn bị bàn giao"]
       },
       "flow-portfolio-story": {
-        title: "Flow kể câu chuyện portfolio",
-        description: "Luồng biến công việc engineering thật thành câu chuyện CV, blog và phỏng vấn có bằng chứng.",
-        panels: ["Context", "Trade-off", "Impact"],
-        timeline: ["Context đã ghi lại", "Evidence impact đã chọn", "Story draft đã định hình"]
+        title: "Portfolio Story Flow",
+        description: "Cách biến một việc kỹ thuật có thật thành câu chuyện cho CV, blog hoặc phỏng vấn mà không thổi phồng đóng góp.",
+        panels: ["Bối cảnh", "Đánh đổi", "Kết quả"],
+        timeline: ["Ghi đủ bối cảnh", "Chọn bằng chứng phù hợp", "Viết thành câu chuyện rõ ràng"]
       },
       "flow-react-flow-architecture-demo": {
-        title: "Example",
-        description: "Canvas React Flow kiểu thư viện demo với dropdown view cho overview, interaction, grouping, layout, styling, whiteboard và software architecture example.",
-        panels: ["Chọn example", "Canvas gallery", "Vùng kiến trúc"],
-        timeline: ["Nhóm example đã map", "Dropdown view đã nối", "Canvas control đã bật"]
+        title: "React Flow Examples",
+        description: "Bộ ví dụ tương tác về điều hướng, gom nhóm, bố cục, bảng phác thảo và sơ đồ kiến trúc bằng React Flow.",
+        panels: ["Chọn ví dụ", "Khám phá sơ đồ", "Xem từng vùng kiến trúc"],
+        timeline: ["Chọn kiểu sơ đồ", "Xem các mối liên hệ", "Thử công cụ trên bảng"]
       },
       "flow-react-flow-system-blueprint": {
-        title: "System Design Blueprint",
-        description: "Blueprint React Flow dày đặc, mô hình hóa DNS, edge policy, load balancing, storage, media processing, queue và fan-out service.",
-        panels: ["Blueprint đầy đủ", "View tập trung", "Từ vựng production"],
-        timeline: ["DNS path đã map", "Runtime và storage đã nối", "Media fan-out đã mô hình hóa"]
+        title: "System Blueprint",
+        description: "Sơ đồ chi tiết cho DNS, edge policy, load balancing, storage, media processing, queue và các fan-out service.",
+        panels: ["Sơ đồ đầy đủ", "Góc nhìn tập trung", "Thành phần khi vận hành"],
+        timeline: ["Lần theo đường đi của yêu cầu", "Xem tầng chạy và lưu trữ", "Theo dõi xử lý media và phân phối dữ liệu"]
       }
     },
     welcome: {
       ...englishStudioCopy.welcome,
-      eyebrow: "Studio home",
-      lead: "Đây là nơi em gom những phần thực dụng nhất của công việc vào cùng một chỗ: setup note, AI skill có thể tái dùng, checklist delivery và flow trực quan để biến context rời rạc thành thứ có thể làm, ship hoặc giải thích lại được.",
-      note: "Cứ xem Studio như một bàn làm việc yên tĩnh. Chọn đúng route cho việc đang làm, giữ nguồn và bằng chứng rõ ràng, rồi rời khỏi trang với một artifact cụ thể thay vì thêm một tab còn dang dở.",
+      eyebrow: "Bàn làm việc cá nhân",
+      lead: "Tôi gom ở đây những thứ dùng thường xuyên trong công việc kỹ thuật: ghi chú thiết lập, hướng dẫn làm việc với AI, danh sách kiểm tra và sơ đồ hệ thống.",
+      note: "Hãy chọn đúng trang cho việc đang làm, kiểm lại tài liệu gốc, rồi kết thúc bằng một quyết định, danh sách, sơ đồ hoặc thay đổi đã được kiểm chứng.",
       studioLinks: "Lối tắt trong Studio",
-      publicLinks: "Link profile tiện ích",
+      publicLinks: "Liên kết trong hồ sơ",
       open: "Mở",
       routeCards: {
-        "ai-agent-setup": { label: "AI Setup", detail: "Ghi chú máy, MCP path và setup cá nhân cho agent." },
-        "ai-skills": { label: "AI Skill", detail: "Prompt và operating rule có thể copy vào phiên agent." },
-        "delivery-checklists": { label: "Checklist", detail: "Checklist nhận task, release readiness và rollout." },
-        "flow-react-flow-architecture-demo": { label: "Example", detail: "Demo React Flow cho kiến trúc, layout, grouping, styling và interaction." },
-        "flow-react-flow-system-blueprint": { label: "Blueprint", detail: "Canvas system design cỡ poster với DNS, runtime, storage, media và fan-out zone." }
+        "ai-agent-setup": { label: "AI Setup", detail: "Vai trò của từng công cụ, cách nối MCP và ghi chú chuẩn bị máy mới." },
+        "ai-skills": { label: "AI Skills", detail: "Các skill dùng lại cho research, code và review." },
+        "delivery-checklists": { label: "Checklists", detail: "Checklist từ lúc nhận task, code, review đến release." },
+        "flow-react-flow-architecture-demo": { label: "React Flow Examples", detail: "Các React Flow pattern cho architecture diagram, layout, grouping và interaction." },
+        "flow-react-flow-system-blueprint": { label: "System Blueprint", detail: "System map cho DNS, runtime, storage, media pipeline và fan-out." }
       },
       linkCards: {
-        home: { label: "Trang chủ", detail: "Tổng quan public profile." },
-        notes: { label: "Note", detail: "Ghi chú ngắn và suy nghĩ đang dùng." },
+        home: { label: "Trang chủ", detail: "Tổng quan hồ sơ cá nhân." },
+        notes: { label: "Ghi chép", detail: "Những ghi chép ngắn từ công việc và đời sống." },
         blog: { label: "Blog", detail: "Bài viết dài hơn về kỹ thuật và trải nghiệm." },
-        apps: { label: "Apps", detail: "Công cụ nhỏ và thử nghiệm cá nhân." },
-        resume: { label: "Resume", detail: "Mở bản CV PDF mới nhất." }
+        apps: { label: "Ứng dụng", detail: "Công cụ nhỏ và thử nghiệm cá nhân." },
+        resume: { label: "CV", detail: "Mở bản CV PDF mới nhất." }
       }
     },
     flows: {
       ...englishStudioCopy.flows,
-      emptyTitle: "Thư viện flow đang trống",
-      emptyDescription: "Thêm Studio flow vào data trước khi mở menu này.",
-      menu: "Menu flow",
-      menuDetail: "Các đường làm việc có thể tái dùng cho system design, production delivery, coding có AI hỗ trợ và career proof.",
-      groupMenuLabel: "Nhóm flow",
-      flowListLabel: "Studio flow có thể share",
-      selectedFlow: "Flow Studio đang chọn",
-      chartLabel: "Sơ đồ flow",
-      chartHint: "Đọc từ trái sang phải: mỗi node là một điểm quyết định, không phải một ghi chú dài.",
+      emptyTitle: "Chưa có Flow nào",
+      emptyDescription: "Flow đã hoàn thiện sẽ xuất hiện ở đây.",
+      menu: "Flow Library",
+      menuDetail: "Các flow dùng lại cho System Design, release lên production, AI-assisted engineering và xây portfolio.",
+      groupMenuLabel: "Nhóm Flow",
+      flowListLabel: "Các Flow trong Studio",
+      selectedFlow: "Flow đang chọn",
+      chartLabel: "Flow chart",
+      chartHint: "Đọc từ trái sang phải. Mỗi node là một bước xử lý hoặc điểm ra quyết định, kèm evidence và output cần có.",
       chartOutcome: "Kết quả cần đạt",
-      exampleFamily: "Nhóm example",
-      exampleView: "Kiểu view",
-      boardTools: "Công cụ board",
-      viewNotes: "Ghi chú view",
+      exampleFamily: "Example family",
+      exampleView: "View",
+      exampleSelectorLabel: "Chọn ví dụ React Flow",
+      boardTools: "Board tools",
+      viewNotes: "View notes",
       useWhen: "Dùng khi",
       outcome: "Kết quả",
-      officeExample: "Ví dụ nơi làm việc",
-      artifacts: "Artifact",
-      cvSignals: "Signal cho CV",
+      officeExample: "Ví dụ thực tế",
+      artifacts: "Artifacts",
+      cvSignals: "Portfolio evidence",
       evidence: "Evidence",
       output: "Output",
-      shareFlow: "Share flow",
-      copied: "Đã copy",
-      openFlow: "Mở flow",
-      enterFullscreen: "Phóng to board",
-      exitFullscreen: "Thoát fullscreen",
-      canvasMode: "Chế độ canvas",
+      shareFlow: "Chia sẻ Flow",
+      copied: "Đã sao chép",
+      openFlow: "Mở quy trình",
+      enterFullscreen: "Mở toàn màn hình",
+      exitFullscreen: "Thoát toàn màn hình",
+      canvasMode: "Canvas mode",
       inspectMode: "Inspect",
       editMode: "Edit sandbox",
       layoutMode: "Layout",
-      layoutSource: "Gốc",
+      layoutSource: "Source",
       layoutHorizontal: "Ngang",
       layoutVertical: "Dọc",
       layoutGrid: "Lưới",
-      layoutPreset: "Preset layout",
-      layoutPresetSource: "Gốc",
+      layoutPreset: "Layout presets",
+      layoutPresetSource: "Source",
       layoutPresetCompact: "Compact",
       layoutPresetWide: "Wide",
       layoutPresetTall: "Tall",
       layoutPresetGrid: "Grid",
-      applyLayout: "Áp layout",
-      resetBoard: "Reset",
-      undo: "Undo",
-      redo: "Redo",
+      applyLayout: "Áp dụng layout",
+      resetBoard: "Đặt lại",
+      undo: "Hoàn tác",
+      redo: "Làm lại",
       copyNode: "Copy node",
       pasteNode: "Paste node",
-      addNote: "Thêm note",
+      addNote: "Thêm ghi chú",
       deleteNode: "Xóa node",
-      fitBoard: "Fit board",
+      fitBoard: "Vừa khung nhìn",
       isolate: "Isolate",
-      fullGraph: "Toàn bộ graph",
+      fullGraph: "Full graph",
       upstream: "Upstream",
       current: "Đang chọn",
       downstream: "Downstream",
-      trailEmpty: "Chưa có link",
+      trailEmpty: "Chưa có liên kết",
       trailMore: (count) => `+${count} nữa`,
       relationMap: "Relation map",
-      nodeDetails: "Chi tiết node",
-      edgeDetails: "Chi tiết edge",
+      nodeDetails: "Node details",
+      edgeDetails: "Edge details",
       inspector: "Inspector",
       selectedNode: "Node đang chọn",
       selectedEdge: "Edge đang chọn",
       noSelection: "Chọn một node hoặc edge để xem chi tiết.",
-      nodeCount: "Node",
-      edgeCount: "Edge",
-      groupCount: "Group",
+      nodeCount: "Nodes",
+      edgeCount: "Edges",
+      groupCount: "Groups",
       hiddenCount: "Đang ẩn",
+      tags: "Chủ đề của quy trình",
+      details: "Thông tin quy trình",
+      scratch: "Scratch",
+      reviewNote: "Review note",
+      temporaryAnnotation: "Ghi chú tạm trong phiên Studio này.",
+      nodeLabels: {
+        hub: "Hub",
+        step: "Step",
+        detail: "Detail",
+        input: "Input",
+        default: "Default",
+        output: "Output",
+        group: "Group",
+        service: "Service",
+        gateway: "Gateway",
+        database: "Database",
+        queue: "Queue",
+        topic: "Topic",
+        cache: "Cache",
+        worker: "Worker",
+        external: "External",
+        decision: "Decision",
+        risk: "Risk",
+        note: "Note",
+        system: "System",
+        source: "Source",
+        process: "Process",
+        agent: "Agent",
+        review: "Review",
+        storage: "Storage",
+        event: "Event"
+      },
+      familyLabels: {
+        overview: "Overview",
+        interaction: "Interaction",
+        grouping: "Subflows & Grouping",
+        layout: "Layout",
+        styling: "Styling",
+        whiteboard: "Whiteboard",
+        architecture: "Software Architecture"
+      },
       collapseGroup: "Thu gọn group",
-      expandGroup: "Mở group",
-      boardSandbox: "Sandbox theo phiên: chỉnh sửa có thể undo hoặc reset và không đổi source diagram."
+      expandGroup: "Mở rộng group",
+      boardSandbox: "Các chỉnh sửa chỉ tồn tại trong session này. Có thể undo hoặc reset bất cứ lúc nào; source diagram không bị thay đổi."
     },
     aiSetup: {
       ...englishStudioCopy.aiSetup,
       addNote: "Thêm note",
-      setupLibrary: "Thư viện setup",
-      agentSetupNotes: "Ghi chú setup agent",
-      agentRuntimes: "Agent runtime",
-      selectedNote: "Note AI setup đang chọn",
+      setupLibrary: "Setup notes",
+      agentSetupNotes: "AI setup notes",
+      agentRuntimes: "AI runtimes",
+      selectedNote: "Note đang chọn",
       updated: "Cập nhật",
-      setupNoteTags: "Tag setup note",
-      commandRunbook: "Runbook lệnh",
-      commandRunbookDetail: "Các lệnh cần kiểm chứng trước khi dùng trên máy mới.",
-      setupCommands: "Lệnh setup",
-      referenceLinks: "Link tham khảo",
+      setupNoteTags: "Chủ đề của ghi chú",
+      commandRunbook: "Command runbook",
+      commandRunbookDetail: "Luôn đối chiếu tài liệu mới nhất trước khi chạy trên máy mới.",
+      setupCommands: "Setup commands",
+      referenceLinks: "Tài liệu tham khảo",
       aiWorkflow: "AI workflow",
-      aiWorkflowDetail: "Container đầu tiên cho research và operating note.",
-      setupChecklist: "Checklist setup",
-      researchQueue: "Hàng đợi nghiên cứu"
+      aiWorkflowDetail: "Một đường đi đơn giản từ tài liệu gốc đến kết quả đã được kiểm chứng và có thể dùng lại.",
+      setupChecklist: "Setup checklist",
+      researchQueue: "Research queue"
     },
     aiSkills: {
       ...englishStudioCopy.aiSkills,
-      emptyTitle: "Thư viện skill đang trống",
-      emptyDescription: "Thêm markdown skill vào Studio data trước khi mở menu này.",
-      copyMarkdown: "Copy markdown",
-      copied: "Đã copy",
-      copy: "Copy",
-      skillLibrary: "Thư viện skill",
-      skillLibraryDetail: "Prompt markdown có thể copy vào một phiên agent.",
-      categoriesLabel: "Nhóm skill",
-      skillCountLabel: (count) => `${count} skill`,
-      selectedSkill: "Markdown skill đang chọn",
-      skillTags: "Tag skill",
+      emptyTitle: "Chưa có AI Skill nào",
+      emptyDescription: "Skill đã hoàn thiện sẽ xuất hiện ở đây.",
+      copyMarkdown: "Sao chép Markdown",
+      copied: "Đã sao chép",
+      copy: "Sao chép",
+      skillLibrary: "Skill Library",
+      skillLibraryDetail: "Các skill có thể copy thẳng vào một phiên làm việc với AI.",
+      categoriesLabel: "Nhóm công việc",
+      skillCountLabel: (count) => `${count} skills`,
+      selectedSkill: "Skill đang chọn",
+      skillTags: "Chủ đề",
       useThisWhen: "Dùng khi",
-      copyBehavior: "Cách copy",
-      copyBehaviorDetail: "Nút này copy nguyên khối markdown, gồm heading, process, output format và guardrail.",
-      operatingRule: "Quy tắc vận hành",
-      operatingRuleDetail: "Giữ skill đủ cụ thể để dùng được, nhưng đủ ngắn để paste vào Codex, Claude, Gemini hoặc agent khác."
+      copyBehavior: "Nội dung được sao chép",
+      copyBehaviorDetail: "Nút này copy toàn bộ Markdown, gồm workflow, expected output và guardrails.",
+      operatingRule: "Cách dùng",
+      operatingRuleDetail: "Hãy xem đây là điểm bắt đầu. Vẫn cần nêu rõ phạm vi, cung cấp đúng tài liệu gốc và tự chịu trách nhiệm cho quyết định cuối cùng."
     },
     checklists: {
       ...englishStudioCopy.checklists,
-      emptyTitle: "Thư viện checklist đang trống",
-      emptyDescription: "Thêm workflow checklist vào Studio data trước khi mở menu này.",
+      emptyTitle: "Chưa có checklist nào",
+      emptyDescription: "Checklist đã hoàn thiện sẽ xuất hiện ở đây.",
       copyChecklist: "Copy checklist",
-      copied: "Đã copy",
-      copy: "Copy",
-      menu: "Menu checklist",
-      menuDetail: "Danh sách vận hành từ nhận ticket đến rollout.",
-      workflowListLabel: "Workflow checklist",
+      copied: "Đã sao chép",
+      copy: "Sao chép",
+      menu: "Checklist Library",
+      menuDetail: "Các checklist từ lúc nhận task đến release và rollout.",
+      workflowListLabel: "Workflow checklists",
       selectedChecklist: "Checklist đang chọn",
-      checklistTags: "Tag checklist",
+      checklistTags: "Chủ đề",
       sections: "phần",
       steps: "bước",
       whenToUse: "Khi dùng",
       structure: "Cấu trúc",
-      structureDetail: (sections, steps) => `${sections} phần, ${steps} bước con, có thể copy dạng markdown.`,
-      markdownCopy: "Markdown copy",
-      markdownUseWhen: "Dùng khi"
+      structureDetail: (sections, steps) => `${sections} phần, ${steps} bước chi tiết, có thể sao chép dưới dạng Markdown.`,
+      markdownCopy: "Bản Markdown",
+      markdownUseWhen: "Dùng khi",
+      detailsLabel: "Chi tiết checklist"
     },
     preferences: {
       ...englishStudioCopy.preferences,
       title: "Tùy chỉnh",
-      description: "Theme, font và layout cho Studio workspace.",
-      palette: "CV palette",
-      themeMode: "Chế độ theme",
+      description: "Chọn giao diện, phông chữ và cách trình bày cho Studio.",
+      palette: "Giao diện",
+      themeMode: "Chế độ màu",
       resolvedNow: "Đang áp dụng",
-      font: "Font",
-      pageLayout: "Layout trang",
-      pageLayoutHelp: "Centered giúp đọc bình tĩnh hơn. Full width phù hợp bề mặt thao tác rộng.",
-      navbarBehavior: "Navbar",
-      navbarHelp: "Sticky giữ control luôn thấy được. Scroll cho toàn bộ workspace cuộn cùng nhau.",
-      sidebarStyle: "Kiểu sidebar",
-      sidebarStyleHelp: "Chọn density phù hợp với việc setup hiện tại.",
+      font: "Phông chữ",
+      pageLayout: "Bề rộng nội dung",
+      pageLayoutHelp: "Căn giữa dễ đọc hơn. Toàn chiều rộng cho sơ đồ và khu làm việc nhiều chỗ hơn.",
+      navbarBehavior: "Thanh công cụ",
+      navbarHelp: "Cố định để luôn thấy các nút điều khiển. Cuộn để thanh này đi cùng nội dung.",
+      sidebarStyle: "Kiểu thanh bên",
+      sidebarStyleHelp: "Chọn cách thanh điều hướng nằm cạnh khu làm việc.",
       collapseMode: "Cách thu gọn",
-      collapseModeHelp: "Icon giữ rail còn thấy được. Offcanvas ẩn hẳn trên desktop.",
-      restoreDefaults: "Khôi phục layout mặc định",
+      collapseModeHelp: "Biểu tượng giữ lại một dải điều hướng nhỏ. Ẩn hoàn toàn sẽ cất thanh bên trên máy tính.",
+      restoreDefaults: "Khôi phục cách trình bày mặc định",
       themeOptions: { light: "Sáng", system: "Hệ thống", dark: "Tối" },
-      contentLayoutOptions: { centered: "Căn giữa", "full-width": "Full width" },
-      navbarStyleOptions: { sticky: "Sticky", scroll: "Scroll" },
-      sidebarVariantOptions: { inset: "Inset", sidebar: "Sidebar", floating: "Floating" },
-      sidebarCollapsibleOptions: { icon: "Icon", offcanvas: "Offcanvas" }
+      contentLayoutOptions: { centered: "Căn giữa", "full-width": "Toàn chiều rộng" },
+      navbarStyleOptions: { sticky: "Cố định", scroll: "Cuộn theo trang" },
+      sidebarVariantOptions: { inset: "Liền khối", sidebar: "Thanh bên", floating: "Tách nền" },
+      sidebarCollapsibleOptions: { icon: "Thu còn biểu tượng", offcanvas: "Ẩn hoàn toàn" }
     }
   },
   zh: createCompactStudioCopy({
@@ -2422,6 +2523,33 @@ const aiWorkflowSteps = [
     state: "next"
   }
 ];
+
+function getAiWorkflowSteps(locale: string) {
+  if (locale !== "vi") return aiWorkflowSteps;
+
+  return [
+    {
+      title: "Thu thập nguồn",
+      detail: "Đưa dữ kiện, tài liệu gốc, log và ghi chú vào NotebookLM hoặc một dự án riêng trước khi nhờ AI đưa ra nhận định.",
+      state: "ready"
+    },
+    {
+      title: "Làm rõ bài toán",
+      detail: "Dùng GPT để tách mục tiêu, giả định, giới hạn, quyết định cần đưa ra và việc tiếp theo.",
+      state: "active"
+    },
+    {
+      title: "Phản biện",
+      detail: "Dùng Claude để soi giả định yếu, rủi ro kiến trúc, trường hợp khó và độ rõ của cách trình bày.",
+      state: "required"
+    },
+    {
+      title: "Thực hiện và lưu lại",
+      detail: "Dùng Codex hoặc Antigravity cho phần việc có ranh giới rõ, rồi lưu câu lệnh, kết quả, bằng chứng kiểm tra và bài học.",
+      state: "next"
+    }
+  ];
+}
 
 const aiRuntimeTargets = ["NotebookLM", "GPT", "Claude", "Codex", "Antigravity"];
 
@@ -3578,18 +3706,21 @@ function AiAgentSetupPage({
   copy: StudioUiCopy;
   profileActions: StudioProfileMenuItem[];
 }) {
-  const setupFolder = studioFolders.find((folder) => folder.id === "machine-bootstrap");
+  const localizedFolders = useMemo(() => getLocalizedStudioFolders(locale), [locale]);
+  const localizedNotes = useMemo(() => getLocalizedStudioNotes(locale), [locale]);
+  const localizedWorkflowSteps = useMemo(() => getAiWorkflowSteps(locale), [locale]);
+  const setupFolder = localizedFolders.find((folder) => folder.id === "machine-bootstrap");
   const setupGroups = setupFolder?.groups ?? [];
   const setupNoteIds = new Set(setupGroups.flatMap((group) => group.noteIds));
-  const setupNotes = studioNotes.filter((note) => setupNoteIds.has(note.id));
+  const setupNotes = localizedNotes.filter((note) => setupNoteIds.has(note.id));
   const initialNoteId = setupNotes.some((note) => note.id === defaultStudioNoteId)
     ? defaultStudioNoteId
     : setupNotes[0]?.id ?? defaultStudioNoteId;
   const [selectedNoteId, setSelectedNoteId] = useState(initialNoteId);
-  const selectedNote = setupNotes.find((note) => note.id === selectedNoteId) ?? setupNotes[0] ?? studioNotes[0];
-  const workflowFolder = studioFolders.find((folder) => folder.id === "ai-learning");
+  const selectedNote = setupNotes.find((note) => note.id === selectedNoteId) ?? setupNotes[0] ?? localizedNotes[0];
+  const workflowFolder = localizedFolders.find((folder) => folder.id === "ai-learning");
   const workflowNoteIds = new Set(workflowFolder?.groups.flatMap((group) => group.noteIds) ?? []);
-  const workflowNotes = studioNotes.filter((note) => workflowNoteIds.has(note.id));
+  const workflowNotes = localizedNotes.filter((note) => workflowNoteIds.has(note.id));
 
   return (
     <section className="route-page ai-setup-route">
@@ -3615,10 +3746,6 @@ function AiAgentSetupPage({
               </a>
             );
           })}
-          <button type="button" className="outline-button">
-            <LuPlusCircle aria-hidden="true" />
-            {copy.aiSetup.addNote}
-          </button>
         </div>
       </RouteHeading>
 
@@ -3644,7 +3771,7 @@ function AiAgentSetupPage({
                 <p>{group.label}</p>
                 <div>
                   {group.noteIds.map((noteId) => {
-                    const note = studioNotes.find((item) => item.id === noteId);
+                    const note = localizedNotes.find((item) => item.id === noteId);
                     if (!note) return null;
 
                     return (
@@ -3668,7 +3795,7 @@ function AiAgentSetupPage({
           </div>
         </aside>
 
-        <article className="ai-setup-reader" aria-label={copy.aiSetup.selectedNote}>
+        <article id={selectedNote.id} className="ai-setup-reader" aria-label={copy.aiSetup.selectedNote}>
           <div className="ai-reader-head">
             <div>
               <span className={`ai-status-pill status-${selectedNote.status}`}>{statusText(selectedNote.status, copy)}</span>
@@ -3736,7 +3863,7 @@ function AiAgentSetupPage({
           </div>
 
           <div className="ai-workflow-steps">
-            {aiWorkflowSteps.map((step, index) => (
+            {localizedWorkflowSteps.map((step, index) => (
               <article key={step.title} className={`ai-workflow-step state-${step.state}`}>
                 <span>{index + 1}</span>
                 <div>
@@ -4100,7 +4227,7 @@ function DeliveryChecklistsPage({ route, locale, copy }: { route: StudioRoute; l
           </div>
         </article>
 
-        <aside className="checklist-side-pane" aria-label="Checklist details">
+        <aside className="checklist-side-pane" aria-label={copy.checklists.detailsLabel}>
           <section>
             <h3>{copy.checklists.whenToUse}</h3>
             <p>{selectedChecklist.whenToUse}</p>
@@ -4276,8 +4403,8 @@ const reactFlowExampleFamilyLabels: Record<string, string> = {
   architecture: "Software Architecture"
 };
 
-function getReactFlowFamilyLabel(family: string) {
-  return reactFlowExampleFamilyLabels[family] ?? family;
+function getReactFlowFamilyLabel(family: string, copy: StudioUiCopy["flows"]) {
+  return copy.familyLabels[family] ?? reactFlowExampleFamilyLabels[family] ?? family;
 }
 
 function formatStudioFlowLabel(value: string) {
@@ -4309,10 +4436,10 @@ function renderStudioFlowNodeIcon(kind: StudioFlowCanvasNodeKind, badge?: string
 function StudioFlowCanvasNodeCard({ data, selected }: NodeProps<StudioFlowCanvasNode>) {
   const canConnect = data.kind !== "group";
   const detail = data.collapsed && data.hiddenChildCount
-    ? `${data.detail} ${data.hiddenChildCount} hidden.`
+    ? `${data.detail} ${data.hiddenChildCount} ${data.hiddenLabel ?? "hidden"}.`
     : data.detail;
-  const kindLabel = formatStudioFlowLabel(data.kind);
-  const toneLabel = formatStudioFlowLabel(data.tone);
+  const kindLabel = data.kindLabel ?? formatStudioFlowLabel(data.kind);
+  const toneLabel = data.toneLabel ?? formatStudioFlowLabel(data.tone);
 
   return (
     <div className={`flow-react-node flow-react-node--${data.kind} tone-${data.tone}${data.active ? " is-active" : ""}${data.compact ? " is-compact" : ""}${data.collapsed ? " is-collapsed" : ""}${data.scratch ? " is-scratch" : ""}${data.dimmed ? " is-dimmed" : ""}${selected ? " is-selected" : ""}`}>
@@ -4329,8 +4456,8 @@ function StudioFlowCanvasNodeCard({ data, selected }: NodeProps<StudioFlowCanvas
       <small>{detail}</small>
       <div className="flow-react-node-footer">
         <span>{toneLabel}</span>
-        {data.scratch && <em>Scratch</em>}
-        {data.hiddenChildCount ? <em>{data.hiddenChildCount} hidden</em> : null}
+        {data.scratch && <em>{data.scratchLabel ?? "Scratch"}</em>}
+        {data.hiddenChildCount ? <em>{data.hiddenChildCount} {data.hiddenLabel ?? "hidden"}</em> : null}
       </div>
       {canConnect && <Handle type="source" position={Position.Right} />}
       {canConnect && <Handle className="flow-react-handle-bottom" type="source" position={Position.Bottom} />}
@@ -4338,12 +4465,12 @@ function StudioFlowCanvasNodeCard({ data, selected }: NodeProps<StudioFlowCanvas
   );
 }
 
-function buildStudioFlowCanvas(flow: StudioFlow, viewId?: string): {
+function buildStudioFlowCanvas(flow: StudioFlow, copy: StudioUiCopy["flows"], viewId?: string): {
   nodes: StudioFlowCanvasNode[];
   edges: Edge[];
 } {
   if (flow.architectureDemo) {
-    return buildArchitectureDemoCanvas(flow, viewId);
+    return buildArchitectureDemoCanvas(flow, copy, viewId);
   }
 
   const nodes = flow.steps.map<StudioFlowCanvasNode>((step, index) => {
@@ -4360,7 +4487,11 @@ function buildStudioFlowCanvas(flow: StudioFlow, viewId?: string): {
         title: step.title,
         detail: step.output,
         badge: String(index + 1).padStart(2, "0"),
-        tone
+        tone,
+        kindLabel: copy.nodeLabels["step"],
+        toneLabel: copy.nodeLabels[tone],
+        scratchLabel: copy.scratch,
+        hiddenLabel: copy.hiddenCount.toLocaleLowerCase()
       }
     };
   });
@@ -4371,10 +4502,14 @@ function buildStudioFlowCanvas(flow: StudioFlow, viewId?: string): {
     position: { x: flow.steps.length * 270 + 16, y: 90 },
     data: {
       kind: "detail",
-      title: "Outcome",
+      title: copy.chartOutcome,
       detail: flow.outcome,
       badge: "goal",
-      tone: "output"
+      tone: "output",
+      kindLabel: copy.nodeLabels["detail"],
+      toneLabel: copy.nodeLabels["output"],
+      scratchLabel: copy.scratch,
+      hiddenLabel: copy.hiddenCount.toLocaleLowerCase()
     }
   };
 
@@ -4417,7 +4552,7 @@ function getStudioFlowEdgeMarker(marker: StudioFlowArchitectureEdgeSpec["marker"
   return undefined;
 }
 
-function buildArchitectureDemoCanvas(flow: StudioFlow, viewId?: string): {
+function buildArchitectureDemoCanvas(flow: StudioFlow, copy: StudioUiCopy["flows"], viewId?: string): {
   nodes: StudioFlowCanvasNode[];
   edges: Edge[];
 } {
@@ -4441,6 +4576,10 @@ function buildArchitectureDemoCanvas(flow: StudioFlow, viewId?: string): {
       detail: node.detail,
       badge: node.badge,
       tone: node.tone,
+      kindLabel: copy.nodeLabels[node.kind],
+      toneLabel: copy.nodeLabels[node.tone],
+      scratchLabel: copy.scratch,
+      hiddenLabel: copy.hiddenCount.toLocaleLowerCase(),
       active: node.kind !== "group",
       compact: node.compact
     }
@@ -4656,7 +4795,7 @@ function createScratchNodeId(prefix: string) {
   return `${prefix}-${Date.now().toString(36)}-${scratchNodeSequence.toString(36)}-${uniquePart}`;
 }
 
-function createScratchNoteNode(anchorNode?: StudioFlowCanvasNode): StudioFlowCanvasNode {
+function createScratchNoteNode(copy: StudioUiCopy["flows"], anchorNode?: StudioFlowCanvasNode): StudioFlowCanvasNode {
   const position = anchorNode
     ? { x: anchorNode.position.x + 280, y: anchorNode.position.y + 24 }
     : { x: 40, y: 40 };
@@ -4666,10 +4805,14 @@ function createScratchNoteNode(anchorNode?: StudioFlowCanvasNode): StudioFlowCan
     position,
     data: {
       kind: "note",
-      title: "Review note",
-      detail: "Temporary annotation for this Studio session.",
+      title: copy.reviewNote,
+      detail: copy.temporaryAnnotation,
       badge: "note",
       tone: "review",
+      kindLabel: copy.nodeLabels["note"],
+      toneLabel: copy.nodeLabels["review"],
+      scratchLabel: copy.scratch,
+      hiddenLabel: copy.hiddenCount.toLocaleLowerCase(),
       active: true,
       scratch: true
     }
@@ -4850,10 +4993,10 @@ function StudioFlowChart({ flow, copy }: { flow: StudioFlow; copy: StudioUiCopy 
   const familyOptions = useMemo(() => {
     const families = new Map<string, string>();
     demoViews.forEach((view) => {
-      if (!families.has(view.family)) families.set(view.family, getReactFlowFamilyLabel(view.family));
+      if (!families.has(view.family)) families.set(view.family, getReactFlowFamilyLabel(view.family, copy.flows));
     });
     return Array.from(families, ([value, label]) => ({ value, label }));
-  }, [demoViews]);
+  }, [copy.flows, demoViews]);
   const selectedFamilyViews = useMemo(
     () => demoViews.filter((view) => view.family === selectedFamily),
     [demoViews, selectedFamily]
@@ -4861,7 +5004,10 @@ function StudioFlowChart({ flow, copy }: { flow: StudioFlow; copy: StudioUiCopy 
   const selectedView = demoViews.find((view) => view.id === selectedViewId)
     ?? selectedFamilyViews[0]
     ?? initialDemoView;
-  const sourceCanvas = useMemo(() => buildStudioFlowCanvas(flow, selectedView?.id), [flow, selectedView?.id]);
+  const sourceCanvas = useMemo(
+    () => buildStudioFlowCanvas(flow, copy.flows, selectedView?.id),
+    [copy.flows, flow, selectedView?.id]
+  );
   const [canvasNodes, setCanvasNodes] = useState<StudioFlowCanvasNode[]>(() => cloneStudioFlowNodes(sourceCanvas.nodes));
   const [canvasEdges, setCanvasEdges] = useState<Edge[]>(() => cloneStudioFlowEdges(sourceCanvas.edges));
   const canvasNodesRef = useRef(canvasNodes);
@@ -4967,7 +5113,7 @@ function StudioFlowChart({ flow, copy }: { flow: StudioFlow; copy: StudioUiCopy 
   }, [layoutMode]);
 
   const resetCanvasToSource = useCallback((viewId?: string) => {
-    const nextCanvas = buildStudioFlowCanvas(flow, viewId);
+    const nextCanvas = buildStudioFlowCanvas(flow, copy.flows, viewId);
     setCanvasNodes(cloneStudioFlowNodes(nextCanvas.nodes));
     setCanvasEdges(cloneStudioFlowEdges(nextCanvas.edges));
     setHiddenGroupIds([]);
@@ -4981,7 +5127,7 @@ function StudioFlowChart({ flow, copy }: { flow: StudioFlow; copy: StudioUiCopy 
     setPendingLayoutMode("source");
     setHelperLines({ x: null, y: null });
     scheduleFitBoard();
-  }, [flow, scheduleFitBoard]);
+  }, [copy.flows, flow, scheduleFitBoard]);
 
   useEffect(() => {
     if (!isBoardFullscreen) return undefined;
@@ -5203,7 +5349,7 @@ function StudioFlowChart({ flow, copy }: { flow: StudioFlow; copy: StudioUiCopy 
 
   const handleAddNote = () => {
     captureHistory();
-    const noteNode = createScratchNoteNode(selectedNode ?? undefined);
+    const noteNode = createScratchNoteNode(copy.flows, selectedNode ?? undefined);
     setCanvasNodes((current) => [
       ...current.map((node) => ({ ...node, selected: false })),
       noteNode
@@ -5298,7 +5444,7 @@ function StudioFlowChart({ flow, copy }: { flow: StudioFlow; copy: StudioUiCopy 
 
       <div className={`flow-board-toolbar${demo && selectedView ? " has-selectors" : ""}`} aria-label={copy.flows.boardTools}>
         {demo && selectedView && (
-          <div className="flow-example-toolbar" aria-label="React Flow example selector">
+          <div className="flow-example-toolbar" aria-label={copy.flows.exampleSelectorLabel}>
             <label>
               <span>{copy.flows.exampleFamily}</span>
               <select
@@ -5691,7 +5837,10 @@ function StudioFlowMenuPage({
   copy: StudioUiCopy;
   onActivate: (routeId: StudioRouteId, source?: StudioRouteActivationSource) => void;
 }) {
-  const localizedFlows = useMemo(() => getLocalizedStudioFlows(locale), [locale]);
+  const localizedFlows = useMemo(
+    () => getLocalizedStudioDemoFlows(getLocalizedStudioFlows(locale), locale),
+    [locale]
+  );
   const localizedGroups = useMemo(() => getLocalizedStudioFlowGroups(locale), [locale]);
   const [copiedFlowId, setCopiedFlowId] = useState<string | null>(null);
   const selectedFlowId = flowIdFromRoute(route.id) ?? localizedFlows[0]?.id ?? "";
@@ -5747,6 +5896,7 @@ function StudioFlowMenuPage({
 
   return (
     <section className="route-page studio-flow-route">
+      {selectedFlow.architectureDemo && <h1 className="sr-only">{selectedFlow.title}</h1>}
       {!selectedFlow.architectureDemo && (
         <>
           <RouteHeading route={route} copy={copy}>
@@ -5831,7 +5981,7 @@ function StudioFlowMenuPage({
                 </a>
               </div>
 
-              <div className="ai-tag-list" aria-label="Flow tags">
+              <div className="ai-tag-list" aria-label={copy.flows.tags}>
                 {selectedFlow.tags.map((tag) => (
                   <span key={tag}>{tag}</span>
                 ))}
@@ -5839,7 +5989,7 @@ function StudioFlowMenuPage({
             </>
           )}
 
-          <StudioFlowChart key={selectedFlow.id} flow={selectedFlow} copy={copy} />
+          <StudioFlowChart key={`${locale}:${selectedFlow.id}`} flow={selectedFlow} copy={copy} />
 
           {!selectedFlow.architectureDemo && (
             <ol className="flow-step-map" aria-label={`${copy.flows.evidence} / ${copy.flows.output}`}>
@@ -5867,7 +6017,7 @@ function StudioFlowMenuPage({
         </article>
 
         {!selectedFlow.architectureDemo && (
-          <aside className="flow-side-pane" aria-label="Flow details">
+          <aside className="flow-side-pane" aria-label={copy.flows.details}>
             <section>
               <h3>{copy.flows.useWhen}</h3>
               <p>{selectedFlow.useWhen}</p>

--- a/src/app/[locale]/studio/studio.data.ts
+++ b/src/app/[locale]/studio/studio.data.ts
@@ -207,10 +207,10 @@ const baseStudioAiSkills: StudioAiSkill[] = [
   {
     id: "code-review",
     category: "engineering",
-    title: "Code Review Expert",
-    summary: "Review diffs like a Staff engineer: correctness first, security/privacy next, then maintainability, tests, and operational risk.",
+    title: "Code Review",
+    summary: "Review diffs for correctness, security, privacy, maintainability, test coverage, and operational risk.",
     tags: ["Code Review", "Correctness", "Security", "Test Strategy"],
-    markdown: `# Code Review Skill
+    markdown: `# Code Review
 
 Use this skill when reviewing pull requests, local diffs, generated code, refactors, migrations, or production bug fixes.
 
@@ -253,7 +253,7 @@ Use this skill when reviewing pull requests, local diffs, generated code, refact
     title: "Frontend Architecture",
     summary: "Shape frontend systems around route boundaries, state ownership, accessibility, telemetry, and Core Web Vitals.",
     tags: ["Frontend", "React", "Web Vitals", "Accessibility"],
-    markdown: `# Frontend Architecture Skill
+    markdown: `# Frontend Architecture
 
 Use this skill when designing routes, dashboards, component systems, forms, filters, search UIs, or frontend refactors.
 
@@ -287,9 +287,9 @@ Use this skill when designing routes, dashboards, component systems, forms, filt
     id: "backend-architecture",
     category: "engineering",
     title: "Backend Architecture",
-    summary: "Design backend systems with clear domain ownership, explicit contracts, resilient data flows, and operable failure modes.",
+    summary: "Design backend systems with clear domain ownership, explicit contracts, resilient data flows, and failure modes the team can detect, contain, and recover from.",
     tags: ["Backend", "API Design", "Distributed Systems", "Reliability"],
-    markdown: `# Backend Architecture Skill
+    markdown: `# Backend Architecture
 
 Use this skill for APIs, services, background jobs, webhooks, event streams, data migrations, and integrations.
 
@@ -322,10 +322,10 @@ Use this skill for APIs, services, background jobs, webhooks, event streams, dat
   {
     id: "blog-content-writer",
     category: "content",
-    title: "Technical Content Strategist",
-    summary: "Write technical content with a clear thesis, grounded evidence, semantic SEO, and calm expert authority.",
+    title: "Technical Writing",
+    summary: "Write clear technical content with a focused thesis, grounded evidence, useful SEO metadata, and a calm professional voice.",
     tags: ["Technical Writing", "SEO", "Editorial Strategy"],
-    markdown: `# Blog Content Writer Skill
+    markdown: `# Technical Writing
 
 Use this skill for engineering articles, technical explainers, architectural postmortems, product notes, and public documentation.
 
@@ -358,10 +358,10 @@ Use this skill for engineering articles, technical explainers, architectural pos
   {
     id: "prompt-writing",
     category: "content",
-    title: "Prompt Engineering Expert",
-    summary: "Design prompts and system instructions with explicit roles, bounded context, injection resistance, and verifiable output schemas.",
+    title: "Prompt Design",
+    summary: "Design prompts and system instructions with clear roles, bounded context, injection resistance, and verifiable output formats.",
     tags: ["Prompt Engineering", "LLM", "Agents", "Evaluation"],
-    markdown: `# Prompt Writing Skill
+    markdown: `# Prompt Design
 
 Use this skill to design system prompts, task prompts, few-shot examples, agent policies, extraction prompts, and output schemas.
 
@@ -394,10 +394,10 @@ Use this skill to design system prompts, task prompts, few-shot examples, agent 
   {
     id: "status-report",
     category: "operations",
-    title: "Executive Status & Operations",
-    summary: "Turn workstream noise into executive signal: health, impact, blockers, decisions, owners, and path to green.",
+    title: "Executive Status Reporting",
+    summary: "Turn scattered workstream updates into a clear view of health, impact, blockers, decisions, owners, and recovery actions.",
     tags: ["Operations", "Reporting", "OKR", "Escalation"],
-    markdown: `# Status Report Skill
+    markdown: `# Executive Status Reporting
 
 Use this skill for daily standups, weekly status reports, monthly OKR reviews, incident updates, and stakeholder escalations.
 
@@ -433,7 +433,7 @@ Use this skill for daily standups, weekly status reports, monthly OKR reviews, i
     title: "Technical Specification & RFC",
     summary: "Write decision-ready specs that bind product intent to architecture, NFRs, threat model, rollout, and verification.",
     tags: ["RFC", "ADR", "Architecture", "NFR"],
-    markdown: `# Doc / Spec / Tech Spec Skill
+    markdown: `# Technical Specification & RFC
 
 Use this skill for RFCs, ADRs, technical specifications, migration plans, system designs, and implementation handoffs.
 
@@ -469,7 +469,7 @@ Use this skill for RFCs, ADRs, technical specifications, migration plans, system
     title: "Strategic Pitch & Proposal",
     summary: "Build proposals that connect pain, value, ROI, risk, proof, and a concrete decision request.",
     tags: ["Proposal", "Strategy", "Executive Communication"],
-    markdown: `# Proposal / Slide / Pitch Deck Skill
+    markdown: `# Strategic Pitch & Proposal
 
 Use this skill for executive proposals, product strategy memos, budget asks, pitch decks, and technical-business trade-off narratives.
 
@@ -502,10 +502,10 @@ Use this skill for executive proposals, product strategy memos, budget asks, pit
   {
     id: "ai-operating-system",
     category: "strategy",
-    title: "AI Operating System & Orchestration",
-    summary: "Design agent workflows with model routing, context control, tool boundaries, RAG grounding, and human approval gates.",
+    title: "AI Workflow Design",
+    summary: "Design agent workflows with deliberate model routing, controlled context, clear tool boundaries, source grounding, and human approval gates.",
     tags: ["AI Orchestration", "Agents", "RAG", "MCP"],
-    markdown: `# AI Operating System Skill
+    markdown: `# AI Workflow Design
 
 Use this skill to design multi-agent workflows, AI workbenches, RAG pipelines, Codex/Claude/GPT task routing, and MCP tool policies.
 
@@ -538,10 +538,10 @@ Use this skill to design multi-agent workflows, AI workbenches, RAG pipelines, C
   {
     id: "daily-ai-learning-coach",
     category: "learning",
-    title: "Continuous AI Learning & Neuroplasticity",
-    summary: "Compound AI skill through deliberate practice, active recall, feedback loops, and reusable artifacts.",
+    title: "Continuous AI Learning",
+    summary: "Build practical AI skills through deliberate practice, active recall, feedback, and reusable work notes.",
     tags: ["Learning", "Deliberate Practice", "AI Fluency", "Feedback"],
-    markdown: `# Daily AI Learning Coach Skill
+    markdown: `# Continuous AI Learning
 
 Use this skill to plan daily AI up-skilling, technical practice, tool fluency, and long-term knowledge compounding.
 
@@ -574,10 +574,10 @@ Use this skill to plan daily AI up-skilling, technical practice, tool fluency, a
   {
     id: "notebooklm-source-of-truth",
     category: "learning",
-    title: "RAG-Grounded Knowledge Extraction",
-    summary: "Extract source-grounded answers from trusted documents with citations, contradiction checks, and explicit unknowns.",
+    title: "Source-Grounded Knowledge Extraction",
+    summary: "Extract answers from trusted documents with citations, contradiction checks, and explicit unknowns.",
     tags: ["RAG", "Citations", "Research", "Knowledge Graph"],
-    markdown: `# NotebookLM Source Of Truth Skill
+    markdown: `# Source-Grounded Knowledge Extraction
 
 Use this skill for dense document sets, NotebookLM-style corpora, PRDs, RFCs, research papers, financial reports, and knowledge bases.
 
@@ -610,10 +610,10 @@ Use this skill for dense document sets, NotebookLM-style corpora, PRDs, RFCs, re
   {
     id: "ai-delivery-factory",
     category: "engineering",
-    title: "Autonomous Delivery & CI/CD",
-    summary: "Run AI-assisted delivery from scoped requirement to implementation, verification, PR, and release-ready handoff.",
+    title: "AI-Assisted Delivery & CI/CD",
+    summary: "Guide AI-assisted delivery from a scoped requirement through implementation, verification, PR review, and a release-ready handoff.",
     tags: ["AI Delivery", "CI/CD", "Testing", "Automation"],
-    markdown: `# AI Delivery Factory Skill
+    markdown: `# AI-Assisted Delivery & CI/CD
 
 Use this skill when AI agents help implement features, refactors, migrations, test suites, CI changes, or release handoffs.
 
@@ -646,10 +646,10 @@ Use this skill when AI agents help implement features, refactors, migrations, te
   {
     id: "claude-deep-review",
     category: "engineering",
-    title: "Adversarial Semantic Review",
-    summary: "Use adversarial review to expose hidden assumptions, failure modes, ambiguity, and system-level fragility.",
+    title: "Adversarial Design Review",
+    summary: "Challenge a design to expose hidden assumptions, failure modes, ambiguity, and system-level fragility.",
     tags: ["Adversarial Review", "Red Teaming", "Architecture", "Security"],
-    markdown: `# Claude Deep Review Skill
+    markdown: `# Adversarial Design Review
 
 Use this skill for deep critique of PRs, RFCs, architecture proposals, incident narratives, strategy memos, or AI-generated plans.
 
@@ -682,10 +682,10 @@ Use this skill for deep critique of PRs, RFCs, architecture proposals, incident 
   {
     id: "career-ai-strategy",
     category: "strategy",
-    title: "Capability Compounding & Leverage",
-    summary: "Build durable career leverage through Staff-level scope, AI fluency, portfolio evidence, and compounding systems.",
+    title: "Building Durable Engineering Skills",
+    summary: "Develop broader engineering judgment through larger scope, responsible AI use, visible work evidence, and repeatable learning habits.",
     tags: ["Career Strategy", "Staff Engineer", "Leverage", "Portfolio"],
-    markdown: `# Career AI Strategy Skill
+    markdown: `# Building Durable Engineering Skills
 
 Use this skill for career planning, Staff/Principal path design, promotion packets, AI leverage strategy, and portfolio roadmaps.
 
@@ -718,10 +718,10 @@ Use this skill for career planning, Staff/Principal path design, promotion packe
   {
     id: "engineering-decision-map",
     category: "engineering",
-    title: "Systemic Decision Topography",
+    title: "Architecture Decision Mapping",
     summary: "Map business requirements to domain invariants, architecture options, trade-offs, risks, and operational readiness.",
     tags: ["Decision Matrix", "Systems Thinking", "Trade-offs", "Requirements"],
-    markdown: `# Engineering Decision Map Skill
+    markdown: `# Architecture Decision Mapping
 
 Use this skill when requirements are ambiguous, decisions are cross-functional, or architecture must balance product, data, and operations.
 
@@ -754,10 +754,10 @@ Use this skill when requirements are ambiguous, decisions are cross-functional, 
   {
     id: "staff-engineer-ai-review-pack",
     category: "engineering",
-    title: "Staff-Level Architectural Audit",
-    summary: "Audit high-risk technical changes through Staff-level lenses: product, architecture, security, data, SRE, QA, and rollout.",
+    title: "Architecture Risk Audit",
+    summary: "Audit high-risk technical changes across product behavior, architecture, security, data, reliability, testing, and rollout.",
     tags: ["Staff Engineer", "Architecture Review", "PRR", "Risk Audit"],
-    markdown: `# Staff Engineer AI Review Pack Skill
+    markdown: `# Architecture Risk Audit
 
 Use this skill for major architectural changes, multi-system integrations, sensitive-data features, migrations, and launch readiness reviews.
 
@@ -793,7 +793,7 @@ Use this skill for major architectural changes, multi-system integrations, sensi
     title: "Distributed Resilience & Telemetry",
     summary: "Review data integrity, distributed resilience, telemetry, and recovery plans before systems carry production load.",
     tags: ["Data", "Resilience", "Observability", "SRE"],
-    markdown: `# Data, Resilience, Observability Review Skill
+    markdown: `# Distributed Resilience & Telemetry
 
 Use this skill for databases, caches, queues, search indexes, event streams, third-party integrations, and production readiness reviews.
 
@@ -826,10 +826,10 @@ Use this skill for databases, caches, queues, search indexes, event streams, thi
   {
     id: "installed-skill-library-cartographer",
     category: "strategy",
-    title: "Installed Skill Library Cartographer",
-    summary: "Inventory installed agent skills, remove duplicates, classify capabilities, and turn scattered playbooks into a usable routing system.",
+    title: "Skill Library Inventory",
+    summary: "Inventory installed agent skills, remove duplicates, classify capabilities, and organize scattered playbooks into a usable library.",
     tags: ["Skill Inventory", "Agent Routing", "Taxonomy", "Governance"],
-    markdown: `# Installed Skill Library Cartographer Skill
+    markdown: `# Skill Library Inventory
 
 Use this skill when consolidating installed Codex, Claude, Gemini, Antigravity, local .agents, marketplace, plugin, or project skills into a coherent operating library.
 
@@ -864,10 +864,10 @@ Use this skill when consolidating installed Codex, Claude, Gemini, Antigravity, 
   {
     id: "ai-product-evaluation",
     category: "strategy",
-    title: "AI Product & Evaluation",
+    title: "AI Product Evaluation",
     summary: "Move AI features from impressive demos to trustworthy products with evals, safety boundaries, cost controls, and measurable user value.",
     tags: ["AI Product", "Evals", "LLM Quality", "Trust"],
-    markdown: `# AI Product & Evaluation Skill
+    markdown: `# AI Product Evaluation
 
 Use this skill when designing, auditing, or shipping AI-powered product features, agents, copilots, chat interfaces, retrieval systems, or model-powered workflows.
 
@@ -903,7 +903,7 @@ Use this skill when designing, auditing, or shipping AI-powered product features
     title: "Agent Tools, MCP & Workflow Automation",
     summary: "Design reliable tool-using agents across MCP, GitHub, Slack, Gmail, Outlook, Notion, Airtable, browsers, and local CLIs.",
     tags: ["MCP", "Automation", "Integrations", "Tool Use"],
-    markdown: `# Agent Tools, MCP & Workflow Automation Skill
+    markdown: `# Agent Tools, MCP & Workflow Automation
 
 Use this skill when an agent needs to use tools, connectors, MCP servers, CLIs, browsers, or app integrations to complete a workflow.
 
@@ -939,7 +939,7 @@ Use this skill when an agent needs to use tools, connectors, MCP servers, CLIs, 
     title: "Product Analytics & Growth Experimentation",
     summary: "Turn behavior data into decisions through event taxonomy, funnels, cohorts, A/B tests, attribution, and growth loops.",
     tags: ["Analytics", "Growth", "Experimentation", "PostHog"],
-    markdown: `# Product Analytics & Growth Experimentation Skill
+    markdown: `# Product Analytics & Growth Experimentation
 
 Use this skill when designing analytics, auditing tracking, planning growth experiments, measuring funnels, or deciding whether a feature worked.
 
@@ -975,7 +975,7 @@ Use this skill when designing analytics, auditing tracking, planning growth expe
     title: "Research & Market Intelligence",
     summary: "Produce grounded research from local docs, web sources, competitors, customers, papers, and market signals with explicit confidence.",
     tags: ["Research", "Market Intelligence", "Source Grounding", "Synthesis"],
-    markdown: `# Research & Market Intelligence Skill
+    markdown: `# Research & Market Intelligence
 
 Use this skill for market research, competitor analysis, product discovery, customer insight synthesis, technical literature review, or strategic scanning.
 
@@ -1011,7 +1011,7 @@ Use this skill for market research, competitor analysis, product discovery, cust
     title: "Security, Privacy & Threat Modeling",
     summary: "Audit systems for abuse paths, auth flaws, PII exposure, supply-chain risk, compliance gaps, and secure rollout.",
     tags: ["Security", "Privacy", "Threat Modeling", "Compliance"],
-    markdown: `# Security, Privacy & Threat Modeling Skill
+    markdown: `# Security, Privacy & Threat Modeling
 
 Use this skill when a change touches authentication, authorization, user input, sensitive data, payments, file uploads, integrations, AI tools, infrastructure, or production operations.
 
@@ -1047,7 +1047,7 @@ Use this skill when a change touches authentication, authorization, user input, 
     title: "Design System & UI Craft",
     summary: "Create polished, accessible, responsive interfaces using design systems, component libraries, visual hierarchy, and interaction states.",
     tags: ["Design System", "UI", "Accessibility", "Responsive"],
-    markdown: `# Design System & UI Craft Skill
+    markdown: `# Design System & UI Craft
 
 Use this skill when building or refining product UI, design systems, dashboards, landing pages, mobile layouts, component libraries, or visual prototypes.
 
@@ -1083,7 +1083,7 @@ Use this skill when building or refining product UI, design systems, dashboards,
     title: "Mobile Platform Engineering",
     summary: "Build and review iOS, Android, SwiftUI, Kotlin, React Native, and app-store workflows with performance and release discipline.",
     tags: ["Mobile", "iOS", "Android", "SwiftUI"],
-    markdown: `# Mobile Platform Engineering Skill
+    markdown: `# Mobile Platform Engineering
 
 Use this skill for native iOS, Android, SwiftUI, Kotlin, React Native, app packaging, app-store release work, or mobile UI/performance audits.
 
@@ -1119,7 +1119,7 @@ Use this skill for native iOS, Android, SwiftUI, Kotlin, React Native, app packa
     title: "Data, ML & Scientific Workflow",
     summary: "Handle data, ML, and science tasks with reproducible notebooks, trustworthy sources, evaluation, provenance, and statistical caution.",
     tags: ["Data", "ML", "Science", "Reproducibility"],
-    markdown: `# Data, ML & Scientific Workflow Skill
+    markdown: `# Data, ML & Scientific Workflow
 
 Use this skill for data analysis, ML experiments, scientific APIs, bioinformatics, finance data, geospatial work, notebooks, dashboards, or model evaluation.
 
@@ -1584,15 +1584,15 @@ export const studioAiSkills: StudioAiSkill[] = baseStudioAiSkills.map((skill) =>
 export const studioWorkflowChecklists: StudioWorkflowChecklist[] = [
   {
     id: "ticket-intake-to-start",
-    title: "Ticket intake to first commit",
-    summary: "A checklist for turning a ticket into clear scope, context, plan, and first implementation step.",
+    title: "From Ticket to First Commit",
+    summary: "A practical checklist for clarifying scope, gathering the right context, choosing a plan, and making the first reviewable change.",
     whenToUse: "Use before coding when a task arrives from product, support, design, or another engineer.",
     tags: ["Ticket", "Scoping", "Start work"],
     sections: [
       {
         id: "understand",
         title: "Understand the task",
-        detail: "Make sure the work is a real problem, not only a requested change.",
+        detail: "Clarify the underlying problem before deciding what to change.",
         steps: [
           { id: "read-ticket", label: "Read the ticket and restate the goal in one sentence." },
           { id: "identify-user", label: "Identify the affected user, route, workflow, or system boundary." },
@@ -1626,9 +1626,9 @@ export const studioWorkflowChecklists: StudioWorkflowChecklist[] = [
   },
   {
     id: "ai-driven-engineering-foundation-roadmap",
-    title: "AI-driven engineering foundation roadmap",
-    summary: "A layered roadmap for building senior engineering judgment in the AI era.",
-    whenToUse: "Use as a daily study map before or after engineering work, especially when a task touches architecture, data, reliability, or rollout.",
+    title: "Engineering Foundations for AI-Assisted Work",
+    summary: "A layered study plan for strengthening design, data, reliability, and production judgment while using AI.",
+    whenToUse: "Use before or after engineering work, especially when a task touches architecture, data, reliability, or rollout.",
     tags: ["Engineering foundation", "Architecture", "Production"],
     sections: [
       {
@@ -1695,9 +1695,9 @@ export const studioWorkflowChecklists: StudioWorkflowChecklist[] = [
   },
   {
     id: "engineering-delivery-checklist",
-    title: "Engineering delivery checklist",
+    title: "Engineering Delivery Checklist",
     summary: "An eight-phase checklist from task intake to post-rollout review.",
-    whenToUse: "Use whenever a task might affect architecture, data, traffic, users, production operation, or team handoff.",
+    whenToUse: "Use whenever a task may affect architecture, data, traffic, users, production behavior, or team handoff.",
     tags: ["Task", "Delivery", "Rollout"],
     sections: [
       {
@@ -1785,9 +1785,9 @@ export const studioWorkflowChecklists: StudioWorkflowChecklist[] = [
   },
   {
     id: "senior-engineer-reflex",
-    title: "Senior engineer reflex",
-    summary: "A compact question set for any feature: business, product, domain, API, data, consistency, resilience, security, observability, and rollout.",
-    whenToUse: "Use before implementation when the task feels simple but could hide production, data, or user risk.",
+    title: "Senior Engineering Questions",
+    summary: "A compact set of questions covering business, product, domain, API, data, consistency, resilience, security, observability, and rollout.",
+    whenToUse: "Use before implementation when a task looks simple but may hide production, data, or user risk.",
     tags: ["Senior reflex", "Questions", "Risk"],
     sections: [
       {
@@ -1834,9 +1834,9 @@ export const studioWorkflowChecklists: StudioWorkflowChecklist[] = [
   },
   {
     id: "capstone-production-project",
-    title: "Capstone production project",
-    summary: "A long-running e-commerce, subscription, or booking lab that combines architecture, data, resilience, events, and observability.",
-    whenToUse: "Use as the practical lab for turning the roadmap into visible evidence and reusable engineering muscle.",
+    title: "Production Systems Practice Project",
+    summary: "A long-running e-commerce, subscription, or booking project for practicing architecture, data, resilience, events, and observability together.",
+    whenToUse: "Use to turn the roadmap into practical experience, visible evidence, and reusable engineering notes.",
     tags: ["Capstone", "Practice", "Portfolio"],
     sections: [
       {
@@ -1884,8 +1884,8 @@ export const studioWorkflowChecklists: StudioWorkflowChecklist[] = [
   },
   {
     id: "module-creation",
-    title: "Create a new module",
-    summary: "A checklist for adding a route, feature module, service module, or reusable component without leaking responsibility.",
+    title: "Create a New Module",
+    summary: "A checklist for adding a route, feature module, service module, or reusable component without blurring ownership.",
     whenToUse: "Use when adding a new feature surface or reusable module.",
     tags: ["Module", "Architecture", "Frontend", "Backend"],
     sections: [
@@ -1946,9 +1946,9 @@ export const studioWorkflowChecklists: StudioWorkflowChecklist[] = [
   },
   {
     id: "ai-system-engineering-roadmap",
-    title: "AI system engineering roadmap",
-    summary: "A daily learning checklist for SDLC ownership, distributed architecture, storage systems, and AI-assisted engineering review.",
-    whenToUse: "Use as the daily AI up-skill map when the goal is to become stronger at technical decisions, not only faster at code generation.",
+    title: "System Engineering Roadmap for AI-Assisted Work",
+    summary: "A study checklist for SDLC ownership, distributed architecture, storage systems, and AI-assisted engineering review.",
+    whenToUse: "Use when the goal is to improve technical decisions, not only generate code faster.",
     tags: ["AI up-skill", "System engineering", "Distributed systems", "Storage", "SDLC"],
     sections: [
       {
@@ -2063,7 +2063,7 @@ export const studioWorkflowChecklists: StudioWorkflowChecklist[] = [
   },
   {
     id: "release-readiness",
-    title: "Release readiness",
+    title: "Release Readiness",
     summary: "A checklist for deciding whether a change is ready to leave the branch.",
     whenToUse: "Use before merging, tagging, or preparing a production deployment.",
     tags: ["Release", "QA", "Merge"],
@@ -2105,7 +2105,7 @@ export const studioWorkflowChecklists: StudioWorkflowChecklist[] = [
   },
   {
     id: "rollout-plan",
-    title: "Rollout plan",
+    title: "Rollout Plan",
     summary: "A checklist for moving from merged code to production adoption with guardrails.",
     whenToUse: "Use for staged releases, feature flags, customer cohorts, migrations, or high-impact UI changes.",
     tags: ["Rollout", "Feature flag", "Monitoring"],
@@ -2156,9 +2156,9 @@ export const studioWorkflowChecklists: StudioWorkflowChecklist[] = [
   },
   {
     id: "daily-ai-learning-loop",
-    title: "Daily AI learning loop",
-    summary: "A short daily loop for improving AI skill through one useful practice, one saved artifact, and one review.",
-    whenToUse: "Use every morning and evening when the goal is steady AI skill compounding without overloading the day.",
+    title: "Daily AI Practice Loop",
+    summary: "A short daily routine built around one useful practice, one saved note or artifact, and one review.",
+    whenToUse: "Use at the start and end of the workday to build AI skills steadily without overloading the day.",
     tags: ["Daily", "AI learning", "Habit"],
     sections: [
       {
@@ -2198,9 +2198,9 @@ export const studioWorkflowChecklists: StudioWorkflowChecklist[] = [
   },
   {
     id: "weekly-ai-os-review",
-    title: "Weekly AI OS review",
-    summary: "A weekly review for work, learning, finance, life, and the AI workflows that should compound.",
-    whenToUse: "Use at the end of the week to convert scattered AI usage into reusable systems.",
+    title: "Weekly AI Workflow Review",
+    summary: "A weekly review of recurring work, learning, and personal workflows that are worth keeping or improving.",
+    whenToUse: "Use at the end of the week to turn scattered AI usage into reusable habits, notes, and templates.",
     tags: ["Weekly review", "Life OS", "Career"],
     sections: [
       {
@@ -2240,9 +2240,9 @@ export const studioWorkflowChecklists: StudioWorkflowChecklist[] = [
   },
   {
     id: "ai-tool-routing-decision-tree",
-    title: "AI tool routing decision tree",
+    title: "AI Tool Routing Guide",
     summary: "A checklist for choosing NotebookLM, GPT, Claude, Codex, or Antigravity before starting work.",
-    whenToUse: "Use when a task is vague, large, or tempting to ask every AI tool at once.",
+    whenToUse: "Use when a task is broad or unclear and you need to choose one tool or a deliberate sequence.",
     tags: ["Tool routing", "Decision", "Guardrails"],
     sections: [
       {
@@ -2284,7 +2284,7 @@ export const studioWorkflowChecklists: StudioWorkflowChecklist[] = [
   },
   {
     id: "ai-assisted-feature-workflow",
-    title: "AI-assisted feature workflow",
+    title: "AI-Assisted Feature Workflow",
     summary: "A full feature workflow from idea to spec, implementation, review, rollout, and knowledge archive.",
     whenToUse: "Use for meaningful product or engineering changes where multiple AI tools can help without losing ownership.",
     tags: ["Feature", "GPT", "Claude", "Codex", "Antigravity"],
@@ -2324,9 +2324,9 @@ export const studioWorkflowChecklists: StudioWorkflowChecklist[] = [
   },
   {
     id: "ninety-day-ai-skill-plan",
-    title: "90-day AI skill plan",
-    summary: "A phased plan for turning AI tools into daily practice, engineering leverage, career assets, and personal operating systems.",
-    whenToUse: "Use as the quarterly roadmap for raising AI literacy and turning the stack into durable leverage.",
+    title: "90-Day AI Practice Plan",
+    summary: "A phased plan for building daily habits, improving engineering work, documenting evidence, and creating useful personal workflows.",
+    whenToUse: "Use as a quarterly guide for building AI literacy through small, repeatable practices.",
     tags: ["90 days", "Roadmap", "AI literacy"],
     sections: [
       {
@@ -2432,33 +2432,33 @@ export const studioNotes: StudioNote[] = [
   {
     id: "ai-operating-system",
     folderId: "machine-bootstrap",
-    title: "AI Operating System",
-    subtitle: "Daily direction for using NotebookLM, GPT, Claude, Codex, and Antigravity as one system.",
+    title: "My AI Working System",
+    subtitle: "How I use NotebookLM, GPT, Claude, Codex, and Antigravity across research, review, and implementation.",
     status: "ready",
     updatedAt: "2026-06-21",
     tags: ["AI OS", "NotebookLM", "GPT", "Claude", "Codex", "Antigravity", "Daily learning"],
     summary:
-      "This note turns the AI stack into a daily operating system: NotebookLM keeps source-backed truth, GPT plans, Claude critiques, Codex ships code, Antigravity verifies prototypes, and every useful lesson becomes a reusable artifact.",
+      "This note records how I divide research, planning, review, and repository work across several AI tools while keeping verification and final decisions with me.",
     sections: [
       {
-        heading: "The operating principle",
+        heading: "The working principle",
         body:
-          "The bottleneck is not a lack of AI tools. The bottleneck is scattered context. The system should capture facts first, clarify the real problem, route work to the right tool, review risky output, and archive the lesson so tomorrow starts from a better baseline."
+          "More tools do not help when the context is scattered. I start with the facts, clarify the problem, choose the tool that fits the task, review risky output, and save the useful lesson for the next time."
       },
       {
         heading: "Tool roles",
         body:
-          "NotebookLM is the source-backed memory. GPT is the chief of staff for planning, research, decision support, and weekly reviews. Claude is the deep reviewer for architecture, writing, assumptions, and sensitive communication. Codex is the repo execution engine for PRs, tests, refactors, and migrations. Antigravity is the agentic lab for prototypes, UI flows, browser verification, and multi-agent dev experiments."
+          "I use NotebookLM to review source material; GPT for planning and research; Claude for critique and writing; Codex for repository changes; and Antigravity for prototypes, UI flows, browser checks, and multi-agent experiments. These roles are working preferences, not fixed rules."
       },
       {
         heading: "Daily learning direction",
         body:
-          "Each day should produce one small improvement: a better prompt, a reusable checklist, a reviewed diff, a clearer decision, a sourced note, or one saved workflow. The goal is not to use every tool every day; the goal is to make the right tool choice repeatable."
+          "A useful day leaves one small improvement behind: a better prompt, a reusable checklist, a reviewed diff, a clearer decision, a sourced note, or a saved workflow. I do not need to use every tool every day; I need to make good tool choices repeatable."
       },
       {
         heading: "Career direction",
         body:
-          "The strongest path is AI-native Staff Engineer / Tech Lead: software architecture, agent orchestration, engineering leadership, product thinking, communication, and financial discipline. The assets to build are an AI engineering playbook, architecture portfolio, public writing, and automation demos."
+          "The direction I am working toward combines software architecture, responsible AI use, engineering leadership, product judgment, and clear communication. I want to keep building practical playbooks, architecture examples, public writing, and small automation demos that show the work honestly."
       }
     ],
     commands: [
@@ -2509,13 +2509,13 @@ export const studioNotes: StudioNote[] = [
   {
     id: "ai-driven-engineering-foundation",
     folderId: "machine-bootstrap",
-    title: "AI-Driven Engineering Foundation",
-    subtitle: "Daily roadmap for technical decision-making from task intake to production operation.",
+    title: "Engineering Foundations for AI-Assisted Work",
+    subtitle: "A practical roadmap for technical decisions from task intake through production operations.",
     status: "ready",
     updatedAt: "2026-06-21",
     tags: ["Engineering roadmap", "Architecture", "Data", "Resilience", "Observability", "AI workflow"],
     summary:
-      "This note keeps the long-term learning direction visible: AI can generate code quickly, but senior leverage comes from asking the right technical questions, choosing the right trade-offs, verifying failure modes, and owning production behavior.",
+      "This note keeps the long-term learning direction visible: AI can generate code quickly, but sound engineering still depends on good questions, explicit trade-offs, tested failure modes, and ownership of production behavior.",
     sections: [
       {
         heading: "Why this matters",
@@ -2586,13 +2586,13 @@ export const studioNotes: StudioNote[] = [
   {
     id: "ai-system-engineering-roadmap",
     folderId: "ai-learning",
-    title: "AI-Driven System Engineering Roadmap",
+    title: "System Engineering Roadmap for AI-Assisted Work",
     subtitle: "Daily map for SDLC ownership, distributed systems, storage scale, and AI-assisted review.",
     status: "ready",
     updatedAt: "2026-06-21",
     tags: ["AI up-skill", "System engineering", "SDLC", "Distributed systems", "Storage", "AI workflow"],
     summary:
-      "This roadmap keeps the next learning layer visible: AI can write code faster, but a senior engineer must own architecture decisions, verify distributed failure modes, understand storage trade-offs, and use AI as a disciplined reviewer.",
+      "This roadmap keeps the next learning layer visible: architecture decisions, distributed failure modes, storage trade-offs, and disciplined review still need clear human ownership when AI helps write the code.",
     sections: [
       {
         heading: "Core shift",
@@ -2665,7 +2665,7 @@ export const studioNotes: StudioNote[] = [
     id: "antigravity-awesome-skills",
     folderId: "machine-bootstrap",
     title: "Antigravity Awesome Skills",
-    subtitle: "The command that installs my reusable agent skill library.",
+    subtitle: "Setup notes for reinstalling the reusable agent skill library I use.",
     status: "ready",
     updatedAt: "2026-06-20",
     tags: ["AI setup", "Antigravity", "Codex", "Claude", "Gemini", "Skills"],
@@ -2753,27 +2753,27 @@ export const studioNotes: StudioNote[] = [
     id: "open-design",
     folderId: "design-tools",
     title: "Open Design",
-    subtitle: "Design workspace and MCP helper for agent-driven UI artifacts.",
+    subtitle: "A local-first design workspace with MCP support for AI-assisted UI work.",
     status: "ready",
     updatedAt: "2026-06-20",
     tags: ["Design", "MCP", "Codex", "Claude", "Gemini", "Antigravity"],
     summary:
-      "Open Design can support this Studio direction as a design reference and future MCP integration. I do not have a callable Open Design tool in this session, but the project itself is worth keeping in the setup notes.",
+      "Open Design is kept here as a design reference and a possible MCP integration for UI work. Its current setup commands and supported tools should be checked in the project documentation before installation.",
     sections: [
       {
         heading: "What it is",
         body:
-          "Open Design describes itself as a local-first, open-source Claude Design alternative. It focuses on agent-native design artifacts: prototypes, dashboards, decks, images, videos, HyperFrames, design systems, plugins, and exportable HTML/PDF/PPTX/MP4 outputs."
+          "The project describes itself as a local-first, open-source workspace for creating design artifacts with AI agents. I keep the note focused on the parts relevant to this Studio: interface prototypes, design systems, and exportable review material."
       },
       {
-        heading: "Why it belongs in this setup",
+        heading: "Why I keep it here",
         body:
-          "It matches the direction of this route: a Studio surface where agents can help create or polish interface artifacts. It also supports mainstream coding agents through an MCP install command."
+          "It may be useful when an agent needs to create or refine an interface artifact without moving the work into a separate design process. The MCP path also makes it relevant to the agent setup notes."
       },
       {
         heading: "How to use it later",
         body:
-          "On a new machine, install Open Design first, then wire MCP into the agent I want to use. For this repo, Codex and Antigravity are the first targets; Claude and Gemini are next."
+          "On a new machine, first check the current project documentation, then install the app and connect MCP only to the agent that needs it. Start with one integration and verify it before adding more."
       }
     ],
     commands: [
@@ -2915,7 +2915,7 @@ export const studioNotes: StudioNote[] = [
     updatedAt: "2026-06-20",
     tags: ["AI learning", "Multi-agent", "Workflow"],
     summary:
-      "Future note for patterns where multiple agents help plan, code, review, test, or research without turning the workflow into noise.",
+      "Planned research into when several agents improve planning, implementation, review, testing, or research—and when they only add coordination cost.",
     sections: [
       {
         heading: "Question to answer",
@@ -2936,12 +2936,12 @@ export const studioNotes: StudioNote[] = [
     id: "openhands",
     folderId: "ai-learning",
     title: "OpenHands",
-    subtitle: "Place to capture setup notes and real use cases later.",
+    subtitle: "Planned research on setup, sandboxing, and longer coding tasks.",
     status: "next",
     updatedAt: "2026-06-20",
     tags: ["AI learning", "OpenHands"],
     summary:
-      "A placeholder note for OpenHands. The useful future version should include install commands, project fit, and where it overlaps with Codex or Claude.",
+      "A planned evaluation of OpenHands covering installation, repository fit, sandbox boundaries, longer tasks, and overlap with Codex or Claude.",
     sections: [
       {
         heading: "Question to answer",
@@ -2954,12 +2954,12 @@ export const studioNotes: StudioNote[] = [
     id: "crewai",
     folderId: "ai-learning",
     title: "CrewAI",
-    subtitle: "Place to capture crew patterns after practical experiments.",
+    subtitle: "Planned research on explicit agent roles, memory, and handoffs.",
     status: "next",
     updatedAt: "2026-06-20",
     tags: ["AI learning", "CrewAI", "Agents"],
     summary:
-      "A placeholder note for CrewAI. The future note should focus on when a crew abstraction helps more than a plain script or a single agent.",
+      "A planned evaluation of CrewAI focused on when structured roles, memory, and handoffs help more than a plain script or a single agent.",
     sections: [
       {
         heading: "Question to answer",
@@ -2974,33 +2974,33 @@ export const studioFlowGroups: StudioFlowGroup[] = [
   {
     id: "architecture",
     title: "Architecture & System Design",
-    subtitle: "Decide before drawing boxes.",
+    subtitle: "Clarify the problem before drawing the system.",
     description:
-      "Flows for system design interviews, architecture reviews, and trade-off decisions where the hard part is choosing boundaries.",
+      "Guides for system design and architecture decisions, with an emphasis on boundaries, trade-offs, and the cost of change.",
     flowIds: ["system-design", "architecture-decision"]
   },
   {
     id: "production",
     title: "Production & Delivery",
-    subtitle: "Move carefully when real users are involved.",
+    subtitle: "Protect users while change moves forward.",
     description:
-      "Flows for incidents, release readiness, rollout gates, and operational handoffs that protect reliability without slowing every change.",
+      "Guides for incident response, release readiness, rollout decisions, and operational handoffs with clear ownership.",
     flowIds: ["incident-response", "release-readiness"]
   },
   {
     id: "ai-and-career",
-    title: "AI Delivery & Career Proof",
-    subtitle: "Turn work into leverage.",
+    title: "AI Delivery & Engineering Portfolio",
+    subtitle: "Make useful work easier to review and explain.",
     description:
-      "Flows for AI-assisted delivery and portfolio stories that make engineering judgment visible without turning the work into marketing copy.",
+      "Guides for using AI responsibly in delivery and documenting engineering work without turning it into marketing copy.",
     flowIds: ["ai-delivery", "portfolio-story"]
   },
   {
     id: "react-flow-library",
-    title: "React Flow",
-    subtitle: "Switch between example shapes before choosing a diagram.",
+    title: "React Flow Patterns",
+    subtitle: "Compare diagram patterns before choosing a structure.",
     description:
-      "A React Flow showcase for example families: built-in nodes, custom architecture shapes, grouping, layout, validation, annotation, edge styles, labels, markers, minimap, controls, and background.",
+      "An interactive library of React Flow patterns for nodes, edges, groups, layouts, annotations, and architecture diagrams.",
     flowIds: ["react-flow-architecture-demo", "react-flow-system-blueprint"]
   }
 ];
@@ -3009,16 +3009,16 @@ export const studioFlows: StudioFlow[] = [
   {
     id: "system-design",
     groupId: "architecture",
-    title: "System Design Interview Flow",
+    title: "System Design Flow",
     summary:
-      "A calm path from vague prompt to clear architecture, with capacity, data, API, failure modes, and trade-offs handled in order.",
-    seoTitle: "System Design Interview Flow for Senior Software Engineers",
+      "A practical path from an open-ended problem to clear boundaries, interfaces, data choices, failure handling, and trade-offs.",
+    seoTitle: "Practical System Design Flow for Software Engineers",
     seoDescription:
-      "A practical system design flow for framing requirements, choosing boundaries, modeling data, handling scale, and explaining trade-offs clearly.",
+      "A system design flow for framing requirements, choosing boundaries, modeling data, handling scale, and explaining trade-offs clearly.",
     useWhen:
-      "Use this when a prompt starts broad, such as designing a notification system, a booking platform, a feed, or an internal workflow tool.",
+      "Use when a design request starts broad, such as a notification system, booking platform, feed, or internal workflow tool.",
     outcome:
-      "A shareable design narrative that shows senior judgment: what matters, what can wait, where the risks are, and how the system evolves.",
+      "A shareable design narrative that makes priorities, deferred decisions, risks, and the evolution path explicit.",
     officeExample:
       "A product manager asks for a new partner onboarding flow. Instead of jumping to services and queues, this flow starts with who changes what data, which steps need approval, and where rollback matters.",
     tags: ["System Design", "Architecture", "Trade-offs", "Interview"],
@@ -3092,14 +3092,14 @@ export const studioFlows: StudioFlow[] = [
     groupId: "architecture",
     title: "Architecture Decision Flow",
     summary:
-      "A lightweight RFC/ADR path for turning messy options into one clear recommendation, including trade-offs and rollback.",
-    seoTitle: "Architecture Decision Flow with RFC and ADR Thinking",
+      "A lightweight RFC/ADR process for comparing practical options and recording a clear recommendation, trade-offs, and rollback path.",
+    seoTitle: "Architecture Decision Flow for RFCs and ADRs",
     seoDescription:
-      "A practical architecture decision flow for comparing options, scoring trade-offs, documenting risks, and aligning teams before implementation.",
+      "A practical process for comparing architecture options, documenting trade-offs and risks, and aligning a team before implementation.",
     useWhen:
-      "Use this before a feature crosses module boundaries, changes data ownership, adds a new integration, or introduces a hard-to-reverse dependency.",
+      "Use before a feature crosses module boundaries, changes data ownership, adds an integration, or introduces a hard-to-reverse dependency.",
     outcome:
-      "A decision note that helps teammates understand not only what was chosen, but why the rejected paths were rejected.",
+      "A concise decision record that explains what was chosen, why it fits, and why the practical alternatives were not selected.",
     officeExample:
       "A team debates whether to add a queue for partner sync. This flow separates the real need, failure behavior, team support cost, and the moment where async processing actually earns its complexity.",
     tags: ["RFC", "ADR", "Architecture Review", "Decision Matrix"],
@@ -3164,14 +3164,14 @@ export const studioFlows: StudioFlow[] = [
     groupId: "production",
     title: "Production Incident Flow",
     summary:
-      "A practical incident path from first signal to rollback, communication, root cause, and follow-up work.",
+      "A practical sequence from the first signal through mitigation, communication, recovery, root cause, and follow-up work.",
     seoTitle: "Production Incident Response Flow for Engineering Teams",
     seoDescription:
       "A production incident flow for triage, blast-radius control, rollback, communication, root cause analysis, and follow-up tracking.",
     useWhen:
-      "Use this when alerts, customer reports, deploy regressions, or partner failures create pressure and the team needs calm sequencing.",
+      "Use when alerts, customer reports, deployment regressions, or partner failures require a clear order of operations.",
     outcome:
-      "A controlled incident response where decisions are visible, users are protected, and the postmortem produces real prevention work.",
+      "A controlled incident response with visible decisions, protected users, and specific prevention work with owners.",
     officeExample:
       "After a release, checkout latency climbs and support sees duplicate complaints. This flow keeps the team from guessing by separating signal, mitigation, rollback, and root-cause work.",
     tags: ["Incident", "SRE", "Rollback", "Postmortem"],
@@ -3236,14 +3236,14 @@ export const studioFlows: StudioFlow[] = [
     groupId: "production",
     title: "Release Readiness Flow",
     summary:
-      "A rollout gate for checking scope, tests, observability, migration safety, communication, and rollback before release.",
-    seoTitle: "Release Readiness Flow for Safe Software Rollouts",
+      "A pre-release check for scope, tests, observability, migration safety, communication, rollout, and rollback.",
+    seoTitle: "Release Readiness Checklist and Rollout Flow",
     seoDescription:
-      "A release readiness flow for validating tests, analytics, migration safety, observability, communication, rollout gates, and rollback plans.",
+      "A release readiness flow for checking tests, analytics, migration safety, observability, communication, rollout decisions, and rollback plans.",
     useWhen:
-      "Use this before a feature reaches production, especially when it touches checkout, authentication, data migration, integrations, or user-facing routes.",
+      "Use before a change reaches production, especially when it touches checkout, authentication, data migration, integrations, or public routes.",
     outcome:
-      "A release that can be explained, monitored, paused, and rolled back without heroic cleanup after the fact.",
+      "A release that can be explained, monitored, paused, and rolled back with clear ownership.",
     officeExample:
       "A team is shipping a new dashboard filter with analytics and SEO changes. This flow makes sure behavior, tracking, empty states, and rollback are covered before the deploy button becomes tempting.",
     tags: ["Release", "Rollout", "QA", "Observability"],
@@ -3308,14 +3308,14 @@ export const studioFlows: StudioFlow[] = [
     groupId: "ai-and-career",
     title: "AI-Assisted Delivery Flow",
     summary:
-      "A controlled way to use AI agents for implementation without losing scope, privacy, tests, or human judgment.",
+      "A bounded process for using AI agents in implementation without losing scope, privacy, verification, or human judgment.",
     seoTitle: "AI-Assisted Software Delivery Flow with Human Review",
     seoDescription:
       "An AI-assisted delivery flow for scoping tasks, packaging context, applying changes, verifying behavior, and handing off review-ready work.",
     useWhen:
-      "Use this when an AI agent helps with coding, review, research, docs, refactors, or test generation inside a real codebase.",
+      "Use when an AI agent assists with coding, review, research, documentation, refactoring, or test generation in a real codebase.",
     outcome:
-      "A review-ready change where AI helped with speed and coverage, while the engineer still owns scope, correctness, and release risk.",
+      "A review-ready change in which AI improves speed or coverage while the engineer retains ownership of scope, correctness, and release risk.",
     officeExample:
       "A teammate asks for a Studio feature. This flow turns the request into bounded context, tells the agent what not to touch, verifies analytics and SEO, then reviews the diff before commit.",
     tags: ["AI Delivery", "Agents", "Code Review", "Verification"],
@@ -3380,12 +3380,12 @@ export const studioFlows: StudioFlow[] = [
     groupId: "ai-and-career",
     title: "Portfolio Story Flow",
     summary:
-      "A way to turn real engineering work into a clear CV, blog, or interview story without over-polishing the truth.",
-    seoTitle: "Engineering Portfolio Story Flow for CV and Interview Proof",
+      "A practical way to turn real engineering work into a clear CV, blog, interview, or portfolio story without overstating it.",
+    seoTitle: "Engineering Portfolio Story Flow for CVs and Interviews",
     seoDescription:
-      "A portfolio story flow for turning engineering work into clear context, actions, trade-offs, impact, evidence, and next-step learning.",
+      "A portfolio story flow for documenting engineering context, actions, trade-offs, impact, evidence, and next-step learning.",
     useWhen:
-      "Use this after a project, incident, migration, release, leadership moment, or hard trade-off that should become career evidence.",
+      "Use after a project, incident, migration, release, leadership moment, or difficult trade-off that is worth documenting.",
     outcome:
       "A grounded story that can become a CV bullet, blog post, interview answer, or portfolio case study.",
     officeExample:
@@ -3450,16 +3450,16 @@ export const studioFlows: StudioFlow[] = [
   {
     id: "react-flow-architecture-demo",
     groupId: "react-flow-library",
-    title: "Example",
+    title: "React Flow Pattern Library",
     summary:
-      "A library-style canvas showing what @xyflow/react can express across overview, interaction, grouping, layout, styling, whiteboard, and software architecture examples.",
-    seoTitle: "React Flow Example for Software Diagrams",
+      "An interactive library of React Flow patterns for nodes, edges, grouping, layouts, annotations, and software architecture diagrams.",
+    seoTitle: "React Flow Pattern Library for Software Diagrams",
     seoDescription:
-      "A React Flow studio demo with built-in node styles, custom architecture shapes, grouping, layout, validation, whiteboard annotation, edge types, labels, markers, minimap, controls, and background.",
+      "A React Flow pattern library with built-in nodes, custom architecture shapes, grouping, layouts, validation, annotations, edge styles, labels, markers, a minimap, and canvas controls.",
     useWhen:
-      "Use this when choosing how to model a system architecture, service map, platform topology, event flow, deployment boundary, or graph-editor interaction with React Flow.",
+      "Use when choosing how to model a system architecture, service map, platform topology, event flow, deployment boundary, or graph-editor interaction with React Flow.",
     outcome:
-      "A visual catalog of React Flow node, edge, grouping, layout, interaction, whiteboard, and architecture patterns without turning the page into a product use-case map.",
+      "A visual reference for choosing node, edge, grouping, layout, interaction, annotation, and architecture patterns.",
     officeExample:
       "A team wants to choose how a technical diagram should look before drawing the real system. This gallery lets them compare overview, subflow, layout, validation, whiteboard, event-driven, topology, and data-lineage views in one React Flow canvas.",
     tags: ["React Flow", "XYFlow", "Architecture Diagram", "Node Shapes", "Edge Types"],
@@ -3534,14 +3534,14 @@ export const studioFlows: StudioFlow[] = [
     groupId: "react-flow-library",
     title: "System Design Blueprint",
     summary:
-      "A poster-scale React Flow system design map that shows DNS, edge policy, load balancing, backend services, cache, data stores, media queues, workers, and fan-out services.",
-    seoTitle: "React Flow System Design Blueprint Example",
+      "A detailed React Flow map of DNS, edge policy, load balancing, backend services, cache, data stores, media queues, workers, and downstream services.",
+    seoTitle: "Interactive React Flow Blueprint for System Design",
     seoDescription:
-      "A large React Flow system design blueprint with grouped architecture zones, custom nodes, labeled edges, animated async paths, minimap, controls, and focused diagram views.",
+      "An interactive React Flow system design blueprint with grouped architecture zones, custom nodes, labeled edges, asynchronous paths, a minimap, controls, and focused views.",
     useWhen:
-      "Use this when a diagram needs to prove React Flow can handle dense system design posters, not only small workflow charts.",
+      "Use when an architecture review needs a dense, interactive system map rather than a static image or a small workflow chart.",
     outcome:
-      "A powerful architecture canvas that stays inspectable: overview for the full story, focused views for DNS, runtime, storage, media processing, and fan-out.",
+      "An inspectable architecture map with an overview for the full system and focused views for DNS, runtime, storage, media processing, and fan-out.",
     officeExample:
       "A team wants a poster-style architecture map for a review. This example keeps the diagram interactive, searchable by zone, and zoomable instead of freezing it as a static image.",
     tags: ["React Flow", "System Design", "Blueprint", "Distributed Systems", "Media Pipeline"],

--- a/src/app/[locale]/studio/studio.localized-content.ts
+++ b/src/app/[locale]/studio/studio.localized-content.ts
@@ -70,789 +70,789 @@ type LocalizedFlowCopy = {
 
 const vietnameseSkillCopies: Record<string, LocalizedSkillCopy> = {
   "code-review": {
-    title: "Code Review Expert",
-    summary: "Review thay đổi theo correctness trước, rồi security/privacy, maintainability, test coverage và operational risk.",
-    tags: ["Code Review", "Correctness", "Security", "Test Strategy"],
+    title: "Rà soát mã nguồn",
+    summary: "Rà soát thay đổi theo đúng thứ tự: tính đúng đắn trước, sau đó đến bảo mật và quyền riêng tư, khả năng bảo trì, mức độ kiểm thử và rủi ro vận hành.",
+    tags: ["Rà soát mã nguồn", "Tính đúng đắn", "Bảo mật", "Chiến lược kiểm thử"],
     useWhen: [
-      "Khi review pull request, local diff, generated code, refactor, migration hoặc hotfix production.",
-      "Khi cần tìm blocker thật sự trước khi bàn về code style.",
-      "Khi thay đổi chạm tới auth model, data model, analytics event, SEO path, feature flag hoặc rollout plan."
+      "Khi rà soát pull request, phần thay đổi trên máy, mã do công cụ tạo, đợt refactor, migration hoặc bản sửa nóng trên production.",
+      "Khi cần tìm lỗi có thể làm hỏng hành vi trước khi bàn đến cách trình bày mã nguồn.",
+      "Khi thay đổi tác động đến mô hình xác thực, mô hình dữ liệu, sự kiện analytics, đường dẫn SEO, feature flag hoặc kế hoạch rollout."
     ],
     process: [
-      "Xác nhận intent: so diff với requirement, acceptance criteria và behavior người dùng.",
-      "Chứng minh correctness: control flow, state transitions, boundary cases, nullability, concurrency, idempotency và failure paths.",
-      "Threat model thay đổi: OWASP Top 10, injection, authz/authn bypass, IDOR, CSRF/XSS, secrets, PII và tenant isolation.",
-      "Đánh giá kiến trúc: coupling, leaky abstraction, cyclic dependency, API compatibility, schema drift và maintenance cost.",
-      "Review data structure: array, map, set, queue, tree, index, cache và DTO phải hợp access pattern, không vô tình biến lookup/grouping thành O(n) ở đường nóng.",
-      "Review design pattern: chỉ dùng pattern quen thuộc khi nó giảm complexity thật, ví dụ Strategy cho rule thay thế được, Factory cho creation policy, Adapter cho external API, Repository cho persistence boundary, State Machine cho workflow nhiều bước.",
-      "Review clean architecture: domain rule không phụ thuộc UI, framework, transport, ORM, analytics hay vendor SDK; dependency nên đi vào trong thay vì kéo business logic ra ngoài edge.",
-      "Review boundary: application service giữ orchestration, domain service giữ business rule, repository/gateway giữ persistence và integration, utility chỉ giữ transform/validator/formatter/parser thuần.",
-      "Kiểm tra vận hành: N+1 query, algorithmic blowup, memory pressure, hydration regression, observability gap và rollback risk.",
-      "Đối chiếu verification: unit, integration, E2E, contract, accessibility và regression tests có phủ đúng behavior mới không."
+      "Xác nhận mục đích: đối chiếu phần thay đổi với yêu cầu, tiêu chí nghiệm thu và hành vi người dùng.",
+      "Kiểm tra tính đúng đắn qua luồng điều khiển, chuyển đổi trạng thái, giá trị biên, giá trị rỗng, xử lý đồng thời, tính idempotent và các nhánh lỗi.",
+      "Lập mô hình đe dọa cho thay đổi: OWASP Top 10, injection, vượt qua xác thực hoặc phân quyền, IDOR, CSRF/XSS, bí mật hệ thống, PII và cách ly tenant.",
+      "Đánh giá kiến trúc qua mức độ phụ thuộc, abstraction làm rò rỉ chi tiết cài đặt, phụ thuộc vòng, khả năng tương thích API, sai lệch schema và chi phí bảo trì.",
+      "Kiểm tra cấu trúc dữ liệu: array, map, set, queue, tree, index, cache và DTO phải hợp với cách truy cập, không vô tình biến thao tác tra cứu hoặc gom nhóm trong luồng xử lý chính thành O(n).",
+      "Chỉ dùng design pattern khi nó thực sự làm hệ thống dễ hiểu hơn, chẳng hạn Strategy cho quy tắc có thể thay thế, Factory cho chính sách khởi tạo, Adapter cho API bên ngoài, Repository cho ranh giới lưu trữ và State Machine cho quy trình nhiều bước.",
+      "Kiểm tra clean architecture: quy tắc nghiệp vụ không phụ thuộc UI, framework, giao thức truyền tải, ORM, analytics hay SDK của nhà cung cấp; chiều phụ thuộc phải hướng vào lõi.",
+      "Kiểm tra ranh giới trách nhiệm: application service điều phối, domain service giữ quy tắc nghiệp vụ, repository hoặc gateway phụ trách lưu trữ và tích hợp, utility chỉ chứa phép biến đổi, kiểm tra hoặc định dạng thuần.",
+      "Kiểm tra khả năng vận hành: truy vấn N+1, độ phức tạp tăng đột biến, áp lực bộ nhớ, lỗi hydration, khoảng trống observability và rủi ro rollback.",
+      "Đối chiếu kiểm thử unit, integration, E2E, contract, khả năng tiếp cận và regression với đúng hành vi vừa thay đổi."
     ],
     output: [
-      "Findings xếp theo severity: Blocker, Major, Minor, Nit.",
-      "Mỗi finding có file/line, evidence, impact và smallest practical fix.",
-      "Architecture/code-shape note khi change thêm service, repository, helper dùng chung, design pattern hoặc data structure mới.",
-      "Open questions chỉ khi ảnh hưởng tới correctness, security, rollout hoặc product behavior.",
-      "Residual risk và verification gaps còn lại."
+      "Các phát hiện được xếp theo mức độ: Blocker, Major, Minor, Nit.",
+      "Mỗi phát hiện nêu rõ file và dòng, bằng chứng, tác động cùng cách sửa nhỏ nhất có thể áp dụng.",
+      "Ghi chú về kiến trúc và cách tổ chức mã nguồn khi thay đổi thêm service, repository, helper dùng chung, design pattern hoặc cấu trúc dữ liệu mới.",
+      "Chỉ đặt câu hỏi còn mở khi câu trả lời ảnh hưởng đến tính đúng đắn, bảo mật, rollout hoặc hành vi sản phẩm.",
+      "Nêu rõ rủi ro còn lại và phần chưa được kiểm chứng."
     ],
     guardrails: [
-      "KHÔNG tiêu review budget vào preference cá nhân nếu behavior, convention và tests đã ổn.",
-      "KHÔNG approve business logic mới nếu thiếu meaningful verification.",
-      "KHÔNG gom business logic stateful vào file utils chỉ để nhìn gọn; nếu có ownership/domain rule thì tách service hoặc module rõ.",
-      "KHÔNG đòi rewrite toàn bộ design nếu current design chưa tạo rủi ro đo được."
+      "Không mất thời gian vào sở thích cá nhân khi hành vi, quy ước và kiểm thử đều ổn.",
+      "Không chấp thuận quy tắc nghiệp vụ mới khi chưa có cách kiểm chứng đủ sức thuyết phục.",
+      "Không gom logic nghiệp vụ có trạng thái vào file utility chỉ để mã trông gọn hơn; nếu có quyền sở hữu hoặc quy tắc miền thì phải tách thành service hay module rõ ràng.",
+      "Không yêu cầu viết lại toàn bộ thiết kế khi cách làm hiện tại chưa tạo ra rủi ro có thể chỉ ra hoặc đo được."
     ]
   },
   "frontend-architecture": {
     title: "Kiến trúc frontend",
-    summary: "Thiết kế frontend quanh route boundaries, state ownership, accessibility, telemetry và Core Web Vitals.",
-    tags: ["Frontend", "React", "Web Vitals", "Accessibility"],
+    summary: "Thiết kế frontend với ranh giới đường dẫn rõ ràng, biết trạng thái thuộc về đâu, đồng thời bảo đảm khả năng tiếp cận, đo lường và Core Web Vitals.",
+    tags: ["Frontend", "React", "Web Vitals", "Khả năng tiếp cận"],
     useWhen: [
-      "Khi thiết kế route, dashboard, component system, form, filter, search UI hoặc frontend refactor.",
-      "Khi UI cần quản lý URL state, server state, preferences, form state hoặc client-only interactions.",
-      "Khi SEO, locale behavior, analytics, accessibility và mobile behavior là acceptance criteria bắt buộc."
+      "Khi thiết kế đường dẫn, dashboard, hệ thống component, biểu mẫu, bộ lọc, giao diện tìm kiếm hoặc refactor frontend.",
+      "Khi UI cần quản lý URL state, server state, user preferences, form state hoặc browser-only interaction.",
+      "Khi SEO, hành vi theo ngôn ngữ, analytics, khả năng tiếp cận và trải nghiệm trên thiết bị di động là tiêu chí nghiệm thu bắt buộc."
     ],
     process: [
-      "Định nghĩa route/layout boundaries cùng loading, empty, error, partial-data, permission và not-found states.",
-      "Chọn rendering mode có chủ đích: SSR, SSG, ISR, CSR, streaming hoặc client island theo freshness, SEO, privacy và personalization.",
-      "Phân loại state: server state, URL state, durable preferences, global app state, form state và ephemeral component state.",
-      "Thiết kế component ownership: visual shell nhỏ, domain logic tách riêng, tránh prop drilling qua lớp không liên quan.",
-      "Bảo vệ interaction quality: keyboard access, focus management, ARIA semantics, reduced motion, contrast và responsive constraints.",
-      "Định nghĩa performance/analytics plan: LCP, INP, CLS, bundle budget, event names, PageTracker và funnel events."
+      "Xác định ranh giới giữa đường dẫn và bố cục, cùng các trạng thái đang tải, trống, lỗi, thiếu một phần dữ liệu, thiếu quyền và không tìm thấy.",
+      "Chọn cách render có chủ đích: SSR, SSG, ISR, CSR, streaming hoặc client island dựa trên độ mới của dữ liệu, SEO, quyền riêng tư và nhu cầu cá nhân hóa.",
+      "Phân loại trạng thái: dữ liệu từ máy chủ, trạng thái trên URL, thiết lập cần lưu lâu dài, trạng thái toàn ứng dụng, trạng thái biểu mẫu và trạng thái tạm thời trong component.",
+      "Phân chia trách nhiệm của component: lớp giao diện ngoài nên nhỏ, logic miền được tách riêng và dữ liệu không bị truyền xuyên qua các lớp không liên quan.",
+      "Bảo vệ chất lượng tương tác: dùng được bằng bàn phím, quản lý focus, ngữ nghĩa ARIA, giảm chuyển động, độ tương phản và khả năng thích ứng màn hình.",
+      "Lập kế hoạch hiệu năng và analytics: LCP, INP, CLS, giới hạn bundle, tên sự kiện, PageTracker và các sự kiện trong funnel."
     ],
     output: [
-      "Route map và component map với ownership boundaries.",
-      "State/data-fetching plan cùng cache invalidation rules.",
-      "UX state matrix cho loading, empty, error, disabled, success và responsive behavior.",
-      "Checklist performance, accessibility và analytics.",
-      "Implementation slices theo thứ tự rủi ro."
+      "Sơ đồ đường dẫn và component, kèm ranh giới trách nhiệm.",
+      "Kế hoạch quản lý state, data fetching và cache invalidation.",
+      "Ma trận trạng thái UX cho lúc đang tải, trống, lỗi, bị vô hiệu hóa, thành công và trên các kích thước màn hình.",
+      "Danh sách kiểm tra hiệu năng, khả năng tiếp cận và analytics.",
+      "Các phần triển khai nhỏ được sắp theo mức độ rủi ro."
     ],
     guardrails: [
-      "KHÔNG đưa local interaction vào global state nếu không có lý do kiến trúc.",
-      "KHÔNG ship visual surface nếu thiếu keyboard, screen reader và mobile behavior.",
-      "KHÔNG đổi analytics hoặc locale behavior hiện có nếu thiếu migration plan rõ ràng."
+      "Không đưa tương tác cục bộ vào trạng thái toàn ứng dụng nếu không có lý do kiến trúc rõ ràng.",
+      "Không phát hành giao diện khi chưa dùng được bằng bàn phím, trình đọc màn hình và thiết bị di động.",
+      "Không đổi analytics hoặc hành vi theo ngôn ngữ hiện có khi chưa có kế hoạch chuyển đổi rõ ràng."
     ]
   },
   "backend-architecture": {
-    title: "Kiến trúc Backend",
-    summary: "Thiết kế backend với domain ownership rõ, contracts tường minh, data flow bền vững và failure modes vận hành được.",
-    tags: ["Backend", "API Design", "Distributed Systems", "Reliability"],
+    title: "Kiến trúc backend",
+    summary: "Thiết kế backend với quyền sở hữu miền rõ ràng, hợp đồng tường minh, dữ liệu bền vững và phương án xử lý được các tình huống lỗi khi vận hành.",
+    tags: ["Backend", "Thiết kế API", "Hệ thống phân tán", "Độ tin cậy"],
     useWhen: [
-      "Khi thiết kế APIs, services, background jobs, webhooks, event streams, data migrations hoặc integrations.",
+      "Khi thiết kế API, service, tác vụ nền, webhook, luồng sự kiện, migration dữ liệu hoặc tích hợp.",
       "Khi thay đổi kéo theo database migration, message queue, rate limiting, external dependency hoặc auth/RBAC.",
-      "Khi hệ thống cần latency SLO, durability, consistency model, safe rollout và rollback rõ ràng."
+      "Khi hệ thống cần SLO về độ trễ, độ bền và tính nhất quán của dữ liệu, cùng kế hoạch rollout và rollback an toàn."
     ],
     process: [
-      "Model domain: bounded contexts, aggregates, invariants, ownership của read/write và lifecycle events.",
-      "Chọn topology: modular monolith, service extraction, serverless, queue-backed worker hoặc event-driven flow theo operational need.",
-      "Contract-first: OpenAPI, gRPC, AsyncAPI, event schemas, idempotency keys, pagination, error taxonomy và versioning.",
-      "Thiết kế persistence: schema, indexes, migration plan, retention, encryption, backup/restore và consistency model.",
-      "Thiết kế resilience: timeouts, retry budgets, backoff with jitter, DLQ, circuit breakers, bulkheads, rate limiting và graceful degradation.",
-      "Định nghĩa operability: structured logs, traces, metrics, alerts, runbooks, canary/feature flags và rollback triggers."
+      "Mô hình hóa miền: bounded context, aggregate, invariant, quyền đọc và ghi cùng các sự kiện trong vòng đời.",
+      "Chọn cấu trúc triển khai phù hợp nhu cầu vận hành: modular monolith, tách service, serverless, worker dùng queue hoặc luồng hướng sự kiện.",
+      "Thiết kế contract-first: OpenAPI, gRPC, AsyncAPI, event schema, idempotency key, pagination, error taxonomy và versioning.",
+      "Thiết kế lớp lưu trữ: schema, index, kế hoạch migration, thời hạn giữ dữ liệu, mã hóa, sao lưu, khôi phục và mức nhất quán cần bảo đảm.",
+      "Thiết kế resilience: timeout, retry budget, exponential backoff có jitter, DLQ, circuit breaker, bulkhead, rate limiting và graceful degradation.",
+      "Xác định cách vận hành: log có cấu trúc, trace, metric, cảnh báo, runbook, canary hoặc feature flag và điều kiện kích hoạt rollback."
     ],
     output: [
-      "Domain và responsibility map.",
-      "API/event contract kèm failure modes.",
-      "Data model và migration strategy.",
-      "Resilience, security và observability plan.",
-      "Rollout, rollback và disaster recovery plan."
+      "Sơ đồ miền và trách nhiệm.",
+      "Hợp đồng API hoặc sự kiện kèm các tình huống lỗi.",
+      "Mô hình dữ liệu và chiến lược migration.",
+      "Kế hoạch chống lỗi, bảo mật và observability.",
+      "Kế hoạch rollout, rollback và khôi phục sau thảm họa."
     ],
     guardrails: [
       "Ưu tiên topology đơn giản nhất vẫn giữ được invariant và đạt SLO.",
-      "KHÔNG introduce async processing nếu thiếu idempotency, observability và replay semantics.",
-      "KHÔNG gọi design là production-ready nếu thiếu rollback và data recovery."
+      "Không thêm xử lý bất đồng bộ khi chưa có idempotency, observability và quy tắc phát lại.",
+      "Không gọi thiết kế là sẵn sàng cho production khi chưa có rollback và khôi phục dữ liệu."
     ]
   },
   "blog-content-writer": {
-    title: "Viết blog content",
-    summary: "Viết technical content có thesis rõ, bằng chứng vững, semantic SEO tự nhiên và giọng chuyên gia điềm tĩnh.",
-    tags: ["Technical Writing", "SEO", "Editorial Strategy"],
+    title: "Viết nội dung kỹ thuật",
+    summary: "Viết bài kỹ thuật có luận điểm rõ, bằng chứng vững, SEO tự nhiên và giọng điệu điềm tĩnh của người hiểu việc.",
+    tags: ["Viết kỹ thuật", "SEO", "Chiến lược biên tập"],
     useWhen: [
-      "Khi viết engineering articles, technical explainers, architecture postmortems, product notes hoặc public documentation.",
-      "Khi cần biến ý tưởng thô thành bài viết có thesis, flow logic, ví dụ thật và reader takeaway rõ.",
-      "Khi nội dung cần giữ tone bình tĩnh, chân thực, analytical, không hype và không sales."
+      "Khi viết bài về kỹ thuật, bài giải thích khái niệm, postmortem kiến trúc, ghi chú sản phẩm hoặc tài liệu công khai.",
+      "Khi cần biến một ý tưởng thô thành bài viết có luận điểm, mạch lập luận, ví dụ thật và điều người đọc có thể mang theo.",
+      "Khi nội dung cần giữ giọng bình tĩnh, chân thực, có phân tích, không cường điệu và không mang màu sắc bán hàng."
     ],
     process: [
-      "Chốt thesis: một claim cụ thể bài viết sẽ chứng minh, không chỉ đặt topic rộng.",
-      "Mở từ tình huống cụ thể: code review, outage, trade-off sản phẩm, requirement mơ hồ, dashboard chậm hoặc khoảnh khắc đi làm.",
-      "Xây mental model cho reader: giải thích thuật ngữ, context, trade-offs và constraints trước khi đưa lời khuyên.",
-      "Chứng minh bằng diagrams, workflows, code snippets, benchmarks, standards, source citations hoặc realistic failure modes.",
-      "Tối ưu cấu trúc: H1/H2/H3 rõ, keywords tự nhiên, internal links, meta title, meta description và canonical path.",
-      "Kết bằng takeaway dùng được: mental model, checklist, decision rule hoặc reflection."
+      "Chốt luận điểm: chọn một nhận định cụ thể mà bài viết sẽ làm sáng tỏ, thay vì chỉ nêu một chủ đề rộng.",
+      "Mở từ tình huống cụ thể như một lần rà soát mã nguồn, sự cố, đánh đổi sản phẩm, yêu cầu mơ hồ, dashboard chậm hoặc một khoảnh khắc quen thuộc ở nơi làm việc.",
+      "Giúp người đọc dựng được cách hiểu: giải thích thuật ngữ, ngữ cảnh, đánh đổi và giới hạn trước khi đưa ra lời khuyên.",
+      "Nâng đỡ lập luận bằng sơ đồ, quy trình, đoạn mã, benchmark, tiêu chuẩn, nguồn trích dẫn hoặc tình huống lỗi sát thực tế.",
+      "Sắp xếp cấu trúc rõ ràng với H1/H2/H3, từ khóa tự nhiên, liên kết nội bộ, meta title, meta description và canonical path.",
+      "Khép lại bằng điều có thể áp dụng: một cách nhìn, danh sách kiểm tra, quy tắc ra quyết định hoặc câu hỏi để suy ngẫm."
     ],
     output: [
-      "SEO metadata và slug recommendation.",
-      "Outline có reader intent và search intent.",
-      "Full manuscript đúng format yêu cầu.",
-      "Source notes, diagram ideas và internal-link suggestions.",
-      "Short social summary khi cần."
+      "Metadata SEO và đề xuất slug.",
+      "Dàn ý bám đúng nhu cầu của người đọc và mục đích tìm kiếm.",
+      "Bản thảo hoàn chỉnh theo đúng định dạng yêu cầu.",
+      "Ghi chú nguồn, ý tưởng sơ đồ và gợi ý liên kết nội bộ.",
+      "Bản giới thiệu ngắn dùng trên mạng xã hội khi cần."
     ],
     guardrails: [
-      "KHÔNG keyword-stuff hoặc thổi phồng claim vượt khỏi evidence.",
-      "KHÔNG bịa statistics, citations, benchmarks hoặc technical capabilities.",
-      "PHẢI bảo toàn locale behavior, content schema, SEO paths và analytics surfaces hiện có."
+      "Không nhồi từ khóa hoặc thổi phồng nhận định vượt quá bằng chứng.",
+      "Không bịa số liệu, trích dẫn, benchmark hay khả năng kỹ thuật.",
+      "Phải giữ nguyên hành vi theo ngôn ngữ, schema nội dung, đường dẫn SEO và các điểm đo analytics hiện có."
     ]
   },
   "prompt-writing": {
-    title: "Prompt Engineering Expert",
-    summary: "Thiết kế prompts/system instructions có role rõ, context đóng khung, chống injection và output schema kiểm chứng được.",
-    tags: ["Prompt Engineering", "LLM", "Agents", "Evaluation"],
+    title: "Thiết kế prompt",
+    summary: "Thiết kế prompt và chỉ dẫn hệ thống với vai trò rõ ràng, ngữ cảnh vừa đủ và đúng phạm vi, khả năng chống prompt injection và schema kết quả có thể kiểm chứng.",
+    tags: ["Thiết kế prompt", "LLM", "Agent AI", "Đánh giá"],
     useWhen: [
-      "Khi thiết kế system prompts, task prompts, few-shot examples, agent policies, extraction prompts hoặc output schemas.",
-      "Khi task definition còn mơ hồ về role, goal, context, constraints hoặc acceptance criteria.",
-      "Khi output pipeline cần JSON Schema, markdown sections, diffs hoặc machine-readable fields ổn định."
+      "Khi thiết kế system prompt, prompt cho tác vụ, ví dụ few-shot, chính sách cho agent, prompt trích xuất hoặc schema kết quả.",
+      "Khi định nghĩa tác vụ còn mơ hồ về vai trò, mục tiêu, ngữ cảnh, giới hạn hoặc tiêu chí nghiệm thu.",
+      "Khi chuỗi xử lý cần JSON Schema, các phần Markdown, diff hoặc trường dữ liệu để máy đọc ổn định."
     ],
     process: [
-      "Định nghĩa role/scope: expertise, authority, non-goals và boundaries agent không được vượt.",
-      "Viết task contract: objective, inputs, assumptions, acceptance criteria và failure conditions.",
-      "Tách context: system rules, developer rules, user request, retrieved evidence và untrusted content bằng delimiters rõ.",
-      "Tạo procedure ngắn: checklist vận hành và yêu cầu rationale/evidence ngắn, không đòi private chain-of-thought.",
-      "Đặc tả output schema: JSON Schema, markdown sections, tables, diffs hoặc structured fields kèm examples.",
-      "Test prompt bằng adversarial cases: ambiguity, prompt injection, missing context, malformed input và schema drift."
+      "Xác định vai trò và phạm vi: chuyên môn, quyền hạn, điều không làm và ranh giới agent không được vượt qua.",
+      "Viết hợp đồng cho tác vụ: mục tiêu, đầu vào, giả định, tiêu chí nghiệm thu và điều kiện thất bại.",
+      "Tách rõ quy tắc hệ thống, quy tắc của developer, yêu cầu người dùng, bằng chứng truy xuất và nội dung không đáng tin bằng dấu phân cách dễ nhận biết.",
+      "Đưa ra quy trình ngắn: danh sách bước cần làm và yêu cầu giải thích hoặc bằng chứng ngắn gọn, không đòi private chain-of-thought.",
+      "Đặc tả schema kết quả bằng JSON Schema, các phần Markdown, bảng, diff hoặc trường có cấu trúc, kèm ví dụ.",
+      "Thử prompt với các trường hợp đối nghịch: yêu cầu mơ hồ, prompt injection, thiếu ngữ cảnh, đầu vào sai định dạng và schema bị lệch."
     ],
     output: [
-      "Production prompt hoặc prompt pack.",
-      "Variable map và input sanitation rules.",
-      "Output schema kèm valid/invalid examples.",
-      "Evaluation checklist với pass/fail criteria.",
-      "Compact version cho ad-hoc usage."
+      "Prompt dùng cho production hoặc bộ prompt hoàn chỉnh.",
+      "Danh sách biến và quy tắc làm sạch đầu vào.",
+      "Schema kết quả kèm ví dụ hợp lệ và không hợp lệ.",
+      "Danh sách đánh giá với tiêu chí đạt hoặc không đạt.",
+      "Bản rút gọn cho nhu cầu dùng nhanh."
     ],
     guardrails: [
-      "KHÔNG yêu cầu private chain-of-thought; chỉ yêu cầu concise rationale, checks hoặc evidence.",
-      "KHÔNG để untrusted content thay đổi role, tools, data access hoặc output policy.",
-      "KHÔNG dùng tính từ mơ hồ như 'tốt hơn' nếu thiếu tiêu chí đo được."
+      "Không yêu cầu private chain-of-thought; chỉ yêu cầu phần giải thích, bước kiểm tra hoặc bằng chứng ngắn gọn.",
+      "Không để nội dung không đáng tin thay đổi vai trò, công cụ, quyền truy cập dữ liệu hoặc chính sách kết quả.",
+      "Không dùng từ mơ hồ như “tốt hơn” khi chưa có tiêu chí đo được."
     ]
   },
   "status-report": {
-    title: "Executive Status & Operations",
-    summary: "Chuyển workstream noise thành executive signal: health, impact, blockers, decisions, owners và path to green.",
-    tags: ["Operations", "Reporting", "OKR", "Escalation"],
+    title: "Báo cáo tiến độ và vận hành",
+    summary: "Gạn bỏ chi tiết vụn để lãnh đạo thấy ngay tình trạng, tác động, điểm nghẽn, quyết định cần chốt, người phụ trách và cách đưa công việc trở lại quỹ đạo.",
+    tags: ["Vận hành", "Báo cáo", "OKR", "Chuyển cấp xử lý"],
     useWhen: [
-      "Khi viết daily standup, weekly status, monthly OKR review, incident update hoặc stakeholder escalation.",
-      "Khi dự án chuyển Yellow/Red và cần quyết định từ cấp trên/cross-functional team.",
-      "Khi cần biến tickets, commits, incidents và metrics thành executive summary có nghĩa."
+      "Khi viết báo cáo standup hằng ngày, tiến độ hằng tuần, tổng kết OKR hằng tháng, cập nhật sự cố hoặc nội dung cần chuyển lên cấp quyết định.",
+      "Khi dự án chuyển sang trạng thái Yellow hoặc Red và cần quyết định từ cấp trên hay nhóm liên chức năng.",
+      "Khi cần biến ticket, commit, sự cố và metric thành bản tóm tắt mà lãnh đạo có thể hành động dựa trên đó."
     ],
     process: [
-      "Dẫn bằng BLUF: health hiện tại, lý do và thay đổi so với update trước.",
-      "Tách facts khỏi interpretation: metrics, shipped artifacts, incidents và unresolved assumptions.",
-      "Định lượng progress: OKR movement, DORA metrics, burn-up/burn-down, SLA/SLO, MTTR, lead time, throughput hoặc adoption.",
-      "Chỉ rõ constraints: blocker, dependency owner, due date, probability, impact và mitigation path.",
-      "Biến decisions thành explicit ask: recommended option, fallback option, deadline và consequence nếu không quyết.",
-      "Kết bằng commitments: owner, date, expected evidence và trigger đổi status."
+      "Mở đầu theo BLUF: tình trạng hiện tại, nguyên nhân và điều đã thay đổi từ lần cập nhật trước.",
+      "Tách sự kiện khỏi diễn giải: metric, phần đã bàn giao, sự cố và giả định chưa được làm rõ.",
+      "Định lượng tiến độ bằng mức tiến triển của OKR, DORA metrics, burn-up hoặc burn-down, SLA/SLO, MTTR, lead time, throughput hay mức độ sử dụng.",
+      "Chỉ rõ giới hạn: điểm nghẽn, người phụ trách phần phụ thuộc, hạn xử lý, xác suất, tác động và hướng giảm nhẹ.",
+      "Biến mỗi quyết định thành một đề nghị cụ thể: phương án khuyến nghị, phương án dự phòng, thời hạn và hệ quả nếu không chốt.",
+      "Kết bằng cam kết rõ ràng: ai phụ trách, ngày hoàn thành, bằng chứng cần có và điều kiện đổi trạng thái."
     ],
     output: [
-      "Status Green/Yellow/Red kèm rationale một câu.",
-      "Progress: shipped value, không phải activity inventory.",
-      "Risks/blockers: severity, owner, next action và date.",
-      "Decisions needed: ask cụ thể và recommendation.",
-      "Next cycle focus và success signal đo được."
+      "Trạng thái Green, Yellow hoặc Red kèm một câu giải thích.",
+      "Tiến độ thể hiện giá trị đã bàn giao, không phải danh sách hoạt động.",
+      "Rủi ro và điểm nghẽn kèm mức độ, người phụ trách, bước tiếp theo và thời hạn.",
+      "Các quyết định cần chốt kèm đề nghị cụ thể và phương án khuyến nghị.",
+      "Trọng tâm của chu kỳ tiếp theo và dấu hiệu thành công có thể đo được."
     ],
     guardrails: [
-      "KHÔNG che bad news bằng progress theater.",
-      "KHÔNG report vanity metrics nếu không gắn với decision hoặc outcome.",
-      "KHÔNG gán ownership mơ hồ kiểu 'team'; phải có role/person chịu trách nhiệm."
+      "Không dùng màn trình diễn tiến độ để che tin xấu.",
+      "Không báo cáo vanity metric khi nó không gắn với quyết định hoặc kết quả.",
+      "Không giao trách nhiệm mơ hồ cho “cả nhóm”; phải nêu vai trò hoặc người chịu trách nhiệm."
     ]
   },
   "doc-spec-tech-spec": {
-    title: "Technical Specification & RFC",
-    summary: "Viết specs decision-ready, nối product intent với architecture, NFRs, threat model, rollout và verification.",
-    tags: ["RFC", "ADR", "Architecture", "NFR"],
+    title: "Đặc tả kỹ thuật và RFC",
+    summary: "Viết đặc tả đủ rõ để ra quyết định, nối mục tiêu sản phẩm với kiến trúc, NFR, mô hình đe dọa, rollout và kiểm chứng.",
+    tags: ["RFC", "ADR", "Kiến trúc", "NFR"],
     useWhen: [
-      "Khi viết RFCs, ADRs, technical specs, migration plans, system designs hoặc implementation handoffs.",
-      "Trước các features có scope lớn, cross-service dependencies, schema migrations hoặc production data impact.",
-      "Khi design có rủi ro security, privacy, performance, SEO, accessibility, analytics hoặc locale behavior."
+      "Khi viết RFC, ADR, đặc tả kỹ thuật, kế hoạch migration, thiết kế hệ thống hoặc tài liệu bàn giao triển khai.",
+      "Trước tính năng có phạm vi lớn, phụ thuộc qua nhiều service, migration schema hoặc tác động đến dữ liệu production.",
+      "Khi thiết kế có rủi ro về bảo mật, quyền riêng tư, hiệu năng, SEO, khả năng tiếp cận, analytics hoặc hành vi theo ngôn ngữ."
     ],
     process: [
-      "Framing vấn đề: tại sao cần làm, ai bị ảnh hưởng, hiện tại vỡ ở đâu và success nghĩa là gì.",
-      "Kiểm soát scope: goals, non-goals, assumptions, constraints và unresolved questions.",
-      "Mô tả proposed design: architecture diagram, data model, APIs/events, dependencies, edge cases và compatibility rules.",
-      "So sánh alternatives: cost, complexity, risk, reversibility và time-to-value của ít nhất hai hướng khả thi.",
-      "Risk model: STRIDE, privacy impact, failure domains, blast radius, data migration risk và operational load.",
-      "Delivery plan: implementation slices, test matrix, observability, rollout, rollback và post-launch validation."
+      "Đặt vấn đề: vì sao cần làm, ai bị ảnh hưởng, cách hiện tại hỏng ở đâu và thế nào được xem là thành công.",
+      "Kiểm soát phạm vi bằng mục tiêu, phần không làm, giả định, giới hạn và câu hỏi chưa có lời giải.",
+      "Mô tả thiết kế đề xuất qua sơ đồ kiến trúc, mô hình dữ liệu, API hoặc sự kiện, phụ thuộc, trường hợp biên và quy tắc tương thích.",
+      "So sánh ít nhất hai hướng khả thi theo chi phí, độ phức tạp, rủi ro, khả năng đảo ngược và thời gian tạo ra giá trị.",
+      "Lập mô hình rủi ro: STRIDE, tác động quyền riêng tư, miền lỗi, phạm vi ảnh hưởng, rủi ro migration dữ liệu và tải vận hành.",
+      "Lập kế hoạch bàn giao: các phần triển khai nhỏ, ma trận kiểm thử, observability, rollout, rollback và kiểm chứng sau phát hành."
     ],
     output: [
-      "RFC hoặc ADR hoàn chỉnh sẵn sàng review.",
-      "Decision table với alternatives và recommendation.",
-      "Implementation plan và ticket breakdown.",
-      "Test, rollout, observability và rollback checklist.",
-      "Sign-off list theo stakeholder function."
+      "RFC hoặc ADR hoàn chỉnh, sẵn sàng để xem xét.",
+      "Bảng quyết định với các phương án và khuyến nghị.",
+      "Kế hoạch triển khai và cách chia ticket.",
+      "Danh sách kiểm tra về kiểm thử, rollout, observability và rollback.",
+      "Danh sách xác nhận theo vai trò liên quan."
     ],
     guardrails: [
-      "KHÔNG biến assumptions thành requirements nếu chưa validate.",
-      "KHÔNG bỏ non-goals; đó là scope control.",
-      "KHÔNG ship spec chạm production data nếu thiếu rollback và recovery details."
+      "Không biến giả định thành yêu cầu khi chưa được kiểm chứng.",
+      "Không bỏ phần không làm; đây là ranh giới bảo vệ phạm vi.",
+      "Không duyệt đặc tả tác động đến dữ liệu production khi chưa có chi tiết rollback và khôi phục."
     ]
   },
   "proposal-slide-pitch": {
-    title: "Strategic Pitch & Proposal",
-    summary: "Xây proposal nối pain, value, ROI, risk, proof và request for decision thật cụ thể.",
-    tags: ["Proposal", "Strategy", "Executive Communication"],
+    title: "Đề xuất và trình bày phương án",
+    summary: "Xây dựng đề xuất nối đúng vấn đề, giá trị, ROI, rủi ro và bằng chứng, rồi kết lại bằng một quyết định cần chốt thật cụ thể.",
+    tags: ["Đề xuất", "Chiến lược", "Giao tiếp với lãnh đạo"],
     useWhen: [
-      "Khi viết executive proposal, product strategy memo, budget ask, pitch deck hoặc technical-business trade-off narrative.",
-      "Khi cần thuyết phục C-level, sponsor hoặc budget owner approve dự án.",
-      "Khi phải giải thích trade-offs kiến trúc phức tạp cho non-technical stakeholders."
+      "Khi viết đề xuất cho lãnh đạo, bản ghi nhớ chiến lược sản phẩm, đề nghị ngân sách, pitch deck hoặc phần giải thích đánh đổi giữa kỹ thuật và kinh doanh.",
+      "Khi cần trình bày với C-level, người bảo trợ hoặc người giữ ngân sách để dự án được phê duyệt.",
+      "Khi phải giải thích những đánh đổi kiến trúc phức tạp cho người không làm kỹ thuật."
     ],
     process: [
-      "Calibrate audience: họ value gì, sợ gì, fund gì và có quyền approve tới đâu.",
-      "Frame the gap: current cost, risk, delay, churn, manual work, missed revenue hoặc strategic exposure.",
-      "Nêu thesis một câu: nên làm gì và vì sao phải làm bây giờ.",
-      "Chứng minh feasibility: benchmark, customer signal, PoC, architecture validation, financial model hoặc comparable case.",
-      "Định lượng impact: ROI, payback period, cost avoided, cycle-time reduction, risk reduction hoặc option value.",
-      "Chốt ask: decision, budget, owner, date, success metric và fallback nếu bị decline."
+      "Hiểu người nghe: họ coi trọng điều gì, lo ngại điều gì, sẵn sàng cấp vốn cho gì và có quyền phê duyệt đến đâu.",
+      "Làm rõ khoảng cách hiện tại qua chi phí, rủi ro, chậm trễ, tỷ lệ rời bỏ, việc thủ công, doanh thu bỏ lỡ hoặc vị thế chiến lược bị đe dọa.",
+      "Nêu luận điểm trong một câu: nên làm gì và vì sao cần làm ngay lúc này.",
+      "Chứng minh tính khả thi bằng benchmark, tín hiệu từ khách hàng, PoC, kết quả thẩm định kiến trúc, mô hình tài chính hoặc trường hợp tương đương.",
+      "Định lượng tác động qua ROI, thời gian hoàn vốn, chi phí tránh được, thời gian chu kỳ giảm, rủi ro giảm hoặc giá trị của quyền lựa chọn.",
+      "Chốt đề nghị: quyết định, ngân sách, người phụ trách, thời hạn, chỉ số thành công và phương án dự phòng nếu không được duyệt."
     ],
     output: [
-      "Thesis một câu và 30-second pitch.",
-      "Slide-by-slide narrative hoặc memo structure.",
-      "ROI và risk model.",
-      "Objection-handling matrix.",
-      "Final decision request và next-step plan."
+      "Luận điểm một câu và phần trình bày 30 giây.",
+      "Mạch kể theo từng slide hoặc cấu trúc bản ghi nhớ.",
+      "Mô hình ROI và rủi ro.",
+      "Ma trận trả lời các phản biện thường gặp.",
+      "Đề nghị quyết định cuối cùng và kế hoạch bước tiếp theo."
     ],
     guardrails: [
-      "KHÔNG dùng buzzwords nếu không tạo decision value.",
-      "KHÔNG overpromise adoption, revenue, cost saving hoặc delivery date.",
-      "KHÔNG giấu ask; ambiguity làm executive decision chết."
+      "Không dùng từ thời thượng nếu chúng không giúp người nghe ra quyết định.",
+      "Không hứa quá mức về mức độ sử dụng, doanh thu, chi phí tiết kiệm hoặc ngày bàn giao.",
+      "Không giấu điều cần xin quyết định; sự mơ hồ sẽ làm cuộc họp kết thúc mà không có lựa chọn nào được chốt."
     ]
   },
   "ai-operating-system": {
-    title: "AI Operating System & Orchestration",
-    summary: "Thiết kế agent workflows với model routing, context control, tool boundaries, RAG grounding và human approval gates.",
-    tags: ["AI Orchestration", "Agents", "RAG", "MCP"],
+    title: "Hệ thống làm việc với AI",
+    summary: "Thiết kế quy trình dùng agent với cách chọn model, kiểm soát ngữ cảnh, giới hạn công cụ, bám sát nguồn bằng RAG và các điểm cần con người phê duyệt.",
+    tags: ["Điều phối AI", "Agent AI", "RAG", "MCP"],
     useWhen: [
-      "Khi thiết kế multi-agent workflow, AI workbench, RAG pipeline, Codex/Claude/GPT task routing hoặc MCP tool policy.",
-      "Khi task cần nhiều pha: retrieval, reasoning, coding, review, planning, synthesis hoặc deterministic automation.",
-      "Khi cần biến prompt chain rời rạc thành operating playbook có validation và approval gates."
+      "Khi thiết kế quy trình nhiều agent, bàn làm việc AI, chuỗi RAG, cách phân việc cho Codex, Claude hoặc GPT, hay chính sách dùng công cụ MCP.",
+      "Khi tác vụ cần nhiều pha: truy xuất, suy luận, viết mã, rà soát, lập kế hoạch, tổng hợp hoặc tự động hóa theo quy tắc cố định.",
+      "Khi cần biến chuỗi prompt rời rạc thành quy trình vận hành có bước kiểm chứng và điểm phê duyệt."
     ],
     process: [
-      "Classify intent: retrieval, reasoning, coding, review, planning, synthesis, browser work hoặc deterministic automation.",
-      "Route theo capability: context length, reasoning depth, tool need, latency, cost và privacy.",
-      "Đóng gói context: source files, docs, constraints, examples, definitions và explicit exclusions.",
-      "Định nghĩa tool boundaries: read/write permissions, filesystem scope, network policy, secrets handling và approval gates.",
-      "Thêm validation: schema checks, tests, citations, diff review, secondary-agent critique và deterministic fallback.",
-      "Archive decisions: prompts, routing matrix, artifacts và reusable playbooks."
+      "Phân loại mục đích: truy xuất, suy luận, viết mã, rà soát, lập kế hoạch, tổng hợp, thao tác trình duyệt hoặc tự động hóa theo quy tắc cố định.",
+      "Chọn model theo năng lực cần có: độ dài ngữ cảnh, độ sâu suy luận, nhu cầu dùng công cụ, độ trễ, chi phí và quyền riêng tư.",
+      "Đóng gói ngữ cảnh gồm file nguồn, tài liệu, giới hạn, ví dụ, định nghĩa và phần được loại trừ rõ ràng.",
+      "Xác định ranh giới công cụ: quyền đọc và ghi, phạm vi filesystem, chính sách mạng, cách xử lý bí mật và điểm cần phê duyệt.",
+      "Thêm lớp kiểm chứng: kiểm tra schema, chạy test, đối chiếu trích dẫn, xem diff, nhờ agent thứ hai phản biện và có phương án dự phòng xác định trước.",
+      "Lưu lại quyết định, prompt, ma trận phân việc, tài liệu tạo ra và quy trình có thể dùng lại."
     ],
     output: [
-      "Agent role map và routing matrix.",
-      "Context packaging template.",
-      "Tool permission matrix và approval gates.",
-      "Validation và fallback plan.",
-      "Reusable prompt pack hoặc operating playbook."
+      "Sơ đồ vai trò của các agent và ma trận phân việc.",
+      "Mẫu chuẩn bị ngữ cảnh.",
+      "Ma trận quyền dùng công cụ và các điểm phê duyệt.",
+      "Kế hoạch kiểm chứng và phương án dự phòng.",
+      "Bộ prompt hoặc quy trình vận hành có thể dùng lại."
     ],
     guardrails: [
-      "KHÔNG để agent mutate production state nếu thiếu explicit approval và observability.",
-      "KHÔNG trộn trusted instructions với untrusted retrieved text.",
-      "KHÔNG tối ưu chỉ theo model intelligence; phải tối ưu correctness, traceability, privacy và cost."
+      "Không để agent thay đổi trạng thái production khi chưa có phê duyệt rõ ràng và observability.",
+      "Không trộn chỉ dẫn đáng tin với nội dung truy xuất chưa được tin cậy.",
+      "Không chỉ chọn model vì khả năng suy luận; phải cân bằng tính đúng đắn, khả năng truy vết, quyền riêng tư và chi phí."
     ]
   },
   "daily-ai-learning-coach": {
-    title: "Continuous AI Learning & Neuroplasticity",
-    summary: "Compound AI skill bằng deliberate practice, active recall, feedback loops và reusable artifacts.",
-    tags: ["Learning", "Deliberate Practice", "AI Fluency", "Feedback"],
+    title: "Rèn kỹ năng AI mỗi ngày",
+    summary: "Bồi đắp kỹ năng AI bằng luyện tập có chủ đích, chủ động nhớ lại, vòng phản hồi và những tài liệu có thể dùng lại.",
+    tags: ["Học tập", "Luyện tập có chủ đích", "Làm việc với AI", "Phản hồi"],
     useWhen: [
-      "Khi lập kế hoạch AI up-skilling hằng ngày, technical practice, tool fluency hoặc long-term knowledge compounding.",
-      "Khi muốn cải thiện prompt slicing, diff review, RAG synthesis, architecture critique, test generation hoặc tool orchestration.",
-      "Khi cần duy trì learning loop nhỏ, đều và gắn với việc thật thay vì side project quá lớn."
+      "Khi lập kế hoạch nâng kỹ năng AI hằng ngày, luyện kỹ thuật, dùng công cụ thành thạo hoặc tích lũy kiến thức dài hạn.",
+      "Khi muốn cải thiện cách chia nhỏ yêu cầu trong prompt, xem diff, tổng hợp bằng RAG, phản biện kiến trúc, tạo test hoặc điều phối công cụ.",
+      "Khi cần duy trì vòng học tập nhỏ, đều và gắn với việc thật thay vì mở một dự án phụ quá lớn."
     ],
     process: [
-      "Chọn một micro-skill: prompt slicing, diff review, RAG synthesis, architecture critique, test generation hoặc tool orchestration.",
-      "Practice trên context thật: current ticket, codebase, document, incident hoặc decision thay vì tutorial chung chung.",
-      "Tạo feedback: yêu cầu AI tìm blind spots, counterexamples, edge cases và missing verification.",
-      "Chuyển thành memory: active recall card, prompt template, checklist, snippet hoặc decision note.",
-      "Lên lịch reinforcement: spaced repetition và transfer challenge ở task khác.",
-      "Đo value: time saved, quality improved, bug avoided, decision clarified hoặc artifact reused."
+      "Chọn một kỹ năng nhỏ: chia prompt, xem diff, tổng hợp bằng RAG, phản biện kiến trúc, tạo test hoặc điều phối công cụ.",
+      "Luyện trên ngữ cảnh thật như ticket đang làm, codebase, tài liệu, sự cố hoặc quyết định, thay vì chỉ theo hướng dẫn chung chung.",
+      "Tạo vòng phản hồi bằng cách yêu cầu AI tìm điểm mù, phản ví dụ, trường hợp biên và phần còn thiếu kiểm chứng.",
+      "Biến điều vừa học thành thẻ chủ động nhớ lại, mẫu prompt, danh sách kiểm tra, đoạn mã hoặc ghi chú quyết định.",
+      "Lên lịch củng cố bằng spaced repetition và thử áp dụng sang một tác vụ khác.",
+      "Đo giá trị qua thời gian tiết kiệm, chất lượng cải thiện, lỗi tránh được, quyết định rõ hơn hoặc tài liệu được dùng lại."
     ],
     output: [
-      "Daily micro-skill target.",
-      "Practice task với input và expected output.",
-      "Feedback prompt và evaluation rubric.",
-      "Artifact cần lưu.",
-      "Next repetition date và transfer challenge."
+      "Mục tiêu kỹ năng nhỏ trong ngày.",
+      "Bài tập với đầu vào và kết quả mong đợi.",
+      "Prompt lấy phản hồi và thang đánh giá.",
+      "Tài liệu cần lưu lại.",
+      "Ngày ôn lại và thử thách áp dụng sang việc khác."
     ],
     guardrails: [
-      "KHÔNG tính passive reading là skill acquisition.",
-      "KHÔNG luyện năm tool trong một session; isolate một behavior.",
-      "Validate AI explanations bằng official docs, local code hoặc empirical tests."
+      "Không tính việc đọc thụ động là đã hình thành kỹ năng.",
+      "Không luyện năm công cụ trong cùng một buổi; mỗi lần chỉ tập trung vào một hành vi.",
+      "Kiểm chứng phần giải thích của AI bằng tài liệu chính thức, mã nguồn trên máy hoặc thử nghiệm thực tế."
     ]
   },
   "notebooklm-source-of-truth": {
-    title: "RAG-Grounded Knowledge Extraction",
-    summary: "Trích xuất câu trả lời grounded trên trusted documents với citations, contradiction checks và unknowns rõ ràng.",
-    tags: ["RAG", "Citations", "Research", "Knowledge Graph"],
+    title: "Rút ý có nguồn bằng NotebookLM và RAG",
+    summary: "Trích xuất câu trả lời từ tài liệu đáng tin, kèm trích dẫn, kiểm tra mâu thuẫn và nêu rõ điều chưa biết.",
+    tags: ["RAG", "Trích dẫn", "Nghiên cứu", "Đồ thị tri thức"],
     useWhen: [
-      "Khi làm việc với document sets dày: PRDs, RFCs, research papers, financial reports hoặc knowledge bases.",
-      "Khi mọi technical claim cần citation để audit.",
-      "Khi cần extraction, synthesis, comparison, timeline reconstruction hoặc gap analysis."
+      "Khi làm việc với tập tài liệu lớn như PRD, RFC, bài nghiên cứu, báo cáo tài chính hoặc kho tri thức.",
+      "Khi mọi nhận định kỹ thuật đều cần trích dẫn để có thể kiểm tra lại.",
+      "Khi cần trích xuất, tổng hợp, so sánh, dựng lại dòng thời gian hoặc phân tích phần còn thiếu."
     ],
     process: [
-      "Sanitize sources: loại bỏ secrets, credentials, PII và tài liệu ngoài approved scope.",
-      "Retrieve hẹp: query theo entity, date, decision, metric, requirement, contradiction và dependency.",
-      "Extract facts: chỉ quote/paraphrase điều source support và giữ source IDs.",
-      "Synthesize cẩn trọng: tách direct evidence, inferred interpretation, conflicts và unknowns.",
-      "Build structure: timeline, entity map, decision log, requirement matrix hoặc FAQ theo task.",
-      "Identify gaps: nêu evidence thiếu và source nào có thể resolve."
+      "Làm sạch nguồn: loại bỏ bí mật, thông tin đăng nhập, PII và tài liệu ngoài phạm vi được phép.",
+      "Truy xuất có trọng tâm theo thực thể, ngày, quyết định, metric, yêu cầu, điểm mâu thuẫn và phần phụ thuộc.",
+      "Trích xuất sự kiện: trích dẫn nguyên văn hoặc diễn giải đúng điều tài liệu hỗ trợ, đồng thời giữ tham chiếu tới nguồn.",
+      "Tổng hợp thận trọng: tách bằng chứng trực tiếp, phần suy luận, điểm xung đột và điều chưa biết.",
+      "Tổ chức kết quả thành dòng thời gian, sơ đồ thực thể, nhật ký quyết định, ma trận yêu cầu hoặc FAQ tùy tác vụ.",
+      "Chỉ ra phần còn thiếu và nguồn nào có thể giúp trả lời."
     ],
     output: [
-      "Direct answer với citations cho factual claims.",
-      "Evidence table: claim, source, confidence, date và caveat.",
-      "Contradictions và outdated-source warnings.",
-      "Entity/timeline/decision map khi hữu ích.",
-      "Unknowns và recommended follow-up sources."
+      "Câu trả lời trực tiếp với trích dẫn cho các nhận định về sự kiện.",
+      "Bảng bằng chứng gồm nhận định, nguồn, độ tin cậy, ngày và điểm cần lưu ý.",
+      "Các mâu thuẫn và cảnh báo về nguồn đã cũ.",
+      "Sơ đồ thực thể, dòng thời gian hoặc quyết định khi hữu ích.",
+      "Điều chưa biết và nguồn nên kiểm tra tiếp."
     ],
     guardrails: [
-      "Nếu source không support claim, ghi rõ: not provided in the source.",
-      "KHÔNG dùng external knowledge nếu task không cho phép.",
-      "KHÔNG gom conflicting sources thành một sự thật giả."
+      "Nếu nguồn không hỗ trợ nhận định, ghi rõ: tài liệu không cung cấp thông tin này.",
+      "Không dùng kiến thức bên ngoài khi tác vụ không cho phép.",
+      "Không hòa các nguồn mâu thuẫn thành một kết luận có vẻ chắc chắn nhưng sai."
     ]
   },
   "ai-delivery-factory": {
-    title: "Autonomous Delivery & CI/CD",
-    summary: "Điều phối AI-assisted delivery từ scoped requirement tới implementation, verification, PR và release-ready handoff.",
-    tags: ["AI Delivery", "CI/CD", "Testing", "Automation"],
+    title: "Làm phần mềm cùng AI và CI/CD",
+    summary: "Tổ chức quá trình làm phần mềm có AI hỗ trợ, từ lúc chốt yêu cầu đến triển khai, kiểm chứng, mở PR và chuẩn bị release.",
+    tags: ["Giao phần mềm với AI", "CI/CD", "Kiểm thử", "Tự động hóa"],
     useWhen: [
-      "Khi AI agents hỗ trợ implement features, refactors, migrations, test suites, CI changes hoặc release handoffs.",
-      "Khi workflow cần separation of duties giữa specification, coding, review và verification.",
-      "Khi agent được phép edit, commit, push, open PR hoặc chỉ prepare patch tùy approval."
+      "Khi agent AI hỗ trợ làm tính năng, refactor, migration, bộ test, thay đổi CI hoặc chuẩn bị release.",
+      "Khi quy trình cần tách trách nhiệm giữa viết đặc tả, viết mã, rà soát và kiểm chứng.",
+      "Khi agent có thể sửa file, commit, push, mở PR hoặc chỉ chuẩn bị patch tùy mức phê duyệt."
     ],
     process: [
-      "Scope work: restate requirement, acceptance criteria, non-goals, affected surfaces và risk level.",
-      "Slice execution: chia implementation chunks nhỏ, mỗi chunk có verification check.",
-      "Implement bằng local context: theo patterns hiện có, preserve unrelated user changes, tránh broad refactor.",
-      "Shift-left verification: typecheck, lint, unit/integration/E2E, schema, accessibility và security checks tùy scope.",
-      "Review diff: kiểm staged changes, secrets, artifacts, analytics wiring và migration safety.",
-      "Handoff sạch: Conventional Commit, push khi có approval, PR notes có impact và verification."
+      "Chốt phạm vi: diễn đạt lại yêu cầu, tiêu chí nghiệm thu, phần không làm, phần hệ thống bị ảnh hưởng và mức rủi ro.",
+      "Chia việc thành những phần triển khai nhỏ; mỗi phần đều có bước kiểm chứng riêng.",
+      "Triển khai dựa trên code hiện có: theo quy ước của dự án, giữ nguyên thay đổi không liên quan của người dùng và tránh refactor lan rộng.",
+      "Kiểm chứng sớm bằng typecheck, lint, test unit, integration, E2E, kiểm tra schema, khả năng tiếp cận và bảo mật tùy phạm vi.",
+      "Xem lại diff đã stage để phát hiện bí mật, file tạo ra ngoài ý muốn, các event analytics chưa được gắn và rủi ro migration.",
+      "Bàn giao sạch: dùng Conventional Commit, chỉ push khi được phép, ghi rõ tác động và kết quả kiểm chứng trong PR."
     ],
     output: [
-      "Execution plan và changed-file summary.",
-      "Verification evidence với command results.",
-      "Commit message và PR body draft.",
-      "Release/deployment/rollback notes.",
-      "Remaining risks hoặc follow-up tickets."
+      "Kế hoạch thực hiện và tóm tắt các file đã đổi.",
+      "Bằng chứng kiểm chứng kèm kết quả lệnh.",
+      "Nội dung commit và bản nháp mô tả PR.",
+      "Ghi chú về release, triển khai và rollback.",
+      "Rủi ro còn lại hoặc ticket cần làm tiếp."
     ],
     guardrails: [
-      "KHÔNG include secrets, local build output, runtime metadata hoặc unrelated user changes vào commit.",
-      "KHÔNG dùng agent-generated diff làm approval cho chính nó.",
-      "KHÔNG deploy hoặc mutate production nếu human chưa explicitly request."
+      "Không đưa bí mật, kết quả build trên máy, metadata của runtime hoặc thay đổi không liên quan của người dùng vào commit.",
+      "Không dùng chính diff do agent tạo ra làm căn cứ duy nhất để tự phê duyệt.",
+      "Không deploy hoặc thay đổi production khi con người chưa yêu cầu rõ ràng."
     ]
   },
   "claude-deep-review": {
-    title: "Adversarial Semantic Review",
-    summary: "Dùng adversarial review để lộ assumptions, failure modes, ambiguity và system-level fragility.",
-    tags: ["Adversarial Review", "Red Teaming", "Architecture", "Security"],
+    title: "Dùng Claude để phản biện sâu",
+    summary: "Phản biện theo hướng đối nghịch để làm lộ giả định yếu, tình huống lỗi, chỗ mơ hồ và điểm mong manh của toàn hệ thống.",
+    tags: ["Rà soát đối nghịch", "Red Team", "Kiến trúc", "Bảo mật"],
     useWhen: [
-      "Khi cần critique sâu cho PRs, RFCs, architecture proposals, incident narratives, strategy memos hoặc AI-generated plans.",
-      "Khi design có rủi ro concurrency, data integrity, security vectors, scale limits hoặc rollout ambiguity.",
-      "Khi cần một reviewer độc lập nói thẳng về weakest links trước khi execution."
+      "Khi cần phản biện sâu PR, RFC, đề xuất kiến trúc, bản tường thuật sự cố, bản ghi nhớ chiến lược hoặc kế hoạch do AI tạo.",
+      "Khi thiết kế có rủi ro về xử lý đồng thời, toàn vẹn dữ liệu, điểm tấn công, giới hạn quy mô hoặc rollout chưa rõ.",
+      "Khi cần một người rà soát độc lập chỉ thẳng mắt xích yếu nhất trước khi bắt tay triển khai."
     ],
     process: [
-      "Decompose system: actors, data flows, state transitions, dependencies, trust boundaries và failure domains.",
-      "Attack assumptions: invalid input, high concurrency, partial failure, network partition, stale cache, malicious user và operator error.",
-      "Trace blast radius: data corruption, availability loss, privacy breach, customer impact, cost explosion và operational burden.",
-      "Challenge alternatives: so proposed path với hướng đơn giản hơn, an toàn hơn, rẻ hơn hoặc dễ rollback hơn.",
-      "Rewrite weak language: loại ambiguity, unsupported claims, hidden dependencies và false certainty.",
-      "Đưa mitigation cụ thể: fixes, validation steps và decision gates."
+      "Phân rã hệ thống thành tác nhân, luồng dữ liệu, chuyển đổi trạng thái, phần phụ thuộc, ranh giới tin cậy và miền lỗi.",
+      "Thử phá các giả định bằng đầu vào sai, tải đồng thời cao, lỗi một phần, phân vùng mạng, cache cũ, người dùng có ý đồ xấu và lỗi vận hành.",
+      "Lần theo phạm vi ảnh hưởng: hỏng dữ liệu, mất khả dụng, xâm phạm quyền riêng tư, tác động khách hàng, chi phí tăng vọt và gánh nặng vận hành.",
+      "So hướng đề xuất với phương án đơn giản hơn, an toàn hơn, rẻ hơn hoặc dễ rollback hơn.",
+      "Viết lại câu chữ yếu, loại bỏ chỗ mơ hồ, nhận định thiếu căn cứ, phụ thuộc bị giấu và sự chắc chắn giả tạo.",
+      "Đưa ra cách giảm rủi ro cụ thể gồm phần cần sửa, bước kiểm chứng và điểm cần ra quyết định."
     ],
     output: [
-      "Critical risks và exploit/failure narrative.",
-      "Assumptions cần chứng minh.",
-      "Alternative designs kèm trade-offs.",
-      "Mitigation plan xếp theo risk reduction.",
-      "Go/No-Go recommendation với evidence threshold."
+      "Các rủi ro nghiêm trọng cùng kịch bản khai thác hoặc sự cố cụ thể.",
+      "Những giả định cần chứng minh.",
+      "Các thiết kế thay thế kèm đánh đổi.",
+      "Kế hoạch giảm nhẹ được xếp theo mức giảm rủi ro.",
+      "Khuyến nghị Go hoặc No-Go với ngưỡng bằng chứng rõ ràng."
     ],
     guardrails: [
-      "Nói thẳng nhưng dựa trên evidence; critique work, không critique author.",
-      "KHÔNG chấp nhận 'probably fine' cho security, data integrity hoặc rollback.",
-      "KHÔNG dừng ở critique; phải đưa smallest path để giảm risk."
+      "Nói thẳng nhưng dựa trên bằng chứng; phản biện công việc, không công kích người làm.",
+      "Không chấp nhận kiểu kết luận “có lẽ ổn” cho bảo mật, toàn vẹn dữ liệu hoặc rollback.",
+      "Không dừng ở phê bình; phải chỉ ra con đường nhỏ nhất để giảm rủi ro."
     ]
   },
   "career-ai-strategy": {
-    title: "Capability Compounding & Leverage",
-    summary: "Xây career leverage bền bằng Staff-level scope, AI fluency, portfolio evidence và compounding systems.",
-    tags: ["Career Strategy", "Staff Engineer", "Leverage", "Portfolio"],
+    title: "Tích lũy năng lực kỹ thuật lâu dài",
+    summary: "Tạo đà phát triển nghề nghiệp bền vững bằng cách nhận việc ở tầm Staff, làm chủ AI, xây hồ sơ năng lực có bằng chứng và duy trì thói quen tích lũy theo thời gian.",
+    tags: ["Chiến lược nghề nghiệp", "Staff Engineer", "Giá trị tích lũy", "Hồ sơ năng lực"],
     useWhen: [
-      "Khi lập career plan, Staff/Principal path, promotion packet, AI leverage strategy hoặc portfolio roadmap.",
-      "Khi cần hệ thống hóa project impact thành artifacts: ADRs, postmortems, engineering writing, OSS, talks hoặc internal tools.",
-      "Khi muốn giữ optionality giữa Staff IC, engineering manager, founder, consultant hoặc AI systems specialist."
+      "Khi lập kế hoạch nghề nghiệp, lộ trình lên Staff hoặc Principal, hồ sơ thăng chức, chiến lược dùng AI hoặc lộ trình xây hồ sơ năng lực.",
+      "Khi cần hệ thống hóa tác động của dự án thành bằng chứng cụ thể như ADR, postmortem, bài viết kỹ thuật, OSS, bài nói chuyện hoặc công cụ nội bộ.",
+      "Khi muốn giữ nhiều lựa chọn giữa Staff IC, quản lý kỹ thuật, người sáng lập, tư vấn hoặc chuyên gia hệ thống AI."
     ],
     process: [
-      "Định nghĩa career thesis: bạn giải quyết market problem nào tốt hơn nhờ skill stack của mình.",
-      "Audit capability: technical depth, system design, product sense, communication, leadership, AI fluency và business judgment.",
-      "Xác định leverage assets: tools, standards, playbooks, public writing, OSS, talks, mentorship và architecture artifacts.",
-      "Chọn bets: 2-3 projects có asymmetric upside, visible impact và reusable proof.",
-      "Xây 90-day operating plan: outcomes, rituals, artifacts, stakeholder alignment và weekly feedback loops.",
-      "Track evidence: before/after metrics, adoption, reliability gains, time saved, decisions influenced và people enabled."
+      "Xác định luận điểm nghề nghiệp: với tổ hợp kỹ năng hiện có, bạn có thể giải quyết vấn đề nào trên thị trường tốt hơn?",
+      "Đánh giá năng lực: chiều sâu kỹ thuật, thiết kế hệ thống, cảm nhận sản phẩm, giao tiếp, lãnh đạo, khả năng làm việc với AI và phán đoán kinh doanh.",
+      "Xác định tài sản tạo đòn bẩy: công cụ, tiêu chuẩn, quy trình, bài viết công khai, OSS, bài nói chuyện, hoạt động cố vấn và tài liệu kiến trúc.",
+      "Chọn hai hoặc ba dự án có cơ hội tạo giá trị lớn hơn công sức bỏ ra, tác động dễ thấy và bằng chứng có thể dùng lại.",
+      "Lập kế hoạch vận hành 90 ngày gồm kết quả, nhịp làm việc, tài liệu cần tạo, cách thống nhất với người liên quan và vòng phản hồi hằng tuần.",
+      "Theo dõi bằng chứng: metric trước và sau, mức độ sử dụng, độ tin cậy tăng, thời gian tiết kiệm, quyết định mình đã góp phần cải thiện và người khác được hỗ trợ."
     ],
     output: [
-      "Career thesis và positioning statement.",
-      "Capability matrix với gaps và proof.",
-      "90-day leverage roadmap.",
-      "Portfolio artifact plan.",
-      "Mentorship, visibility và stakeholder strategy."
+      "Luận điểm nghề nghiệp và cách định vị bản thân.",
+      "Ma trận năng lực với phần còn thiếu và bằng chứng.",
+      "Lộ trình tạo đòn bẩy trong 90 ngày.",
+      "Kế hoạch xây dựng hồ sơ năng lực.",
+      "Chiến lược cố vấn, xây dựng uy tín chuyên môn và làm việc với các bên liên quan."
     ],
     guardrails: [
-      "KHÔNG tối ưu job-title aesthetics hơn real scope và outcomes.",
-      "KHÔNG nhầm tool usage với AI fluency; đo quality, speed, judgment và leverage.",
-      "KHÔNG hy sinh technical depth cho breadth nông."
+      "Không chăm chút chức danh nhiều hơn phạm vi công việc thật và kết quả tạo ra.",
+      "Không nhầm việc dùng nhiều công cụ với khả năng làm việc tốt cùng AI; hãy đo chất lượng, tốc độ, phán đoán và mức đòn bẩy.",
+      "Không đánh đổi chiều sâu kỹ thuật để lấy bề rộng hời hợt."
     ]
   },
   "engineering-decision-map": {
-    title: "Systemic Decision Topography",
-    summary: "Map business requirements tới domain invariants, architecture options, trade-offs, risks và operational readiness.",
-    tags: ["Decision Matrix", "Systems Thinking", "Trade-offs", "Requirements"],
+    title: "Bản đồ quyết định kiến trúc",
+    summary: "Nối yêu cầu kinh doanh với invariant của miền, các phương án kiến trúc, đánh đổi, rủi ro và mức sẵn sàng vận hành.",
+    tags: ["Ma trận quyết định", "Tư duy hệ thống", "Đánh đổi", "Yêu cầu"],
     useWhen: [
-      "Khi requirements còn mơ hồ, decisions cross-functional hoặc architecture phải cân bằng product, data và operations.",
-      "Khi feature chạm core domain, data consistency, integrations, permissions hoặc migration.",
-      "Khi cần biết việc gì AI có thể execute và việc gì human architect phải chốt."
+      "Khi yêu cầu còn mơ hồ, quyết định liên quan nhiều bộ phận hoặc kiến trúc phải cân bằng sản phẩm, dữ liệu và vận hành.",
+      "Khi tính năng chạm vào miền lõi, tính nhất quán dữ liệu, tích hợp, phân quyền hoặc migration.",
+      "Khi cần phân định việc AI có thể thực hiện và việc kiến trúc sư phải trực tiếp quyết định."
     ],
     process: [
-      "Extract invariants: điều gì luôn phải đúng với users, money, permissions, data và compliance.",
-      "Map toàn stack: business process, domain objects, API contracts, data stores, infrastructure, operations và support.",
-      "Generate options: CRUD, CQRS, event sourcing, queue-backed workflows, modular monolith, service extraction hoặc Strangler Fig.",
-      "Score trade-offs: reversibility, delivery speed, data consistency, operational complexity, cost, reliability và team fit.",
-      "Run FMEA: failure modes, blast radius, detection, mitigation, rollback và graceful degradation.",
-      "Chốt decision: two-way door vs one-way door, accepted tech debt và validation milestone."
+      "Rút ra các invariant: điều gì luôn phải đúng với người dùng, tiền, quyền truy cập, dữ liệu và tuân thủ.",
+      "Vẽ toàn bộ hệ thống: quy trình kinh doanh, đối tượng miền, hợp đồng API, nơi lưu dữ liệu, hạ tầng, vận hành và hỗ trợ.",
+      "Đưa ra các phương án như CRUD, CQRS, event sourcing, quy trình dựa trên queue, modular monolith, tách service hoặc Strangler Fig.",
+      "Chấm các đánh đổi theo khả năng đảo ngược, tốc độ bàn giao, tính nhất quán dữ liệu, độ phức tạp vận hành, chi phí, độ tin cậy và mức phù hợp với nhóm.",
+      "Chạy FMEA để chỉ ra tình huống lỗi, phạm vi ảnh hưởng, cách phát hiện, giảm nhẹ, rollback và suy giảm có kiểm soát.",
+      "Chốt quyết định: phân biệt lựa chọn dễ đảo ngược với lựa chọn khó quay lại, ghi rõ technical debt được chấp nhận và mốc kiểm chứng."
     ],
     output: [
-      "Requirement-to-architecture map.",
-      "Weighted decision matrix.",
-      "Recommended option và rejected alternatives.",
-      "Risk register và mitigation plan.",
-      "Operational readiness và rollout outline."
+      "Sơ đồ nối yêu cầu với kiến trúc.",
+      "Ma trận quyết định có trọng số.",
+      "Phương án khuyến nghị và các phương án bị loại.",
+      "Sổ đăng ký rủi ro và kế hoạch giảm nhẹ.",
+      "Đánh giá mức sẵn sàng vận hành và phác thảo rollout."
     ],
     guardrails: [
-      "KHÔNG chọn technology thú vị nếu boring technology giữ invariant đủ tốt.",
-      "KHÔNG finalize decision nếu thiếu observability và rollback.",
-      "Phải nói rõ breaking point của design, không ngầm hứa scale vô hạn."
+      "Không chọn công nghệ thú vị chỉ vì mới lạ nếu công nghệ quen thuộc đã giữ invariant đủ tốt.",
+      "Không chốt quyết định khi chưa có observability và rollback.",
+      "Phải nói rõ điểm thiết kế bắt đầu không chịu nổi tải hoặc độ phức tạp, không ngầm hứa khả năng mở rộng vô hạn."
     ]
   },
   "staff-engineer-ai-review-pack": {
-    title: "Staff-Level Architectural Audit",
-    summary: "Audit technical changes rủi ro cao qua lăng kính Product, Architecture, Security, Data, SRE, QA và Rollout.",
-    tags: ["Staff Engineer", "Architecture Review", "PRR", "Risk Audit"],
+    title: "Rà rủi ro kiến trúc",
+    summary: "Rà soát thay đổi kỹ thuật rủi ro cao qua các góc nhìn độc lập: sản phẩm, kiến trúc, bảo mật, dữ liệu, SRE, QA và rollout.",
+    tags: ["Staff Engineer", "Rà soát kiến trúc", "PRR", "Rà soát rủi ro"],
     useWhen: [
-      "Khi review major architectural change, multi-system integration, sensitive-data feature, migration hoặc launch readiness.",
-      "Khi PR/RFC tác động Tier-1 services, API contracts, schema changes, auth model hoặc SLO.",
-      "Khi cần Production Readiness Review trước merge/go-live."
+      "Khi rà soát thay đổi kiến trúc lớn, tích hợp nhiều hệ thống, tính năng dùng dữ liệu nhạy cảm, migration hoặc mức sẵn sàng phát hành.",
+      "Khi PR hoặc RFC tác động service Tier-1, hợp đồng API, thay đổi schema, mô hình xác thực hoặc SLO.",
+      "Khi cần Production Readiness Review trước lúc merge hoặc đưa vào hoạt động."
     ],
     process: [
-      "Product lens: validate user value, rollout segment, acceptance criteria và cost of delay/simplification.",
-      "Architecture lens: boundaries, coupling, compatibility, contracts, extensibility và architectural drift.",
-      "Security/privacy lens: STRIDE, IAM/RBAC/ABAC, data exposure, tenant isolation, secrets, encryption và auditability.",
-      "Data lens: migration safety, index/lock behavior, backfill, consistency, retention, backup/restore và reconciliation.",
-      "SRE lens: SLO impact, capacity, alerts, dashboards, runbooks, on-call load, failure domains và rollback triggers.",
-      "QA lens: unit, integration, E2E, contract, load, chaos, accessibility và exploratory test coverage."
+      "Góc nhìn sản phẩm: kiểm chứng giá trị cho người dùng, nhóm rollout, tiêu chí nghiệm thu và chi phí của việc trì hoãn hoặc đơn giản hóa.",
+      "Góc nhìn kiến trúc: ranh giới, mức độ phụ thuộc, khả năng tương thích, hợp đồng, khả năng mở rộng và sai lệch khỏi kiến trúc chủ đích.",
+      "Góc nhìn bảo mật và quyền riêng tư: STRIDE, IAM/RBAC/ABAC, lộ dữ liệu, cách ly tenant, bí mật, mã hóa và khả năng kiểm toán.",
+      "Góc nhìn dữ liệu: an toàn migration, hành vi của index và lock, backfill, tính nhất quán, thời hạn lưu giữ, sao lưu, khôi phục và đối soát.",
+      "Góc nhìn SRE: tác động đến SLO, năng lực tải, cảnh báo, dashboard, runbook, gánh nặng trực on-call, miền lỗi và điều kiện rollback.",
+      "Góc nhìn QA: mức phủ của test unit, integration, E2E, contract, tải, chaos, khả năng tiếp cận và kiểm thử thăm dò."
     ],
     output: [
-      "Cross-functional risk matrix.",
-      "Hard blockers và launch conditions.",
-      "Production readiness score với Go/No-Go recommendation.",
-      "Required sign-offs và owners.",
-      "Evolution path từ current state tới target state."
+      "Ma trận rủi ro liên chức năng.",
+      "Điểm chặn bắt buộc và điều kiện phát hành.",
+      "Điểm sẵn sàng production cùng khuyến nghị Go hoặc No-Go.",
+      "Các xác nhận bắt buộc và người phụ trách.",
+      "Lộ trình đi từ trạng thái hiện tại đến trạng thái đích."
     ],
     guardrails: [
-      "KHÔNG approve big-bang rewrite nếu thiếu incremental migration plan.",
-      "KHÔNG chấp nhận launch readiness nếu thiếu measurable SLOs và rollback triggers.",
-      "Ưu tiên data integrity, privacy và reliability hơn delivery optics."
+      "Không chấp thuận viết lại theo kiểu thay toàn bộ một lần khi chưa có kế hoạch migration từng bước.",
+      "Không công nhận là sẵn sàng phát hành khi thiếu SLO đo được và điều kiện rollback.",
+      "Ưu tiên toàn vẹn dữ liệu, quyền riêng tư và độ tin cậy hơn vẻ ngoài của một tiến độ đẹp."
     ]
   },
   "data-resilience-observability-review": {
-    title: "Distributed Resilience & Telemetry",
-    summary: "Review data integrity, distributed resilience, telemetry và recovery plan trước khi hệ thống gánh production load.",
-    tags: ["Data", "Resilience", "Observability", "SRE"],
+    title: "Resilience và Observability cho hệ thống phân tán",
+    summary: "Rà soát tính toàn vẹn dữ liệu, distributed resilience, telemetry và recovery plan trước khi hệ thống chịu tải production.",
+    tags: ["Dữ liệu", "Khả năng phục hồi", "Observability", "SRE"],
     useWhen: [
-      "Khi thiết kế databases, caches, queues, search indexes, event streams, third-party integrations hoặc production readiness reviews.",
-      "Khi PR thay đổi schema, query pattern, consistency model, cache layer, queue semantics hoặc recovery behavior.",
-      "Khi cần chuẩn bị SLO dashboards, alerting, runbooks, restore tests và go-live checklist."
+      "Khi thiết kế database, cache, queue, search index, event stream, third-party integration hoặc rà soát production readiness.",
+      "Khi PR thay đổi schema, cách truy vấn, mô hình nhất quán, lớp cache, quy tắc của queue hoặc cách khôi phục.",
+      "Khi cần chuẩn bị dashboard SLO, cảnh báo, runbook, kiểm thử khôi phục và danh sách kiểm tra trước khi vận hành."
     ],
     process: [
-      "Data integrity: transaction boundaries, isolation level, constraints, idempotency, deduplication, reconciliation và migration safety.",
-      "Query/storage: indexes, cardinality, locking, hot partitions, N+1 access, connection pooling, retention và archival.",
-      "Cache/queue behavior: invalidation, stampede protection, TTL, ordering, replay, DLQ, poison messages và backpressure.",
-      "Failure simulation: network partition, slow dependency, partial write, duplicate event, region failover và third-party outage.",
-      "Telemetry: RED/USE metrics, OpenTelemetry traces, structured logs, correlation IDs, dashboards, SLO burn alerts và runbooks.",
-      "Recovery: backup restore, point-in-time recovery, RPO/RTO, rollback scripts và data repair procedure."
+      "Toàn vẹn dữ liệu: ranh giới transaction, mức isolation, constraint, idempotency, khử trùng lặp, đối soát và an toàn migration.",
+      "Truy vấn và lưu trữ: index, cardinality, lock, phân vùng nóng, truy cập N+1, connection pool, thời hạn lưu giữ và lưu trữ dài hạn.",
+      "Hành vi cache và queue: làm mới dữ liệu, chống stampede, TTL, thứ tự, phát lại, DLQ, poison message và backpressure.",
+      "Mô phỏng lỗi: phân vùng mạng, phụ thuộc phản hồi chậm, ghi dữ liệu một phần, sự kiện trùng, chuyển vùng và sự cố bên thứ ba.",
+      "Telemetry: RED/USE metrics, OpenTelemetry trace, log có cấu trúc, correlation ID, dashboard, cảnh báo SLO burn và runbook.",
+      "Khôi phục: phục hồi từ bản sao lưu, point-in-time recovery, RPO/RTO, script rollback và quy trình sửa dữ liệu."
     ],
     output: [
-      "Consistency và data-integrity assessment.",
-      "Failure-mode matrix với mitigation.",
-      "Telemetry specification và dashboard plan.",
-      "Load, chaos và restore test plan.",
-      "Go-live checklist với rollback/recovery triggers."
+      "Đánh giá tính nhất quán và toàn vẹn dữ liệu.",
+      "Ma trận tình huống lỗi kèm cách giảm nhẹ.",
+      "Đặc tả telemetry và kế hoạch dashboard.",
+      "Kế hoạch kiểm thử tải, chaos và khôi phục.",
+      "Danh sách kiểm tra trước khi vận hành kèm điều kiện rollback hoặc khôi phục."
     ],
     guardrails: [
-      "KHÔNG giả định network, clock, cache, queue hoặc third-party dependency luôn reliable.",
-      "KHÔNG log PII, secrets, tokens hoặc sensitive payloads.",
-      "KHÔNG page humans bằng non-actionable alerts."
+      "Không giả định mạng, đồng hồ, cache, queue hoặc phụ thuộc bên thứ ba luôn đáng tin cậy.",
+      "Không ghi PII, bí mật, token hoặc payload nhạy cảm vào log.",
+      "Không đánh thức người trực bằng cảnh báo mà họ không thể hành động."
     ]
   },
   "installed-skill-library-cartographer": {
-    title: "Bản đồ Skill đã cài",
-    summary: "Inventory skill đã install, loại duplicate, phân loại capability và biến playbook rải rác thành hệ thống routing dùng được.",
-    tags: ["Skill Inventory", "Agent Routing", "Taxonomy", "Governance"],
+    title: "Danh mục AI Skills đã cài",
+    summary: "Kiểm kê skill đã cài, loại bản trùng, phân nhóm năng lực và biến những quy trình rải rác thành hệ thống giúp chọn đúng skill.",
+    tags: ["Danh mục kỹ năng", "Điều phối agent", "Phân loại", "Quản trị"],
     useWhen: [
-      "Dựa trên lần quét local mới nhất: 14.541 raw SKILL.md, 5.035 unique contents, 3.116 unique names, overlap lớn giữa Codex, Claude, Gemini, Antigravity CLI/IDE và local agent runtimes.",
-      "Khi cần tổng hợp skill từ Codex, Claude, Gemini, Antigravity, local .agents, plugin, marketplace hoặc project-local skills.",
-      "Khi thư viện skill có quá nhiều bản duplicate/cache và cần rút thành capability taxonomy rõ.",
-      "Khi muốn update Studio skill library dựa trên corpus thật thay vì cảm tính."
+      "Dựa trên lần quét máy gần nhất: 14.541 file SKILL.md thô, 5.035 nội dung không trùng và 3.116 tên không trùng; mức chồng lặp lớn giữa Codex, Claude, Gemini, Antigravity CLI/IDE và các runtime agent trên máy.",
+      "Khi cần tổng hợp skill từ Codex, Claude, Gemini, Antigravity, thư mục .agents, plugin, marketplace hoặc skill riêng của dự án.",
+      "Khi thư viện có quá nhiều bản trùng hoặc bản cache và cần rút gọn thành hệ phân loại năng lực rõ ràng.",
+      "Khi muốn cập nhật thư viện skill của Studio dựa trên dữ liệu thật thay vì cảm tính."
     ],
     process: [
-      "Inventory sources: Codex, Claude, Gemini, Antigravity CLI/IDE, local .agents, project-local skills, plugins và marketplace caches.",
-      "Extract metadata: name, description, trigger rules, domain keywords, output expectations và safety constraints.",
-      "Cluster capabilities: engineering, frontend/UI, backend/platform, security, AI agents, research, content, product, operations, mobile và learning.",
-      "Tìm gaps: capability có nhiều trong installed skills nhưng thiếu trong public Studio skill library.",
-      "Synthesize target skills: merge playbooks trùng nhau thành expert skills rõ, không duplicate.",
-      "Validate fit: mỗi final skill phải có trigger, required context, process, output contract và guardrails."
+      "Kiểm kê nguồn: Codex, Claude, Gemini, Antigravity CLI/IDE, thư mục .agents, skill riêng của dự án, plugin và cache marketplace.",
+      "Trích xuất metadata: tên, mô tả, quy tắc kích hoạt, từ khóa miền, kết quả mong đợi và giới hạn an toàn.",
+      "Gom nhóm năng lực: kỹ thuật, frontend và UI, backend và nền tảng, bảo mật, agent AI, nghiên cứu, nội dung, sản phẩm, vận hành, di động và học tập.",
+      "Tìm khoảng trống: năng lực xuất hiện nhiều trong các skill đã cài nhưng còn thiếu ở thư viện Studio công khai.",
+      "Tổng hợp skill đích: gộp các quy trình trùng nhau thành skill chuyên sâu, rõ ràng và không lặp.",
+      "Kiểm tra mức phù hợp: mỗi skill cuối cùng phải có điều kiện kích hoạt, ngữ cảnh cần thiết, quy trình, hợp đồng kết quả và giới hạn."
     ],
     output: [
-      "Inventory summary: raw files, unique contents, unique names và runtime coverage.",
-      "Capability taxonomy gắn với source families.",
-      "Gap analysis so với current skill library.",
-      "Đề xuất additions/merges/removals.",
-      "Bản English và Vietnamese copy-ready."
+      "Tóm tắt kiểm kê: số file thô, nội dung không trùng, tên không trùng và các runtime được hỗ trợ.",
+      "Hệ phân loại năng lực gắn với từng nhóm nguồn.",
+      "Phân tích khoảng trống so với thư viện skill hiện tại.",
+      "Đề xuất thêm, gộp hoặc bỏ skill.",
+      "Bản tiếng Anh và tiếng Việt sẵn sàng đưa lên giao diện."
     ],
     guardrails: [
-      "KHÔNG public local paths, username, token, credential hoặc private workspace details.",
-      "KHÔNG phình library bằng cách copy mọi duplicate skill vào UI.",
-      "KHÔNG bê nguyên marketplace/cache content nếu chưa normalize theo vocabulary và nhu cầu của owner."
+      "Không công khai đường dẫn trên máy, tên người dùng, token, thông tin đăng nhập hoặc chi tiết không gian làm việc riêng tư.",
+      "Không làm thư viện phình ra bằng cách đưa mọi skill trùng lặp lên giao diện.",
+      "Không chép nguyên nội dung marketplace hoặc cache khi chưa điều chỉnh từ ngữ và mục đích sử dụng cho phù hợp."
     ]
   },
   "ai-product-evaluation": {
-    title: "AI Product & Evaluation",
-    summary: "Đưa AI feature từ demo ấn tượng thành product đáng tin bằng evals, safety boundaries, cost controls và user value đo được.",
-    tags: ["AI Product", "Evals", "LLM Quality", "Trust"],
+    title: "Đánh giá sản phẩm AI",
+    summary: "Đưa tính năng AI từ bản demo bắt mắt thành sản phẩm đáng tin bằng eval, ranh giới an toàn, kiểm soát chi phí và giá trị người dùng có thể đo được.",
+    tags: ["Sản phẩm AI", "Eval", "Chất lượng LLM", "Độ tin cậy"],
     useWhen: [
-      "Khi thiết kế, audit hoặc ship AI product features, agents, copilots, chat interfaces, retrieval systems hoặc model-powered workflows.",
-      "Khi cần phân biệt demo đẹp với production behavior đáng tin.",
-      "Khi cần đo hallucination, tool-call accuracy, citation fidelity, latency, token spend và task completion."
+      "Khi thiết kế, rà soát hoặc phát hành tính năng sản phẩm AI, agent, copilot, giao diện chat, hệ thống truy xuất hoặc quy trình dùng model.",
+      "Khi cần phân biệt bản demo đẹp với hành vi đủ đáng tin trên production.",
+      "Khi cần đo hallucination, độ chính xác khi gọi công cụ, độ trung thực của trích dẫn, độ trễ, lượng token tiêu thụ và tỷ lệ hoàn thành tác vụ."
     ],
     process: [
-      "Định nghĩa product promise: AI giúp user làm gì và tuyệt đối không được làm gì.",
-      "Tách demo khỏi production: grounding, permissions, fallback UX, observability, rate limits và abuse controls.",
-      "Build evals: golden tasks, adversarial prompts, regression suites, human review rubrics và acceptance thresholds.",
-      "Đo quality/cost: success rate, hallucination rate, tool-call accuracy, citation fidelity, latency, token spend và support impact.",
-      "Thiết kế trust UX: source display, confidence language, editability, audit trail, undo, escalation và human handoff.",
-      "Plan rollout: shadow mode, allowlist, feature flag, red-team review, telemetry, incident playbook và model/provider rollback."
+      "Xác định lời hứa của sản phẩm: AI giúp người dùng làm gì và tuyệt đối không được làm gì.",
+      "Tách yêu cầu của demo khỏi production: nguồn làm căn cứ, quyền hạn, UX dự phòng, observability, giới hạn tần suất và kiểm soát lạm dụng.",
+      "Xây eval gồm tác vụ chuẩn, prompt đối nghịch, bộ regression, thang đánh giá của con người và ngưỡng nghiệm thu.",
+      "Đo cả chất lượng lẫn chi phí: tỷ lệ thành công, hallucination, độ chính xác khi gọi công cụ, độ trung thực của trích dẫn, độ trễ, token tiêu thụ và tác động đến hỗ trợ.",
+      "Thiết kế UX tạo lòng tin: hiển thị nguồn, diễn đạt độ chắc chắn, cho phép chỉnh sửa, có nhật ký, hoàn tác, chuyển cấp và bàn giao cho con người.",
+      "Lập kế hoạch rollout bằng shadow mode, allowlist, feature flag, rà soát Red Team, telemetry, quy trình xử lý sự cố và phương án quay lại model hoặc nhà cung cấp cũ."
     ],
     output: [
-      "AI feature brief với promise, non-goals và risk class.",
-      "Evaluation plan với datasets, rubrics, thresholds và owners.",
-      "Safety và trust UX checklist.",
-      "Cost/latency budget và monitoring plan.",
-      "Rollout và rollback plan."
+      "Bản mô tả tính năng AI với lời hứa, phần không làm và nhóm rủi ro.",
+      "Kế hoạch đánh giá với tập dữ liệu, thang chấm, ngưỡng và người phụ trách.",
+      "Danh sách kiểm tra an toàn và UX tạo lòng tin.",
+      "Ngân sách chi phí, độ trễ và kế hoạch theo dõi.",
+      "Kế hoạch rollout và rollback."
     ],
     guardrails: [
-      "KHÔNG ship AI feature nếu evals không khớp real user tasks.",
-      "KHÔNG che uncertainty, missing sources hoặc model limitations khỏi user.",
-      "KHÔNG cấp write access cho agent nếu thiếu permission boundaries và audit logs."
+      "Không phát hành tính năng AI nếu eval không phản ánh tác vụ thật của người dùng.",
+      "Không che độ bất định, nguồn còn thiếu hoặc giới hạn của model với người dùng.",
+      "Không cấp quyền ghi cho agent khi chưa có ranh giới quyền hạn và nhật ký kiểm toán."
     ]
   },
   "agent-tools-mcp-automation": {
-    title: "Agent Tools, MCP & Workflow Automation",
-    summary: "Thiết kế tool-using agents ổn định qua MCP, GitHub, Slack, Gmail, Outlook, Notion, Airtable, browser và local CLI.",
-    tags: ["MCP", "Automation", "Integrations", "Tool Use"],
+    title: "Công cụ AI agent, MCP và tự động hóa",
+    summary: "Thiết kế agent dùng công cụ ổn định với MCP, GitHub, Slack, Gmail, Outlook, Notion, Airtable, trình duyệt và CLI trên máy.",
+    tags: ["MCP", "Tự động hóa", "Tích hợp", "Dùng công cụ"],
     useWhen: [
-      "Khi agent cần dùng tools, connectors, MCP servers, CLIs, browsers hoặc app integrations để hoàn thành workflow.",
-      "Khi task có read/write permissions, app account boundary, schema, pagination hoặc state mutation.",
-      "Khi cần automation đáng tin nhưng vẫn có audit trail và approval gates."
+      "Khi agent cần dùng công cụ, connector, MCP server, CLI, trình duyệt hoặc tích hợp ứng dụng để hoàn thành quy trình.",
+      "Khi tác vụ có quyền đọc hoặc ghi, ranh giới tài khoản ứng dụng, schema, phân trang hoặc thay đổi trạng thái.",
+      "Khi cần tự động hóa đáng tin nhưng vẫn có nhật ký kiểm toán và điểm phê duyệt."
     ],
     process: [
-      "Discover tools: inspect schemas và required IDs trước khi execute.",
-      "Classify actions: read-only, draft creation, user-reviewed write, immediate write, scheduled action, destructive action hoặc external publish.",
-      "Normalize inputs: resolve IDs, validate schemas, handle time zones, sanitize untrusted content và preserve source links.",
-      "Execute safely: batch chỉ khi independent, paginate tới completeness, checkpoint long work và giữ outputs inspectable.",
-      "Verify results: so returned state với requested state, record links/artifacts và surface partial failures.",
-      "Handoff: summary ngắn, artifacts, residual risk và next human decision nếu cần."
+      "Khám phá công cụ: đọc schema và xác định đủ ID bắt buộc trước khi thực hiện.",
+      "Phân loại hành động: chỉ đọc, tạo bản nháp, ghi sau khi người dùng duyệt, ghi ngay, lên lịch, phá hủy hoặc xuất bản ra bên ngoài.",
+      "Chuẩn hóa đầu vào: phân giải ID, kiểm tra schema, xử lý múi giờ, làm sạch nội dung không đáng tin và giữ liên kết nguồn.",
+      "Thực hiện an toàn: chỉ chạy theo lô khi các lệnh độc lập, phân trang đến khi đủ dữ liệu, lưu điểm giữa chừng cho việc dài và giữ kết quả có thể kiểm tra.",
+      "Kiểm chứng kết quả: đối chiếu trạng thái trả về với trạng thái được yêu cầu, lưu liên kết hoặc tài liệu và nêu rõ lỗi một phần.",
+      "Bàn giao bằng bản tóm tắt ngắn, tài liệu tạo ra, rủi ro còn lại và quyết định tiếp theo cần con người chốt."
     ],
     output: [
-      "Tooling plan với app, action, permission level và risk class.",
-      "Schema-compliant execution inputs.",
-      "Result summary kèm source links hoặc artifact references.",
-      "Failure/retry notes và unresolved blockers.",
-      "Audit trail cho state-changing actions."
+      "Kế hoạch dùng công cụ với ứng dụng, hành động, mức quyền và nhóm rủi ro.",
+      "Đầu vào thực thi đúng schema.",
+      "Tóm tắt kết quả kèm liên kết nguồn hoặc tham chiếu tài liệu.",
+      "Ghi chú lỗi, retry và điểm nghẽn chưa được giải quyết.",
+      "Nhật ký kiểm toán cho các hành động làm thay đổi trạng thái."
     ],
     guardrails: [
-      "KHÔNG execute write/destructive actions nếu thiếu explicit approval hoặc draft-first workflow.",
-      "KHÔNG bịa tool slugs, API fields, account IDs, channel IDs, folder IDs hoặc file IDs.",
-      "KHÔNG expose secrets, OAuth tokens, private payloads hoặc unrelated app data."
+      "Không thực hiện hành động ghi hoặc phá hủy khi chưa có phê duyệt rõ ràng hay quy trình tạo bản nháp trước.",
+      "Không bịa slug của công cụ, trường API, ID tài khoản, kênh, thư mục hoặc file.",
+      "Không làm lộ bí mật, OAuth token, payload riêng tư hoặc dữ liệu ứng dụng không liên quan."
     ]
   },
   "product-analytics-growth": {
-    title: "Product Analytics & Growth Experimentation",
-    summary: "Biến behavior data thành quyết định qua event taxonomy, funnels, cohorts, A/B tests, attribution và growth loops.",
-    tags: ["Analytics", "Growth", "Experimentation", "PostHog"],
+    title: "Phân tích sản phẩm và thử nghiệm tăng trưởng",
+    summary: "Biến dữ liệu hành vi thành quyết định qua hệ thống sự kiện, funnel, cohort, thử nghiệm A/B, attribution và vòng tăng trưởng.",
+    tags: ["Đo lường", "Tăng trưởng", "Thử nghiệm", "PostHog"],
     useWhen: [
-      "Khi thiết kế analytics, audit tracking, plan growth experiments, đo funnel hoặc quyết định feature có hiệu quả không.",
-      "Khi public route, CTA, filter, command UI, form hoặc outbound link cần tracking đúng.",
-      "Khi cần nối product metric với decision thay vì vanity dashboard."
+      "Khi thiết kế analytics, rà soát tracking, lập kế hoạch thử nghiệm tăng trưởng, đo funnel hoặc đánh giá tính năng có hiệu quả hay không.",
+      "Khi đường dẫn công khai, CTA, bộ lọc, giao diện lệnh, biểu mẫu hoặc liên kết ra ngoài cần được đo đúng.",
+      "Khi cần nối metric sản phẩm với quyết định thay vì tạo một dashboard chỉ đẹp để nhìn."
     ],
     process: [
-      "Define decision: metric move/không move/inconclusive thì quyết định gì thay đổi.",
-      "Design event taxonomy: event names, properties, identity resolution, source surface và versioning.",
-      "Validate instrumentation: page views, click events, forms, filters, outbound links, search/command UIs và error states.",
-      "Analyze behavior: funnels, cohorts, retention curves, segmentation, drop-offs, correlation và qualitative context.",
-      "Plan experiments: hypothesis, primary metric, guardrail metrics, sample size, ramp plan và stop conditions.",
-      "Report learning: what changed, what did not, confidence level, next decision và follow-up instrumentation."
+      "Xác định trước quyết định sẽ thay đổi thế nào nếu metric tăng, không đổi hoặc dữ liệu chưa đủ để kết luận.",
+      "Thiết kế hệ thống sự kiện: tên sự kiện, thuộc tính, cách xác định danh tính, nơi phát sinh và phiên bản.",
+      "Kiểm tra việc gắn đo lường cho lượt xem trang, lượt nhấp, biểu mẫu, bộ lọc, liên kết ra ngoài, giao diện tìm kiếm hoặc lệnh và trạng thái lỗi.",
+      "Phân tích hành vi qua funnel, cohort, đường cong giữ chân, phân nhóm, điểm người dùng rời luồng, tương quan và ngữ cảnh định tính.",
+      "Lập kế hoạch thử nghiệm với giả thuyết, metric chính, metric bảo vệ, cỡ mẫu, kế hoạch tăng dần tỷ lệ và điều kiện dừng.",
+      "Báo cáo điều học được: điều gì thay đổi, điều gì không, độ tin cậy, quyết định tiếp theo và phần đo lường cần bổ sung."
     ],
     output: [
-      "Tracking plan với events, properties, owners và surfaces.",
-      "Funnel/cohort dashboard spec.",
-      "Experiment brief với hypothesis, metrics và guardrails.",
-      "Data quality checklist.",
-      "Decision memo với recommendation."
+      "Kế hoạch tracking với sự kiện, thuộc tính, người phụ trách và nơi phát sinh.",
+      "Đặc tả dashboard funnel và cohort.",
+      "Bản mô tả thử nghiệm với giả thuyết, metric và ngưỡng bảo vệ.",
+      "Danh sách kiểm tra chất lượng dữ liệu.",
+      "Bản ghi nhớ quyết định kèm khuyến nghị."
     ],
     guardrails: [
-      "KHÔNG optimize vanity metrics nếu không ảnh hưởng decision.",
-      "KHÔNG thêm public surfaces nếu thiếu analytics theo convention của product.",
-      "KHÔNG bỏ qua privacy choices, Do Not Track, consent hoặc autocapture/session-recording constraints."
+      "Không tối ưu vanity metric khi nó không ảnh hưởng đến quyết định.",
+      "Không thêm giao diện công khai khi thiếu analytics theo quy ước của sản phẩm.",
+      "Không bỏ qua lựa chọn về quyền riêng tư, Do Not Track, sự đồng ý hoặc giới hạn của autocapture và session recording."
     ]
   },
   "research-market-intelligence": {
-    title: "Research & Market Intelligence",
-    summary: "Tạo research grounded từ local docs, web sources, competitors, customers, papers và market signals với confidence rõ.",
-    tags: ["Research", "Market Intelligence", "Source Grounding", "Synthesis"],
+    title: "Nghiên cứu và thông tin thị trường",
+    summary: "Thực hiện nghiên cứu có căn cứ từ tài liệu trên máy, nguồn web, đối thủ, khách hàng, bài nghiên cứu và tín hiệu thị trường, đồng thời nêu rõ độ tin cậy.",
+    tags: ["Nghiên cứu", "Thông tin thị trường", "Bám sát nguồn", "Tổng hợp"],
     useWhen: [
-      "Khi làm market research, competitor analysis, product discovery, customer insight synthesis hoặc technical literature review.",
-      "Khi cần current web research hoặc local-only research có source boundaries rõ.",
-      "Khi quyết định cần evidence table thay vì opinion."
+      "Khi nghiên cứu thị trường, phân tích đối thủ, khám phá sản phẩm, tổng hợp hiểu biết về khách hàng hoặc rà soát tài liệu kỹ thuật.",
+      "Khi cần tìm thông tin mới nhất trên web hoặc nghiên cứu chỉ dùng dữ liệu trên máy với ranh giới nguồn rõ ràng.",
+      "Khi quyết định cần bảng bằng chứng thay vì ý kiến cá nhân."
     ],
     process: [
-      "Frame question: decision, scope, non-goals, assumptions và confidence cần đạt.",
-      "Start local: inspect provided docs, repo notes, prior decisions và internal artifacts trước external lookup.",
-      "Gather evidence: ưu tiên primary sources, so dates, kiểm tra incentives của source và capture citations.",
-      "Analyze patterns: user segments, competitors, jobs-to-be-done, willingness to pay, adoption barriers và market timing.",
-      "Tách signal khỏi speculation: label facts, inferences, weak signals, contradictions và unknowns.",
-      "Recommend action: next decision hoặc experiment nhỏ nhất để giảm uncertainty."
+      "Đặt câu hỏi nghiên cứu quanh quyết định, phạm vi, phần không làm, giả định và độ tin cậy cần đạt.",
+      "Bắt đầu từ dữ liệu trên máy: đọc tài liệu được cung cấp, ghi chú trong repo, quyết định trước đây và tài liệu nội bộ trước khi tìm bên ngoài.",
+      "Thu thập bằng chứng: ưu tiên nguồn sơ cấp, đối chiếu ngày, xem động cơ của nguồn và lưu trích dẫn.",
+      "Tìm mẫu hình trong hành vi người dùng, cách đối thủ định vị, jobs-to-be-done, mức sẵn lòng chi trả, rào cản sử dụng và thời điểm thị trường.",
+      "Tách tín hiệu khỏi suy đoán: ghi rõ sự kiện, suy luận, tín hiệu yếu, mâu thuẫn và điều chưa biết.",
+      "Khuyến nghị hành động: quyết định tiếp theo hoặc thử nghiệm nhỏ nhất có thể thu hẹp điều chưa chắc chắn."
     ],
     output: [
-      "Research brief với question, scope và confidence.",
-      "Evidence table với source, date, claim và caveat.",
-      "Competitor/customer/theme synthesis.",
-      "Unknowns và risk register.",
-      "Recommended next experiment hoặc decision."
+      "Bản tóm tắt nghiên cứu với câu hỏi, phạm vi và độ tin cậy.",
+      "Bảng bằng chứng với nguồn, ngày, nhận định và điểm cần lưu ý.",
+      "Bản tổng hợp về đối thủ, khách hàng và chủ đề.",
+      "Điều chưa biết và sổ đăng ký rủi ro.",
+      "Thử nghiệm hoặc quyết định tiếp theo được khuyến nghị."
     ],
     guardrails: [
-      "KHÔNG browse external nếu task yêu cầu local-only.",
-      "KHÔNG biến outdated/secondhand claims thành current primary evidence.",
-      "KHÔNG giấu uncertainty; phải label confidence và proof gaps."
+      "Không tìm nguồn bên ngoài khi tác vụ yêu cầu chỉ dùng dữ liệu trên máy.",
+      "Không biến nhận định cũ hoặc truyền lại qua người khác thành bằng chứng sơ cấp hiện tại.",
+      "Không giấu phần chưa chắc chắn; phải nêu độ tin cậy và khoảng trống bằng chứng."
     ]
   },
   "security-privacy-threat-modeling": {
-    title: "Security, Privacy & Threat Modeling",
-    summary: "Audit abuse paths, auth flaws, PII exposure, supply-chain risk, compliance gaps và secure rollout.",
-    tags: ["Security", "Privacy", "Threat Modeling", "Compliance"],
+    title: "Bảo mật, quyền riêng tư và mô hình đe dọa",
+    summary: "Rà soát các kịch bản lạm dụng, lỗi xác thực và phân quyền, nguy cơ lộ PII, rủi ro chuỗi cung ứng, thiếu sót tuân thủ và cách rollout an toàn.",
+    tags: ["Bảo mật", "Quyền riêng tư", "Mô hình đe dọa", "Tuân thủ"],
     useWhen: [
-      "Khi change chạm authentication, authorization, user input, sensitive data, payments, uploads, integrations, AI tools hoặc infrastructure.",
-      "Khi cần review data flow, logs, analytics properties, secrets hoặc third-party processors.",
-      "Khi cần Go/No-Go security recommendation trước rollout."
+      "Khi thay đổi chạm đến xác thực, phân quyền, đầu vào người dùng, dữ liệu nhạy cảm, thanh toán, tải file, tích hợp, công cụ AI hoặc hạ tầng.",
+      "Khi cần rà soát luồng dữ liệu, log, thuộc tính analytics, bí mật hoặc bên thứ ba xử lý dữ liệu.",
+      "Khi cần khuyến nghị Go hoặc No-Go về bảo mật trước rollout."
     ],
     process: [
-      "Map assets/trust boundaries: user data, credentials, tokens, payments, internal APIs, model context và admin tools.",
-      "Run STRIDE/LINDDUN: spoofing, tampering, repudiation, information disclosure, denial of service, elevation và privacy risks.",
-      "Test abuse paths: injection, XSS, CSRF, IDOR, SSRF, RCE, path traversal, prompt injection và privilege escalation.",
-      "Check privacy: data minimization, consent, PII redaction, logging hygiene, analytics properties, retention và deletion.",
-      "Assess supply chain: dependencies, SCA, SAST, secrets scanning, container/IaC drift và CI permissions.",
-      "Define mitigations: hard blockers, compensating controls, test cases, monitoring, rollout constraints và incident runbook."
+      "Vẽ tài sản và ranh giới tin cậy: dữ liệu người dùng, thông tin đăng nhập, token, thanh toán, API nội bộ, ngữ cảnh model và công cụ quản trị.",
+      "Chạy STRIDE và LINDDUN cho giả mạo, sửa đổi, chối bỏ, lộ thông tin, từ chối dịch vụ, nâng quyền và rủi ro quyền riêng tư.",
+      "Thử các kịch bản lạm dụng: injection, XSS, CSRF, IDOR, SSRF, RCE, path traversal, prompt injection và nâng quyền.",
+      "Kiểm tra quyền riêng tư: tối thiểu hóa dữ liệu, sự đồng ý, che PII, vệ sinh log, thuộc tính analytics, thời hạn giữ và xóa dữ liệu.",
+      "Đánh giá chuỗi cung ứng: dependency, SCA, SAST, quét bí mật, sai lệch container hoặc IaC và quyền của CI.",
+      "Xác định cách giảm nhẹ: biện pháp bắt buộc phải có, biện pháp bù, ca kiểm thử, theo dõi, giới hạn rollout và runbook xử lý sự cố."
     ],
     output: [
-      "Threat model với assets, actors, boundaries và assumptions.",
-      "Vulnerability findings xếp severity.",
-      "Privacy impact notes và data-flow diagram.",
-      "Required fixes và verification tests.",
-      "Go/No-Go security recommendation."
+      "Mô hình đe dọa với tài sản, tác nhân, ranh giới và giả định.",
+      "Các lỗ hổng được xếp theo mức độ nghiêm trọng.",
+      "Ghi chú tác động quyền riêng tư và sơ đồ luồng dữ liệu.",
+      "Phần bắt buộc sửa và test kiểm chứng.",
+      "Khuyến nghị Go hoặc No-Go về bảo mật."
     ],
     guardrails: [
-      "KHÔNG log, copy hoặc publish secrets, tokens, private keys hoặc sensitive payloads.",
-      "KHÔNG nói chung chung 'sanitize input'; phải nêu exact control và location.",
-      "KHÔNG approve sensitive-data features nếu thiếu auditability và rollback."
+      "Không ghi log, sao chép hoặc công khai bí mật, token, khóa riêng hay payload nhạy cảm.",
+      "Không nói chung chung “làm sạch đầu vào”; phải nêu biện pháp cụ thể và vị trí áp dụng.",
+      "Không chấp thuận tính năng dùng dữ liệu nhạy cảm khi thiếu khả năng kiểm toán và rollback."
     ]
   },
   "design-system-ui-craft": {
-    title: "Design System & UI Craft",
-    summary: "Tạo interface polished, accessible, responsive bằng design system, component libraries, visual hierarchy và interaction states.",
-    tags: ["Design System", "UI", "Accessibility", "Responsive"],
+    title: "Design system và chất lượng UI",
+    summary: "Tạo giao diện chỉn chu, dễ tiếp cận và thích ứng tốt bằng design system, thư viện component, thứ bậc thị giác và trạng thái tương tác đầy đủ.",
+    tags: ["Design system", "UI", "Accessibility", "Responsive"],
     useWhen: [
-      "Khi build hoặc refine product UI, design systems, dashboards, landing pages, mobile layouts, component libraries hoặc prototypes.",
-      "Khi cần UI vừa đẹp vừa usable, có state coverage và responsive constraints.",
-      "Khi cần nối design craft với telemetry và implementation."
+      "Khi xây dựng hoặc tinh chỉnh UI sản phẩm, design system, dashboard, landing page, bố cục di động, thư viện component hoặc prototype.",
+      "Khi cần UI vừa đẹp vừa dễ dùng, có đủ trạng thái và giới hạn thích ứng màn hình.",
+      "Khi cần nối chất lượng thiết kế với telemetry và cách triển khai."
     ],
     process: [
-      "Understand job: repeated workflow, scanning pattern, decision load và error recovery của user.",
-      "Use existing system first: tokens, spacing, icons, button semantics, tabs, menus, forms, charts, tables và empty states.",
-      "Design complete states: hover, focus, disabled, loading, skeleton, empty, error, success, overflow, long text và mobile.",
-      "Build visual hierarchy: typography scale, spacing rhythm, contrast, density, grouping, affordances và layout constraints.",
-      "Verify craft: screenshot review, responsive checks, no overlap, stable dimensions, keyboard navigation và color contrast.",
-      "Connect telemetry: track UI decisions, filters, commands, CTAs, forms, outbound links và preference changes."
+      "Hiểu công việc thật của người dùng: quy trình lặp lại, cách họ lướt thông tin, lượng quyết định phải đưa ra và cách phục hồi sau lỗi.",
+      "Ưu tiên hệ thống hiện có: token, khoảng cách, biểu tượng, ngữ nghĩa nút, tab, menu, biểu mẫu, biểu đồ, bảng và trạng thái trống.",
+      "Thiết kế đủ trạng thái: hover, focus, vô hiệu hóa, đang tải, skeleton, trống, lỗi, thành công, tràn nội dung, văn bản dài và di động.",
+      "Tạo thứ bậc thị giác qua cỡ chữ, nhịp khoảng cách, độ tương phản, mật độ, cách gom nhóm, dấu hiệu tương tác và giới hạn bố cục.",
+      "Kiểm chứng độ chỉn chu bằng ảnh chụp, kiểm tra trên nhiều kích thước màn hình, không chồng lấn, kích thước ổn định, điều hướng bàn phím và độ tương phản màu.",
+      "Nối telemetry để đo quyết định trên UI, bộ lọc, lệnh, CTA, biểu mẫu, liên kết ra ngoài và thay đổi thiết lập."
     ],
     output: [
-      "UI concept và layout rationale.",
-      "Component/state inventory.",
-      "Responsive và accessibility checklist.",
-      "Implementation notes gắn với design system hiện có.",
-      "Screenshot hoặc browser-verification plan khi cần."
+      "Ý tưởng UI và lý do chọn bố cục.",
+      "Danh sách component và trạng thái.",
+      "Danh sách kiểm tra khả năng thích ứng nhiều màn hình và khả năng tiếp cận.",
+      "Ghi chú triển khai gắn với design system hiện có.",
+      "Kế hoạch chụp ảnh hoặc kiểm chứng bằng trình duyệt khi cần."
     ],
     guardrails: [
-      "KHÔNG làm landing page khi user yêu cầu tool hoặc app.",
-      "KHÔNG dùng decorative gradients/orbs thay cho visual assets liên quan product.",
-      "KHÔNG ship text overflow, overlap hoặc vỡ trên mobile."
+      "Không làm landing page khi người dùng yêu cầu một công cụ hoặc ứng dụng.",
+      "Không dùng gradient hay khối trang trí để thay cho hình ảnh thực sự liên quan đến sản phẩm.",
+      "Không phát hành giao diện còn tràn chữ, chồng lấn hoặc vỡ trên thiết bị di động."
     ]
   },
   "mobile-platform-engineering": {
-    title: "Mobile Platform Engineering",
-    summary: "Build/review iOS, Android, SwiftUI, Kotlin, React Native và app-store workflows với performance và release discipline.",
-    tags: ["Mobile", "iOS", "Android", "SwiftUI"],
+    title: "Kỹ thuật nền tảng di động",
+    summary: "Xây dựng và rà soát ứng dụng iOS, Android, SwiftUI, Kotlin, React Native, cùng quy trình phát hành lên app store với kỷ luật về hiệu năng và release.",
+    tags: ["Di động", "iOS", "Android", "SwiftUI"],
     useWhen: [
-      "Khi làm native iOS, Android, SwiftUI, Kotlin, React Native, app packaging, app-store release hoặc mobile UI/performance audit.",
-      "Khi mobile change cần device matrix, accessibility, crash reporting, privacy declaration và phased rollout.",
-      "Khi cần bridge giữa product UX và app-store/release constraints."
+      "Khi làm iOS hoặc Android native, SwiftUI, Kotlin, React Native, đóng gói ứng dụng, phát hành lên app store hoặc rà soát UI và hiệu năng di động.",
+      "Khi thay đổi trên di động cần ma trận thiết bị, khả năng tiếp cận, báo cáo crash, khai báo quyền riêng tư và rollout theo từng giai đoạn.",
+      "Khi cần dung hòa UX sản phẩm với giới hạn của app store và release."
     ],
     process: [
-      "Define platform boundaries: native vs cross-platform, shared logic, UI ownership, device support và release cadence.",
-      "Design lifecycle behavior: launch, navigation, state restoration, background tasks, permissions, offline mode và error recovery.",
-      "Optimize performance: startup time, scrolling, image memory, layout passes, concurrency, battery, network và caching.",
-      "Verify UI: device matrix, orientation, Dynamic Type, TalkBack/VoiceOver, keyboard, gestures và visual regression.",
-      "Harden release: signing, provisioning, app-store metadata, privacy labels, crash monitoring, phased rollout và rollback.",
-      "Capture evidence: simulator/device logs, screenshots, test reports, crash-free sessions và release notes."
+      "Xác định ranh giới nền tảng: native hay cross-platform, logic dùng chung, quyền sở hữu UI, thiết bị hỗ trợ và nhịp release.",
+      "Thiết kế hành vi theo vòng đời: khởi động, điều hướng, khôi phục trạng thái, tác vụ nền, quyền truy cập, chế độ offline và phục hồi sau lỗi.",
+      "Tối ưu hiệu năng: thời gian khởi động, cuộn, bộ nhớ ảnh, số lượt tính bố cục, xử lý đồng thời, pin, mạng và cache.",
+      "Kiểm chứng UI trên ma trận thiết bị, hướng màn hình, Dynamic Type, TalkBack hoặc VoiceOver, bàn phím, cử chỉ và visual regression.",
+      "Làm chắc quy trình release: ký ứng dụng, provisioning, metadata app store, nhãn quyền riêng tư, theo dõi crash, rollout theo giai đoạn và rollback.",
+      "Thu thập bằng chứng từ log simulator hoặc thiết bị, ảnh chụp, báo cáo test, số phiên không crash và release note."
     ],
     output: [
-      "Platform architecture và release plan.",
-      "UI/performance risk matrix.",
-      "Test matrix across devices và OS versions.",
-      "Store submission checklist.",
-      "Post-release monitoring và rollback notes."
+      "Kiến trúc nền tảng và kế hoạch release.",
+      "Ma trận rủi ro UI và hiệu năng.",
+      "Ma trận kiểm thử theo thiết bị và phiên bản hệ điều hành.",
+      "Danh sách kiểm tra trước khi gửi lên store.",
+      "Ghi chú theo dõi sau release và rollback."
     ],
     guardrails: [
-      "KHÔNG xem simulator success là device readiness.",
-      "KHÔNG bỏ qua accessibility, privacy declarations hoặc app-store review constraints.",
-      "KHÔNG ship mobile changes nếu thiếu crash/analytics visibility."
+      "Không xem việc chạy được trên simulator là bằng chứng đã sẵn sàng cho thiết bị thật.",
+      "Không bỏ qua khả năng tiếp cận, khai báo quyền riêng tư hoặc giới hạn xét duyệt của app store.",
+      "Không phát hành thay đổi di động khi chưa quan sát được crash và analytics."
     ]
   },
   "data-ml-science-workflow": {
-    title: "Data, ML & Scientific Workflow",
-    summary: "Xử lý data, ML và science tasks bằng reproducible notebooks, trustworthy sources, evaluation, provenance và statistical caution.",
-    tags: ["Data", "ML", "Science", "Reproducibility"],
+    title: "Quy trình dữ liệu, ML và nghiên cứu",
+    summary: "Xử lý bài toán dữ liệu, ML và nghiên cứu bằng notebook có thể tái lập, nguồn đáng tin, cách đánh giá rõ ràng, nguồn gốc dữ liệu đầy đủ và tư duy thống kê thận trọng.",
+    tags: ["Dữ liệu", "ML", "Khoa học", "Khả năng tái lập"],
     useWhen: [
-      "Khi làm data analysis, ML experiments, scientific APIs, bioinformatics, finance data, geospatial work, notebooks hoặc dashboards.",
-      "Khi analysis có risk về financial, health, science, compliance, privacy hoặc production impact.",
-      "Khi cần evidence và caveat rõ thay vì model output trôi chảy."
+      "Khi phân tích dữ liệu, thử nghiệm ML, dùng API khoa học, làm tin sinh học, dữ liệu tài chính, địa không gian, notebook hoặc dashboard.",
+      "Khi phân tích có rủi ro về tài chính, sức khỏe, khoa học, tuân thủ, quyền riêng tư hoặc tác động production.",
+      "Khi cần bằng chứng và điểm cần lưu ý rõ ràng thay vì một câu trả lời trôi chảy từ model."
     ],
     process: [
-      "Define hypothesis/decision: analysis có thể và không thể chứng minh điều gì.",
-      "Audit data provenance: source, freshness, sampling bias, schema quality, missing values, leakage và sensitive fields.",
-      "Build reproducibly: environment, seed, notebook/script split, versioned data, deterministic transforms và assumptions.",
-      "Analyze rigorously: baselines, confidence intervals, error bars, ablations, train/test split và OOD checks.",
-      "Validate with domain sense: so known constraints, source docs và independent sanity checks.",
-      "Communicate limits: uncertainty, caveats, failed approaches, ethical constraints và next experiment."
+      "Xác định giả thuyết hoặc quyết định: phân tích có thể và không thể chứng minh điều gì.",
+      "Rà soát nguồn gốc dữ liệu: nguồn, độ mới, sai lệch lấy mẫu, chất lượng schema, giá trị thiếu, rò rỉ dữ liệu và trường nhạy cảm.",
+      "Xây dựng khả năng tái lập: môi trường, seed, cách tách notebook và script, dữ liệu có phiên bản, phép biến đổi xác định và giả định.",
+      "Phân tích chặt chẽ bằng baseline, khoảng tin cậy, thanh sai số, ablation, cách chia tập train và test cùng kiểm tra OOD.",
+      "Kiểm chứng bằng hiểu biết miền: đối chiếu giới hạn đã biết, tài liệu nguồn và các phép kiểm tra độc lập.",
+      "Trình bày giới hạn gồm độ bất định, điểm cần lưu ý, hướng đã thử nhưng thất bại, giới hạn đạo đức và thử nghiệm tiếp theo."
     ],
     output: [
-      "Analysis plan và data dictionary.",
-      "Reproducible notebook/script outline.",
-      "Findings với confidence và caveats.",
-      "Evaluation table và error analysis.",
-      "Recommendation hoặc next experiment."
+      "Kế hoạch phân tích và từ điển dữ liệu.",
+      "Dàn ý notebook hoặc script có thể tái lập.",
+      "Các phát hiện kèm độ tin cậy và điểm cần lưu ý.",
+      "Bảng đánh giá và phân tích lỗi.",
+      "Khuyến nghị hoặc thử nghiệm tiếp theo."
     ],
     guardrails: [
-      "KHÔNG ám chỉ causality từ correlation nếu thiếu identification strategy.",
-      "KHÔNG xem model output là truth nếu thiếu validation và error analysis.",
-      "KHÔNG expose sensitive, medical, financial hoặc proprietary data trong public artifacts."
+      "Không suy ra quan hệ nhân quả từ tương quan khi chưa có chiến lược nhận diện phù hợp.",
+      "Không xem kết quả của model là sự thật khi thiếu kiểm chứng và phân tích lỗi.",
+      "Không để lộ dữ liệu nhạy cảm, y tế, tài chính hoặc độc quyền trong tài liệu công khai."
     ]
   }
 };
@@ -873,488 +873,488 @@ function buildVietnameseExpertAddendum({
 }: VietnameseSkillExpertAddendum): string[] {
   return [
     "",
-    "## Lăng kính senior/expert",
+    "## Góc nhìn chuyên gia",
     `- ${role}`,
     ...heuristics.map((item) => `- ${item}`),
     "",
-    "## Bẫy chuyên môn dễ bị bỏ sót",
+    "## Những lỗi dễ bị bỏ sót",
     ...failureModes.map((item) => `- ${item}`),
     "",
-    "## Quality gates",
+    "## Điều kiện chất lượng",
     ...gates.map((item) => `- ${item}`)
   ];
 }
 
 const vietnameseSkillExpertAddenda: Record<string, VietnameseSkillExpertAddendum> = {
   "code-review": {
-    role: "Review như người sẽ chịu trách nhiệm production nếu change này gây incident lúc 2 giờ sáng.",
+    role: "Rà soát như người sẽ trực tiếp chịu trách nhiệm nếu thay đổi này gây sự cố trên production lúc 2 giờ sáng.",
     heuristics: [
-      "Đọc diff qua invariant: tiền, quyền truy cập, identity, dữ liệu, locale, SEO, analytics, cache và rollback.",
-      "Trace cả happy path lẫn abandoned path: double click, stale tab, retry, partial write, duplicate event, disabled user và request timeout.",
-      "Xem test như evidence, không xem test như bảo chứng; mock phải được đối chiếu với contract thật.",
-      "Review code shape trước code style: data structure, design pattern, service boundary và helper extraction phải hợp workflow thật."
+      "Đọc diff qua các invariant về tiền, quyền truy cập, danh tính, dữ liệu, ngôn ngữ, SEO, analytics, cache và rollback.",
+      "Lần theo cả luồng thành công lẫn luồng bị bỏ dở: nhấp hai lần, tab chứa dữ liệu cũ, retry, ghi một phần, sự kiện trùng, người dùng bị vô hiệu hóa và request hết thời gian.",
+      "Xem test là bằng chứng chứ không phải bảo chứng; mock phải được đối chiếu với hợp đồng thật.",
+      "Xem cách tổ chức mã nguồn trước phong cách: cấu trúc dữ liệu, design pattern, ranh giới service và việc tách helper phải phù hợp quy trình thật."
     ],
     failureModes: [
-      "Race condition, stale closure, optimistic UI rollback hoặc retry tạo side effect trùng nhưng unit test vẫn xanh.",
-      "Một sửa UI nhỏ làm vỡ tracking, canonical path, accessibility, focus order hoặc localized copy ở route khác.",
-      "Migration hoặc schema change hợp lệ về cú pháp nhưng tạo lock, backfill chậm, old-reader break hoặc rollback không thể làm sạch data.",
-      "Tên design pattern nghe đúng nhưng boundary sai: business rule trôi vào controller, persistence trôi lên UI, hoặc generic utility bắt đầu giữ product state."
+      "Race condition, stale closure, rollback của optimistic UI hoặc retry tạo tác dụng phụ trùng lặp dù test unit vẫn xanh.",
+      "Một thay đổi UI nhỏ làm hỏng tracking, canonical path, khả năng tiếp cận, thứ tự focus hoặc bản dịch ở đường dẫn khác.",
+      "Migration hay thay đổi schema đúng cú pháp nhưng gây lock, backfill chậm, làm hỏng khả năng đọc dữ liệu theo phiên bản cũ hoặc để lại dữ liệu không thể làm sạch khi rollback.",
+      "Tên design pattern nghe hợp lý nhưng ranh giới sai: quy tắc nghiệp vụ trôi vào controller, logic lưu trữ trôi lên UI hoặc utility dùng chung bắt đầu giữ trạng thái sản phẩm."
     ],
     gates: [
-      "Finding Blocker/Major phải có evidence, impact và smallest fix.",
-      "High-risk diff phải có negative-path verification hoặc residual-risk note rõ.",
-      "Reviewer phải biết signal nào chứng minh production khỏe sau merge.",
-      "Diff thêm service, repository, shared utility, pattern hoặc data structure mới phải có ghi chú ngắn về ownership và lý do chọn."
+      "Phát hiện mức Blocker hoặc Major phải có bằng chứng, tác động và cách sửa nhỏ nhất.",
+      "Diff rủi ro cao phải có kiểm chứng cho nhánh lỗi hoặc ghi chú rõ về rủi ro còn lại.",
+      "Người rà soát phải biết tín hiệu nào chứng minh production vẫn khỏe sau merge.",
+      "Diff thêm service, repository, utility dùng chung, design pattern hoặc cấu trúc dữ liệu mới phải giải thích ngắn gọn trách nhiệm thuộc về đâu và vì sao chọn cách đó."
     ]
   },
   "frontend-architecture": {
-    role: "Thiết kế như Staff Frontend Architect cân bằng product speed, design-system integrity, accessibility và runtime performance.",
+    role: "Thiết kế như một kiến trúc sư frontend cấp Staff, cân bằng tốc độ làm sản phẩm, tính nhất quán của design system, khả năng tiếp cận và hiệu năng khi chạy.",
     heuristics: [
-      "Tách ownership theo route, data loader, URL state, interaction state, visual primitive, analytics surface và error recovery.",
-      "Model UI như state machine: loading, empty, partial, permission, optimistic, failed, retrying, success và stale data.",
-      "Budget cho nội dung xấu nhất: bản dịch dài, dataset rỗng, network chậm, reduced motion, keyboard-only và viewport hẹp."
+      "Chia trách nhiệm theo đường dẫn, bộ nạp dữ liệu, trạng thái URL, trạng thái tương tác, thành phần thị giác nền tảng, các điểm đo analytics và cách phục hồi sau lỗi.",
+      "Mô hình hóa UI như state machine với trạng thái đang tải, trống, có một phần dữ liệu, thiếu quyền, cập nhật lạc quan, thất bại, đang thử lại, thành công và dữ liệu cũ.",
+      "Dành chỗ cho trường hợp nội dung khó nhất: bản dịch dài, tập dữ liệu rỗng, mạng chậm, chế độ giảm chuyển động, chỉ dùng bàn phím và màn hình hẹp."
     ],
     failureModes: [
-      "Hydration mismatch hoặc client-only state làm lệch SEO, first interaction, analytics hoặc cache freshness.",
-      "Component đẹp trên mock nhưng không có stable dimensions nên real data gây CLS, overlap, truncation hoặc mobile unusable.",
-      "Global state được thêm để giải quyết vấn đề local, tạo coupling và stale state giữa các route."
+      "Hydration mismatch hoặc trạng thái chỉ có ở trình duyệt làm sai SEO, tương tác đầu tiên, analytics hoặc độ mới của cache.",
+      "Component đẹp trong bản mẫu nhưng thiếu kích thước ổn định, khiến dữ liệu thật gây CLS, chồng lấn, cắt chữ hoặc không dùng được trên di động.",
+      "Trạng thái toàn ứng dụng được thêm để chữa một vấn đề cục bộ, tạo phụ thuộc và dữ liệu cũ giữa các đường dẫn."
     ],
     gates: [
-      "State taxonomy, responsive matrix và focus order phải rõ trước khi gọi UI ready.",
-      "LCP, INP, CLS, bundle budget, keyboard flow và PageTracker/event tracking có owner.",
-      "Không ship component mới nếu thiếu empty/error/disabled/loading/mobile behavior."
+      "Cách phân loại trạng thái, ma trận theo kích thước màn hình và thứ tự focus phải rõ trước khi coi UI là hoàn tất.",
+      "LCP, INP, CLS, giới hạn bundle, luồng bàn phím và PageTracker hoặc event tracking đều có người phụ trách.",
+      "Không phát hành component mới khi thiếu trạng thái trống, lỗi, vô hiệu hóa, đang tải hoặc hành vi trên di động."
     ]
   },
   "backend-architecture": {
-    role: "Thiết kế như Backend Architect chịu trách nhiệm invariant, compatibility, migration safety và operational load.",
+    role: "Thiết kế như một kiến trúc sư backend chịu trách nhiệm về invariant, khả năng tương thích, an toàn migration và tải vận hành.",
     heuristics: [
-      "Bắt đầu từ invariant trước topology: điều gì vẫn phải đúng sau retry, duplicate message, partial failure, replay và operator error.",
-      "Chọn consistency model có chủ đích: strong, read-your-writes, monotonic read, eventual consistency hoặc compensating transaction.",
-      "Giữ boring architecture cho tới khi throughput, data gravity, ownership hoặc compliance buộc phải phức tạp hơn."
+      "Bắt đầu từ invariant trước cấu trúc triển khai: điều gì vẫn phải đúng sau retry, message trùng, lỗi một phần, phát lại và sai sót vận hành.",
+      "Chọn mô hình nhất quán có chủ đích: strong consistency, read-your-writes, monotonic read, eventual consistency hoặc compensating transaction.",
+      "Giữ kiến trúc quen thuộc và đơn giản cho đến khi throughput, chi phí di chuyển dữ liệu, quyền sở hữu hoặc yêu cầu tuân thủ thực sự buộc hệ thống phức tạp hơn."
     ],
     failureModes: [
-      "Async flow thiếu idempotency, DLQ, replay strategy, reconciliation và observability sẽ biến bug thành data loss âm thầm.",
-      "Retry không phân biệt transient/permanent error nên nhân đôi thanh toán, gửi mail trùng hoặc ghi event sai thứ tự.",
-      "Schema migration bỏ qua lock behavior, index build, backfill throttle, old readers và rollback data."
+      "Luồng bất đồng bộ thiếu idempotency, DLQ, chiến lược phát lại, đối soát và observability sẽ biến lỗi phần mềm thành mất dữ liệu âm thầm.",
+      "Retry không phân biệt lỗi tạm thời và lỗi vĩnh viễn có thể nhân đôi thanh toán, gửi email trùng hoặc ghi sự kiện sai thứ tự.",
+      "Migration schema bỏ qua phạm vi và thời gian lock, thời gian tạo index, giới hạn tốc độ backfill, khả năng đọc dữ liệu theo phiên bản cũ và cách rollback dữ liệu."
     ],
     gates: [
-      "Mỗi mutation path phải có authz, idempotency key, validation, audit signal và rollback semantics.",
-      "Contract phải có pagination, error taxonomy, rate limit, versioning và compatibility note.",
-      "SLO, timeout, retry budget, alert và runbook đủ để on-call xử lý."
+      "Mỗi luồng ghi dữ liệu phải có phân quyền, khóa idempotency, kiểm tra đầu vào, tín hiệu kiểm toán và quy tắc rollback.",
+      "Hợp đồng phải nêu phân trang, hệ thống lỗi, giới hạn tần suất, phiên bản và khả năng tương thích.",
+      "SLO, timeout, ngân sách retry, cảnh báo và runbook phải đủ để người trực xử lý sự cố."
     ]
   },
   "blog-content-writer": {
-    role: "Viết như senior technical editor bảo vệ trust, precision, source fidelity và working memory của reader.",
+    role: "Viết như một biên tập viên kỹ thuật giàu kinh nghiệm, coi trọng niềm tin, độ chính xác, sự bám sát nguồn và thời gian của người đọc.",
     heuristics: [
-      "Biến topic rộng thành một thesis, một reader, một decision và một mental model đáng nhớ.",
-      "Dùng thuật ngữ chuyên ngành khi nó mang tải giải thích; định nghĩa bằng ngữ cảnh, failure mode và trade-off.",
-      "SEO semantic phải nâng clarity, không thay giọng tác giả bằng keyword stuffing."
+      "Thu hẹp chủ đề rộng thành một luận điểm, một nhóm người đọc, một quyết định và một cách hiểu đáng nhớ.",
+      "Dùng thuật ngữ chuyên ngành khi nó giúp giải thích chính xác; làm rõ bằng ngữ cảnh, tình huống lỗi và đánh đổi.",
+      "SEO theo ngữ nghĩa phải làm nội dung rõ hơn, không thay giọng tác giả bằng cách nhồi từ khóa."
     ],
     failureModes: [
-      "Bài nghe có vẻ expert nhưng thiếu falsifiable claim, source trail, ví dụ vận hành hoặc trade-off thật.",
-      "Nội dung có nhiều heading nhưng không có narrative spine nên reader không biết phải làm gì tiếp.",
-      "Claim về performance, security, AI capability hoặc market trend vượt khỏi evidence."
+      "Bài viết nghe có vẻ chuyên sâu nhưng thiếu nhận định có thể kiểm chứng, dấu vết nguồn, ví dụ vận hành hoặc đánh đổi thật.",
+      "Nội dung có nhiều tiêu đề nhưng thiếu mạch kể xuyên suốt nên người đọc không biết bước tiếp theo là gì.",
+      "Nhận định về hiệu năng, bảo mật, khả năng AI hoặc xu hướng thị trường vượt quá bằng chứng."
     ],
     gates: [
-      "Có thesis rõ, heading hierarchy sạch, metadata/slug/schema đúng và internal link hợp lý.",
-      "Strong claim phải được source, demo, code, benchmark hoặc caveat nâng đỡ.",
-      "Giọng viết giữ bình tĩnh, sắc bén, không hype và không sales."
+      "Có luận điểm rõ, hệ thống tiêu đề mạch lạc, metadata, slug và schema đúng, liên kết nội bộ hợp lý.",
+      "Nhận định mạnh phải có nguồn, demo, mã nguồn, benchmark hoặc lưu ý về giới hạn làm căn cứ.",
+      "Giọng viết bình tĩnh, sắc nét, không cường điệu và không bán hàng."
     ]
   },
   "prompt-writing": {
-    role: "Thiết kế prompt như một typed interface chịu được ambiguity, prompt injection, tool use và downstream parsing.",
+    role: "Thiết kế prompt như một interface có kiểu dữ liệu, chịu được yêu cầu mơ hồ, prompt injection, việc dùng công cụ và bước phân tích kết quả phía sau.",
     heuristics: [
-      "Tách authority layers: system, developer, user task, retrieved evidence, examples và untrusted payload.",
-      "Định nghĩa prompt bằng contract: input, precondition, allowed tools, output schema, validation, error và fallback.",
-      "Dùng examples để khóa intent; dùng counterexamples để khóa thứ không được làm."
+      "Tách các tầng thẩm quyền: system, developer, yêu cầu người dùng, bằng chứng truy xuất, ví dụ và payload không đáng tin.",
+      "Định nghĩa prompt như một hợp đồng: đầu vào, điều kiện tiên quyết, công cụ được phép, schema kết quả, cách kiểm tra, lỗi và phương án dự phòng.",
+      "Dùng ví dụ để khóa đúng ý định; dùng phản ví dụ để chỉ rõ điều không được làm."
     ],
     failureModes: [
-      "Prompt dài nhưng không binding vì thiếu acceptance criteria, negative constraints, schema examples và eval cases.",
-      "Untrusted content có thể đổi role, tool boundary, safety policy, source hierarchy hoặc output format.",
-      "Output nhìn đúng nhưng không machine-parse được vì schema không nói rõ optional/null/error state."
+      "Prompt dài nhưng không đủ ràng buộc vì thiếu tiêu chí nghiệm thu, những điều không được phép, ví dụ schema và ca eval.",
+      "Nội dung không đáng tin có thể đổi vai trò, ranh giới công cụ, chính sách an toàn, thứ tự ưu tiên nguồn hoặc định dạng kết quả.",
+      "Kết quả nhìn có vẻ đúng nhưng máy không phân tích được vì schema không nói rõ trường tùy chọn, giá trị null hoặc trạng thái lỗi."
     ],
     gates: [
-      "Prompt pack phải có adversarial tests, malformed-input tests và schema validation.",
-      "Không yêu cầu private chain-of-thought; chỉ yêu cầu rationale/evidence/checks ngắn.",
-      "Structured output có valid/invalid examples và recovery path."
+      "Bộ prompt phải có test đối nghịch, test đầu vào sai định dạng và kiểm tra schema.",
+      "Không yêu cầu private chain-of-thought; chỉ yêu cầu giải thích, bằng chứng hoặc bước kiểm tra ngắn.",
+      "Kết quả có cấu trúc phải kèm ví dụ hợp lệ, không hợp lệ và cách phục hồi khi lỗi."
     ]
   },
   "status-report": {
-    role: "Viết như operator cho lãnh đạo cần hiểu risk, decision và path-to-green trong dưới một phút.",
+    role: "Viết như người vận hành đang giúp lãnh đạo hiểu rủi ro, quyết định cần chốt và cách đưa dự án trở lại quỹ đạo trong chưa đầy một phút.",
     heuristics: [
-      "Tách activity khỏi value shipped, risk retired, decision unblocked và customer/system impact.",
-      "Dùng leading indicators để phát hiện drift trước khi lagging metric xấu đi.",
-      "Escalation tốt phải nói consequence of no decision, không chỉ báo rằng có blocker."
+      "Tách hoạt động khỏi giá trị đã bàn giao, rủi ro đã loại bỏ, quyết định đã được tháo gỡ và tác động đến khách hàng hoặc hệ thống.",
+      "Dùng chỉ báo sớm để nhận ra sai lệch trước khi metric kết quả xấu đi.",
+      "Một nội dung chuyển cấp tốt phải nói rõ hệ quả nếu không có quyết định, không chỉ báo rằng đang có điểm nghẽn."
     ],
     failureModes: [
-      "Green status che scope creep, dependency drift, quality debt hoặc blocker không owner.",
-      "Metric đúng nhưng không actionable vì không gắn với decision hoặc threshold.",
-      "Update kể nhiều việc đã làm nhưng không trả lời project khỏe hay không."
+      "Trạng thái Green che giấu phạm vi phình ra, phần phụ thuộc lệch kế hoạch, nợ chất lượng hoặc điểm nghẽn chưa có người phụ trách.",
+      "Metric chính xác nhưng không giúp hành động vì không gắn với quyết định hoặc ngưỡng cụ thể.",
+      "Bản cập nhật kể nhiều việc đã làm nhưng không trả lời được dự án đang khỏe hay có nguy cơ."
     ],
     gates: [
-      "Mỗi blocker có owner, next action, due date, impact và escalation threshold.",
-      "Health status có rationale một câu và thay đổi so với update trước.",
-      "Decision ask có recommendation, fallback và deadline."
+      "Mỗi điểm nghẽn có người phụ trách, bước tiếp theo, hạn xử lý, tác động và ngưỡng cần chuyển cấp.",
+      "Tình trạng dự án có một câu giải thích và nêu rõ thay đổi so với lần cập nhật trước.",
+      "Đề nghị quyết định phải có phương án khuyến nghị, phương án dự phòng và thời hạn."
     ]
   },
   "doc-spec-tech-spec": {
-    role: "Viết như RFC owner phải tạo được consensus trước khi code bắt đầu.",
+    role: "Viết như người chịu trách nhiệm RFC, cần tạo được sự đồng thuận trước khi bắt đầu viết mã.",
     heuristics: [
-      "Non-goals phải sắc như goals; phần không loại trừ rõ sẽ trở thành scope debt.",
-      "Phân loại decision: two-way door cần tốc độ, one-way door cần evidence và sign-off.",
-      "Spec tốt phải nối product intent với NFRs, data model, threat model, rollout và verification."
+      "Phần không làm phải rõ như phần mục tiêu; điều không được loại trừ sớm sẽ khiến phạm vi cứ phình ra.",
+      "Phân loại quyết định: lựa chọn dễ đảo ngược cần tốc độ, lựa chọn khó quay lại cần bằng chứng và xác nhận.",
+      "Đặc tả tốt phải nối mục tiêu sản phẩm với NFR, mô hình dữ liệu, mô hình đe dọa, rollout và kiểm chứng."
     ],
     failureModes: [
-      "Spec mô tả solution nhưng không chứng minh problem, user impact hoặc operational constraint.",
-      "Migration, privacy, observability, compatibility và rollback bị đẩy sang implementation lúc chi phí đã cao.",
-      "Alternative section yếu nên reviewer không thấy vì sao hướng được chọn là tốt nhất trong constraints."
+      "Đặc tả mô tả giải pháp nhưng không chứng minh vấn đề, tác động đến người dùng hoặc giới hạn vận hành.",
+      "Migration, quyền riêng tư, observability, khả năng tương thích và rollback bị đẩy sang lúc triển khai, khi chi phí thay đổi đã cao.",
+      "Phần phương án thay thế quá yếu khiến người xem không hiểu vì sao hướng được chọn phù hợp nhất trong các giới hạn hiện có."
     ],
     gates: [
-      "Có alternatives, trade-off matrix, risk register, test matrix, rollout/rollback plan.",
-      "Open question có owner, decision date và impact nếu chưa resolve.",
-      "Production-data change phải có migration choreography và recovery procedure."
+      "Có các phương án thay thế, ma trận đánh đổi, sổ đăng ký rủi ro, ma trận kiểm thử cùng kế hoạch rollout và rollback.",
+      "Mỗi câu hỏi còn mở có người phụ trách, ngày cần quyết định và tác động nếu chưa giải quyết.",
+      "Thay đổi dữ liệu production phải có thứ tự migration và quy trình khôi phục."
     ]
   },
   "proposal-slide-pitch": {
-    role: "Giao tiếp như executive operator biến ambiguity thành investment case có thể quyết định ngay.",
+    role: "Trình bày như người đề xuất trước ban lãnh đạo, biến sự mơ hồ thành một đề nghị đầu tư có thể chốt ngay.",
     heuristics: [
-      "Dịch feature thành business levers: revenue, cost, risk, cycle time, resilience, compliance hoặc option value.",
-      "Viết cho nhiều lens cùng lúc: CFO nhìn ROI, CTO nhìn feasibility/risk, Product nhìn adoption, Ops nhìn execution.",
-      "Đặt ask sớm; deck giấu decision sẽ buộc stakeholder tự suy diễn."
+      "Chuyển tính năng thành giá trị kinh doanh: doanh thu, chi phí, rủi ro, thời gian chu kỳ, khả năng chống lỗi, tuân thủ hoặc lợi ích của việc giữ thêm lựa chọn.",
+      "Viết cho nhiều góc nhìn cùng lúc: CFO nhìn ROI, CTO nhìn tính khả thi và rủi ro, Product nhìn mức độ sử dụng, Ops nhìn khả năng thực hiện.",
+      "Nêu điều cần quyết định từ sớm; một deck giấu đề nghị sẽ buộc người liên quan tự suy diễn."
     ],
     failureModes: [
-      "Proposal thuyết phục nhưng không fundable vì thiếu owner, budget, timeline, risk và success metric.",
-      "Technical win được kể bằng jargon nên mỗi stakeholder nghe thành một proposal khác nhau.",
-      "Không prewire objection về cost, adoption, timing, opportunity cost và delivery risk."
+      "Đề xuất nghe thuyết phục nhưng không thể cấp vốn vì thiếu người phụ trách, ngân sách, mốc thời gian, rủi ro và metric thành công.",
+      "Lợi ích kỹ thuật được kể bằng biệt ngữ khiến mỗi người liên quan hiểu thành một đề xuất khác nhau.",
+      "Không chuẩn bị trước phản biện về chi phí, mức độ sử dụng, thời điểm, chi phí cơ hội và rủi ro bàn giao."
     ],
     gates: [
-      "Có one-sentence thesis, decision request, quantified impact model và fallback path.",
-      "Objection matrix bao phủ cost, risk, timing, feasibility, adoption và opportunity cost.",
-      "Success metric đo được sau launch, không chỉ là output đã ship."
+      "Có luận điểm một câu, đề nghị quyết định, mô hình tác động định lượng và phương án dự phòng.",
+      "Ma trận phản biện bao phủ chi phí, rủi ro, thời điểm, tính khả thi, mức độ sử dụng và chi phí cơ hội.",
+      "Metric thành công phải đo được sau khi phát hành, không chỉ ghi nhận phần đã bàn giao."
     ]
   },
   "ai-operating-system": {
-    role: "Thiết kế như AI systems architect xây workflow đáng tin, không chỉ sưu tầm prompt.",
+    role: "Thiết kế như một kiến trúc sư hệ thống AI xây quy trình đáng tin, không chỉ sưu tầm prompt.",
     heuristics: [
-      "Route theo task physics: retrieval, reasoning, coding, validation, UI verification, state mutation và synthesis là các job khác nhau.",
-      "Xem context như supply chain: provenance, freshness, trust level, compression, redaction và exclusion đều quan trọng.",
-      "Đặt validation layer trước khi orchestration phức tạp; multi-agent không tự tạo correctness."
+      "Phân việc theo bản chất tác vụ: truy xuất, suy luận, viết mã, kiểm chứng, kiểm tra UI, thay đổi trạng thái và tổng hợp là những việc khác nhau.",
+      "Xem ngữ cảnh như một chuỗi cung ứng: nguồn gốc, độ mới, mức tin cậy, cách nén, che dữ liệu và loại trừ đều quan trọng.",
+      "Đặt lớp kiểm chứng trước khi điều phối phức tạp; nhiều agent không tự tạo ra tính đúng đắn."
     ],
     failureModes: [
-      "Nhiều agent làm tăng latency và contradiction nhưng không có owner, schema hoặc arbitration rule.",
-      "Agent có tool access quá rộng rồi vượt qua privacy, filesystem, app account hoặc production boundary.",
-      "Memory/RAG chứa source cũ hoặc untrusted text nhưng được đưa vào prompt như instruction đáng tin."
+      "Nhiều agent làm tăng độ trễ và mâu thuẫn nhưng không có người chịu trách nhiệm, schema hay quy tắc phân xử.",
+      "Agent được cấp quyền công cụ quá rộng rồi vượt qua ranh giới quyền riêng tư, filesystem, tài khoản ứng dụng hoặc production.",
+      "Memory hoặc RAG chứa nguồn cũ hay nội dung không đáng tin nhưng lại được đưa vào prompt như chỉ dẫn có thẩm quyền."
     ],
     gates: [
-      "Mỗi agent có role, inputs, tools, write boundary, output schema và verification owner.",
-      "Critical workflow có secondary review, deterministic checks và human approval gates.",
-      "Routing matrix nói rõ model nào dùng cho việc gì, vì sao và khi nào fallback."
+      "Mỗi agent có vai trò, đầu vào, công cụ, ranh giới ghi, schema kết quả và người chịu trách nhiệm kiểm chứng.",
+      "Quy trình quan trọng có lượt rà soát thứ hai, phép kiểm tra xác định trước và điểm cần con người phê duyệt.",
+      "Ma trận phân việc nêu rõ model nào làm việc gì, vì sao và khi nào dùng phương án dự phòng."
     ]
   },
   "daily-ai-learning-coach": {
-    role: "Coach như người thiết kế deliberate practice để AI fluency compound thành judgment, không thành tool-hopping.",
+    role: "Hướng dẫn như người thiết kế luyện tập có chủ đích để khả năng làm việc với AI tích lũy thành phán đoán tốt, không thành thói quen đổi công cụ liên tục.",
     heuristics: [
-      "Luyện một micro-skill mỗi lần: task slicing, source grounding, diff review, eval design hoặc architecture critique.",
-      "Dùng retrieval practice, interleaving và spaced repetition để biến kiến thức thành reflex.",
-      "Practice trên work artifact thật để feedback có cost và context."
+      "Mỗi lần chỉ luyện một kỹ năng nhỏ: chia tác vụ, bám nguồn, xem diff, thiết kế eval hoặc phản biện kiến trúc.",
+      "Dùng retrieval practice, interleaving và spaced repetition để biến kiến thức thành phản xạ.",
+      "Luyện trên tài liệu công việc thật để phản hồi có giá trị và ngữ cảnh rõ ràng."
     ],
     failureModes: [
-      "Xem video, đọc thread hoặc đổi tool liên tục nhưng không tạo artifact hay behavior mới.",
-      "Outsource suy nghĩ cho AI nên tốc độ tăng nhưng mental model yếu đi.",
-      "Học quá rộng khiến không có transfer từ bài tập sang task production."
+      "Xem video, đọc thảo luận hoặc đổi công cụ liên tục nhưng không tạo ra tài liệu hay hành vi mới.",
+      "Giao cả việc suy nghĩ cho AI nên tốc độ tăng nhưng cách hiểu vấn đề lại yếu đi.",
+      "Học quá rộng khiến kỹ năng từ bài tập không chuyển được sang tác vụ production."
     ],
     gates: [
-      "Mỗi session có input thật, expected output, feedback prompt và saved artifact.",
-      "Có active recall card hoặc checklist để dùng lại trong tuần.",
-      "Đo value bằng bug tránh được, decision rõ hơn, time saved hoặc artifact reused."
+      "Mỗi buổi có đầu vào thật, kết quả mong đợi, prompt lấy phản hồi và tài liệu được lưu lại.",
+      "Có thẻ chủ động nhớ lại hoặc danh sách kiểm tra để dùng lại trong tuần.",
+      "Đo giá trị bằng lỗi tránh được, quyết định rõ hơn, thời gian tiết kiệm hoặc tài liệu được dùng lại."
     ]
   },
   "notebooklm-source-of-truth": {
-    role: "Làm như knowledge analyst bảo vệ source fidelity, citation granularity và explicit unknowns.",
+    role: "Làm như một chuyên viên phân tích tri thức, bảo đảm nội dung bám sát nguồn, trích dẫn đủ cụ thể và nêu rõ điều chưa biết.",
     heuristics: [
-      "Xếp hạng source theo trust, date, authority, directness và conflict potential.",
-      "Tách claim, evidence, inference và caveat để tránh biến synthesis thành hallucination có citation.",
-      "Dùng contradiction matrix khi nhiều tài liệu nói khác nhau về cùng entity, metric hoặc decision."
+      "Xếp hạng nguồn theo độ tin cậy, ngày, thẩm quyền, mức độ trực tiếp và khả năng xung đột.",
+      "Tách nhận định, bằng chứng, suy luận và điểm cần lưu ý để tránh biến phần tổng hợp thành hallucination có gắn trích dẫn.",
+      "Dùng ma trận mâu thuẫn khi nhiều tài liệu nói khác nhau về cùng thực thể, metric hoặc quyết định."
     ],
     failureModes: [
-      "Citation gắn với đoạn có liên quan lỏng lẻo nhưng không support claim chính.",
-      "Source cũ bị dùng như hiện tại, nhất là policy, pricing, API behavior, legal hoặc org ownership.",
-      "Tổng hợp mượt làm mất unknowns, caveats và boundary của corpus."
+      "Trích dẫn gắn với đoạn chỉ liên quan lỏng lẻo nhưng không thực sự hỗ trợ nhận định chính.",
+      "Nguồn cũ được dùng như thông tin hiện tại, nhất là chính sách, giá, hành vi API, pháp lý hoặc quyền sở hữu trong tổ chức.",
+      "Bản tổng hợp trôi chảy làm mất điều chưa biết, điểm cần lưu ý và ranh giới của tập tài liệu."
     ],
     gates: [
-      "Fact claim có source/date/confidence; inference phải được label rõ.",
-      "Nếu corpus không có câu trả lời, ghi not provided in the source.",
-      "Sensitive docs được redaction trước khi đưa vào output public."
+      "Nhận định về sự kiện có nguồn, ngày và độ tin cậy; phần suy luận phải được ghi rõ.",
+      "Nếu tập tài liệu không có câu trả lời, ghi rõ rằng tài liệu không cung cấp thông tin này.",
+      "Tài liệu nhạy cảm phải được che dữ liệu trước khi đưa vào nội dung công khai."
     ]
   },
   "ai-delivery-factory": {
-    role: "Điều phối như delivery lead giữ con người sở hữu requirement, risk và release judgment trong khi AI tăng tốc execution.",
+    role: "Điều phối như người dẫn dắt bàn giao, để con người vẫn làm chủ yêu cầu, rủi ro và quyết định release trong khi AI tăng tốc thực hiện.",
     heuristics: [
-      "Tách roles: spec writer, implementer, reviewer, tester, release owner và post-launch observer.",
-      "Mỗi implementation slice phải có verification command hoặc observable artifact.",
-      "Review staged diff như supply-chain artifact: secrets, generated output, unrelated changes, analytics và migration risk."
+      "Tách vai trò: người viết đặc tả, người triển khai, người rà soát, người kiểm thử, người chịu trách nhiệm release và người theo dõi sau phát hành.",
+      "Mỗi phần triển khai nhỏ phải có lệnh kiểm chứng hoặc kết quả có thể kiểm tra lại.",
+      "Xem diff đã stage như một mắt xích chuỗi cung ứng: kiểm tra bí mật, file được tạo, thay đổi không liên quan, analytics và rủi ro migration."
     ],
     failureModes: [
-      "Agent ship nhanh nhưng thiếu acceptance criteria nên đúng code mà sai product behavior.",
-      "AI-generated tests assert implementation detail thay vì user-visible contract.",
-      "Commit lẫn runtime files, local metadata, generated build output hoặc unrelated user changes."
+      "Agent bàn giao nhanh nhưng thiếu tiêu chí nghiệm thu, khiến mã đúng về kỹ thuật mà sai hành vi sản phẩm.",
+      "Test do AI tạo kiểm tra chi tiết triển khai thay vì hợp đồng người dùng có thể quan sát.",
+      "Commit lẫn file runtime, metadata trên máy, kết quả build hoặc thay đổi không liên quan của người dùng."
     ],
     gates: [
-      "Có scope, non-goals, changed-file summary, verification evidence và residual risk.",
-      "Commit/PR dùng Conventional Commit và mô tả impact, test, deployment/rollback.",
-      "Production mutation hoặc deploy chỉ làm khi user đã explicit request."
+      "Có phạm vi, phần không làm, tóm tắt file thay đổi, bằng chứng kiểm chứng và rủi ro còn lại.",
+      "Commit và PR dùng Conventional Commit, đồng thời mô tả tác động, kiểm thử, triển khai và rollback.",
+      "Chỉ thay đổi production hoặc deploy khi người dùng đã yêu cầu rõ ràng."
     ]
   },
   "claude-deep-review": {
-    role: "Review như adversarial architect tìm assumption yếu nhất trước khi nó thành incident.",
+    role: "Rà soát như một kiến trúc sư phản biện, tìm giả định yếu nhất trước khi nó trở thành sự cố.",
     heuristics: [
-      "Decompose actors, trust boundaries, state transitions, dependency graph và failure domains.",
-      "Dùng FMEA, STRIDE, pre-mortem và counterfactual để hỏi design vỡ ở đâu.",
-      "So proposed path với simpler, safer, cheaper, more reversible alternatives."
+      "Phân rã tác nhân, ranh giới tin cậy, chuyển đổi trạng thái, đồ thị phụ thuộc và miền lỗi.",
+      "Dùng FMEA, STRIDE, pre-mortem và tình huống phản thực để hỏi thiết kế sẽ vỡ ở đâu.",
+      "So hướng đề xuất với các phương án đơn giản hơn, an toàn hơn, rẻ hơn và dễ đảo ngược hơn."
     ],
     failureModes: [
-      "Critique nghe sắc nhưng không đưa mitigation nhỏ nhất để giảm risk.",
-      "Review chỉ nhìn code/proposal mà bỏ qua operator error, stale cache, clock skew, network partition và malicious user.",
-      "Weak language như probably, should, likely che assumption chưa chứng minh."
+      "Phản biện nghe sắc nhưng không đưa ra biện pháp nhỏ nhất để giảm rủi ro.",
+      "Chỉ nhìn mã hoặc đề xuất mà bỏ qua lỗi vận hành, cache cũ, lệch đồng hồ, phân vùng mạng và người dùng có ý đồ xấu.",
+      "Những từ mơ hồ như “có lẽ”, “nên” hay “nhiều khả năng” che giấu giả định chưa được chứng minh."
     ],
     gates: [
-      "Mỗi critical risk có failure narrative, blast radius, detection và mitigation.",
-      "Go/No-Go recommendation có evidence threshold.",
-      "Assumption quan trọng có test, metric, owner hoặc explicit decision."
+      "Mỗi rủi ro nghiêm trọng có kịch bản lỗi, phạm vi ảnh hưởng, cách phát hiện và giảm nhẹ.",
+      "Khuyến nghị Go hoặc No-Go có ngưỡng bằng chứng rõ ràng.",
+      "Giả định quan trọng phải có test, metric, người phụ trách hoặc quyết định được ghi rõ."
     ]
   },
   "career-ai-strategy": {
-    role: "Tư vấn như Staff/Principal career strategist tối ưu asymmetric leverage và evidence nhìn thấy được.",
+    role: "Tư vấn như người hoạch định nghề nghiệp ở cấp Staff hoặc Principal, ưu tiên cơ hội tạo giá trị lớn và bằng chứng có thể nhìn thấy.",
     heuristics: [
-      "Định nghĩa career thesis: market problem nào mình giải tốt hơn nhờ technical depth, product sense và AI fluency.",
-      "Chọn bets theo option value: artifact reusable, audience rõ, feedback nhanh và upside lớn.",
-      "Biến work thật thành proof: ADR, postmortem, tooling, writing, talk, mentorship và metric before/after."
+      "Xác định luận điểm nghề nghiệp: vấn đề thị trường nào mình giải tốt hơn nhờ chiều sâu kỹ thuật, cảm nhận sản phẩm và khả năng làm việc với AI.",
+      "Chọn hướng đầu tư mở ra nhiều cơ hội: tài liệu dùng lại được, người đọc rõ, phản hồi nhanh và tiềm năng lớn.",
+      "Biến công việc thật thành bằng chứng: ADR, postmortem, công cụ, bài viết, bài nói chuyện, hoạt động cố vấn và metric trước hoặc sau."
     ],
     failureModes: [
-      "Tối ưu title hoặc tool stack thay vì scope, judgment và outcomes.",
-      "Portfolio nhiều activity nhưng thiếu narrative về problem, trade-off, impact và learning.",
-      "AI usage rộng nhưng không chứng minh quality, speed, leverage hoặc better decisions."
+      "Tối ưu chức danh hoặc bộ công cụ thay vì phạm vi công việc, phán đoán và kết quả.",
+      "Hồ sơ năng lực có nhiều hoạt động nhưng thiếu câu chuyện về vấn đề, đánh đổi, tác động và điều đã học.",
+      "Dùng AI rộng nhưng không chứng minh được chất lượng, tốc độ, công sức tiết kiệm hay quyết định tốt hơn."
     ],
     gates: [
-      "90-day plan có outcomes, rituals, artifacts, stakeholders và weekly feedback loop.",
-      "Capability matrix tách depth, breadth, communication, leadership, AI fluency và business judgment.",
-      "Mỗi asset có target audience và reuse path."
+      "Kế hoạch 90 ngày có kết quả, nhịp làm việc, tài liệu cần tạo, người liên quan và vòng phản hồi hằng tuần.",
+      "Ma trận năng lực tách chiều sâu, bề rộng, giao tiếp, lãnh đạo, khả năng làm việc với AI và phán đoán kinh doanh.",
+      "Mỗi tài liệu có nhóm người đọc đích và cách dùng lại."
     ]
   },
   "engineering-decision-map": {
-    role: "Map quyết định như systems thinker nối requirement, invariant, architecture option và operational consequence.",
+    role: "Lập bản đồ quyết định như người tư duy hệ thống, nối yêu cầu, invariant, phương án kiến trúc và hệ quả vận hành.",
     heuristics: [
-      "Extract invariants trước khi brainstorm solution: users, money, permissions, data, compliance và support.",
-      "Dùng weighted decision matrix nhưng ghi rõ weight đến từ business priority nào.",
-      "Xem reversibility như tài sản: option dễ rollback có thể thắng option tối ưu nhưng brittle."
+      "Rút ra invariant trước khi nghĩ giải pháp: người dùng, tiền, quyền truy cập, dữ liệu, tuân thủ và hỗ trợ.",
+      "Dùng ma trận quyết định có trọng số nhưng phải nêu trọng số xuất phát từ ưu tiên kinh doanh nào.",
+      "Xem khả năng đảo ngược là một tài sản: phương án dễ rollback có thể tốt hơn phương án tối ưu nhưng mong manh."
     ],
     failureModes: [
-      "Decision bị kéo bởi công nghệ thú vị thay vì invariant và team fit.",
-      "Matrix cho điểm nhưng không có threshold, assumption hoặc sensitivity analysis.",
-      "Bỏ qua support workflow, incident handling và migration path nên design chỉ đẹp trên diagram."
+      "Quyết định bị dẫn dắt bởi công nghệ thú vị thay vì invariant và mức phù hợp với nhóm.",
+      "Ma trận có điểm số nhưng thiếu ngưỡng, giả định hoặc phân tích độ nhạy.",
+      "Bỏ qua quy trình hỗ trợ, xử lý sự cố và đường migration nên thiết kế chỉ đẹp trên sơ đồ."
     ],
     gates: [
-      "Có requirement-to-architecture map và rejected alternatives.",
-      "Risk register bao gồm detection, mitigation, rollback và owner.",
-      "Breaking point của design được nói rõ, không hứa scale vô hạn."
+      "Có sơ đồ nối yêu cầu với kiến trúc và các phương án bị loại.",
+      "Sổ đăng ký rủi ro gồm cách phát hiện, giảm nhẹ, rollback và người phụ trách.",
+      "Nêu rõ điểm thiết kế bắt đầu không chịu nổi tải hoặc độ phức tạp, không hứa khả năng mở rộng vô hạn."
     ]
   },
   "staff-engineer-ai-review-pack": {
-    role: "Audit như Staff Engineer chịu trách nhiệm production readiness ở ranh giới product, architecture, security, data, SRE và QA.",
+    role: "Rà soát như một Staff Engineer chịu trách nhiệm về mức sẵn sàng production tại ranh giới sản phẩm, kiến trúc, bảo mật, dữ liệu, SRE và QA.",
     heuristics: [
-      "Review theo lens độc lập rồi tổng hợp: Product, Architecture, Security/Privacy, Data, SRE, QA, Rollout.",
-      "Phân biệt hard blocker, launch condition, accepted risk và follow-up debt.",
-      "Ưu tiên blast radius reduction hơn optics của timeline."
+      "Rà soát từng góc nhìn độc lập rồi tổng hợp: sản phẩm, kiến trúc, bảo mật và quyền riêng tư, dữ liệu, SRE, QA và rollout.",
+      "Phân biệt điểm chặn bắt buộc, điều kiện phát hành, rủi ro được chấp nhận và món nợ cần xử lý sau.",
+      "Ưu tiên thu hẹp phạm vi ảnh hưởng hơn việc làm mốc thời gian trông đẹp."
     ],
     failureModes: [
-      "PRR checklist đầy đủ nhưng không có owner hoặc evidence cho từng launch condition.",
-      "Big-bang rewrite thiếu strangler path, compatibility bridge, backfill/reconciliation và rollback.",
-      "SLO, dashboard, alert, runbook và on-call load được bàn sau khi go-live."
+      "Danh sách PRR đầy đủ nhưng từng điều kiện phát hành lại thiếu người phụ trách hoặc bằng chứng.",
+      "Bản viết lại toàn bộ một lần thiếu lộ trình Strangler, lớp tương thích, backfill, đối soát và rollback.",
+      "SLO, dashboard, cảnh báo, runbook và gánh nặng trực on-call chỉ được bàn sau khi hệ thống đã vận hành."
     ],
     gates: [
-      "Có cross-functional risk matrix và Go/No-Go recommendation.",
-      "Launch condition có owner, verification signal và deadline.",
-      "Không approve nếu data integrity, privacy hoặc rollback chưa rõ."
+      "Có ma trận rủi ro liên chức năng và khuyến nghị Go hoặc No-Go.",
+      "Mỗi điều kiện phát hành có người phụ trách, tín hiệu kiểm chứng và thời hạn.",
+      "Không chấp thuận khi toàn vẹn dữ liệu, quyền riêng tư hoặc rollback chưa rõ."
     ]
   },
   "data-resilience-observability-review": {
-    role: "Review như SRE/Data Reliability engineer giả định network, clock, queue, cache và third-party đều có thể fail.",
+    role: "Rà soát như một kỹ sư SRE và độ tin cậy dữ liệu, luôn giả định mạng, đồng hồ, queue, cache và bên thứ ba đều có thể hỏng.",
     heuristics: [
-      "Đánh giá consistency, idempotency, ordering, replay, deduplication và reconciliation trước throughput.",
-      "Thiết kế telemetry theo RED/USE, correlation ID, trace span, SLO burn rate và actionable alerts.",
-      "Recovery phải được test: backup restore, point-in-time recovery, data repair và rollback script."
+      "Đánh giá tính nhất quán, idempotency, thứ tự, phát lại, khử trùng lặp và đối soát trước throughput.",
+      "Thiết kế telemetry theo RED/USE, correlation ID, trace span, SLO burn rate và cảnh báo cho biết rõ cần làm gì.",
+      "Khả năng khôi phục phải được kiểm thử qua phục hồi bản sao lưu, point-in-time recovery, sửa dữ liệu và script rollback."
     ],
     failureModes: [
-      "Alert nhiều nhưng không actionable, gây alert fatigue và che incident thật.",
-      "Cache invalidation thiếu contract nên stale read thành data integrity bug.",
-      "Queue lag, poison message, hot partition hoặc out-of-order event không có detection."
+      "Nhiều cảnh báo nhưng không thể hành động, gây mệt mỏi và che khuất sự cố thật.",
+      "Việc làm mới cache thiếu hợp đồng rõ ràng khiến lần đọc dữ liệu cũ trở thành lỗi toàn vẹn dữ liệu.",
+      "Queue chậm, poison message, phân vùng nóng hoặc sự kiện sai thứ tự không có cách phát hiện."
     ],
     gates: [
-      "Có failure-mode matrix với detection, mitigation và runbook.",
-      "RPO/RTO, backup restore và rollback/recovery triggers rõ.",
-      "Không log PII, secret, token hoặc sensitive payload."
+      "Có ma trận tình huống lỗi với cách phát hiện, giảm nhẹ và runbook.",
+      "RPO/RTO, khôi phục bản sao lưu và điều kiện rollback hoặc khôi phục đều rõ.",
+      "Không ghi PII, bí mật, token hoặc payload nhạy cảm vào log."
     ]
   },
   "installed-skill-library-cartographer": {
-    role: "Làm như taxonomy architect biến hàng nghìn skill cài rải rác thành capability map dùng được.",
+    role: "Làm như một kiến trúc sư phân loại, biến hàng nghìn skill cài rải rác thành bản đồ năng lực có thể sử dụng.",
     heuristics: [
-      "Deduplicate theo content hash, normalized name và source family vì cache/plugin tạo rất nhiều bản sao.",
-      "Giữ provenance ở mức capability, không public local paths, username hoặc private workspace details.",
-      "Merge playbook trùng nhau thành canonical skills có trigger, context, process, output và guardrails."
+      "Loại bản trùng theo hash nội dung, tên đã chuẩn hóa và nhóm nguồn vì cache hoặc plugin tạo ra rất nhiều bản sao.",
+      "Giữ thông tin nguồn gốc ở mức năng lực, không công khai đường dẫn trên máy, tên người dùng hoặc chi tiết không gian làm việc riêng tư.",
+      "Gộp các quy trình trùng nhau thành skill chuẩn có điều kiện kích hoạt, ngữ cảnh, quy trình, hợp đồng kết quả và giới hạn."
     ],
     failureModes: [
-      "Copy nguyên marketplace/cache content làm library phình to nhưng routing kém.",
-      "Đếm số skill như quality signal trong khi duplicate và stale versions chiếm phần lớn corpus.",
-      "Taxonomy quá rộng nên AI agent không biết khi nào chọn skill nào."
+      "Chép nguyên nội dung marketplace hoặc cache làm thư viện phình to nhưng khả năng chọn skill vẫn kém.",
+      "Dùng số lượng skill làm tín hiệu chất lượng trong khi bản trùng và phiên bản cũ chiếm phần lớn tập dữ liệu.",
+      "Hệ phân loại quá rộng khiến agent AI không biết khi nào nên chọn skill nào."
     ],
     gates: [
-      "Inventory có raw count, unique content, unique names và runtime coverage ở dạng aggregate.",
-      "Gap analysis so current Studio library dẫn tới add/merge/remove rõ.",
-      "Final copy không lộ path, token, private repo, customer data hoặc vendor-specific noise."
+      "Bản kiểm kê có số file thô, nội dung không trùng, tên không trùng và danh sách runtime được hỗ trợ ở dạng tổng hợp.",
+      "Phân tích khoảng trống so với thư viện Studio hiện tại phải dẫn đến đề xuất thêm, gộp hoặc bỏ rõ ràng.",
+      "Nội dung cuối không lộ đường dẫn, token, repo riêng tư, dữ liệu khách hàng hoặc chi tiết thừa riêng của nhà cung cấp."
     ]
   },
   "ai-product-evaluation": {
-    role: "Đánh giá như AI Product/Eval Lead đưa feature từ demo đẹp tới product đáng tin.",
+    role: "Đánh giá như người dẫn dắt sản phẩm và eval AI, đưa tính năng từ bản demo đẹp đến sản phẩm đáng tin.",
     heuristics: [
-      "Định nghĩa product promise và non-goals trước model choice; eval phải đo promise đó.",
-      "Xây eval pyramid: golden tasks, adversarial prompts, regression suite, human rubric và production telemetry.",
-      "Theo dõi quality/cost cùng lúc: task success, hallucination, tool-call accuracy, citation fidelity, latency và token spend."
+      "Xác định lời hứa sản phẩm và phần không làm trước khi chọn model; eval phải đo đúng lời hứa đó.",
+      "Xây tháp eval gồm tác vụ chuẩn, prompt đối nghịch, bộ regression, thang đánh giá của con người và telemetry production.",
+      "Theo dõi chất lượng và chi phí cùng lúc: tỷ lệ hoàn thành tác vụ, hallucination, độ chính xác khi gọi công cụ, mức độ trích dẫn đúng nguồn, độ trễ và token tiêu thụ."
     ],
     failureModes: [
-      "Demo success nhờ curated prompt nhưng real users có messy input, missing context và conflicting sources.",
-      "Evals quá nhỏ hoặc quá synthetic nên không bắt được retrieval drift, prompt injection và silent degradation.",
-      "Trust UX che uncertainty khiến user hiểu nhầm output là authoritative."
+      "Demo thành công nhờ prompt được chuẩn bị kỹ, nhưng người dùng thật đưa đầu vào lộn xộn, thiếu ngữ cảnh và nguồn mâu thuẫn.",
+      "Eval quá nhỏ hoặc quá nhân tạo nên không bắt được sai lệch truy xuất, prompt injection và chất lượng giảm âm thầm.",
+      "UX tạo lòng tin lại che phần chưa chắc chắn, khiến người dùng hiểu nhầm kết quả là kết luận có thẩm quyền."
     ],
     gates: [
-      "Có acceptance thresholds, guardrail metrics, red-team cases và model/provider rollback.",
-      "Write actions cần permission boundary, audit log, undo/escalation và human approval khi risk cao.",
-      "Telemetry phải phân biệt quality issue, retrieval issue, tool issue và user-abandonment."
+      "Có ngưỡng nghiệm thu, metric bảo vệ, ca red-team và phương án quay lại model hoặc nhà cung cấp cũ.",
+      "Hành động ghi cần ranh giới quyền, nhật ký kiểm toán, khả năng hoàn tác hoặc chuyển cấp và phê duyệt của con người khi rủi ro cao.",
+      "Telemetry phải phân biệt vấn đề chất lượng, truy xuất, công cụ và việc người dùng bỏ dở."
     ]
   },
   "agent-tools-mcp-automation": {
-    role: "Thiết kế như automation architect cho agents dùng tools có schema, permission, audit và recovery rõ.",
+    role: "Thiết kế như một kiến trúc sư tự động hóa, để agent dùng công cụ với schema, quyền hạn, kiểm toán và khôi phục rõ ràng.",
     heuristics: [
-      "Resolve IDs bằng read step trước write step; tên người, channel, folder hoặc issue title không đủ để mutate state.",
-      "Phân loại action: read-only, draft, reviewed write, immediate write, scheduled, destructive hoặc external publish.",
-      "Batch chỉ khi calls độc lập; pagination phải chạy tới completeness nếu user cần toàn bộ kết quả."
+      "Phân giải ID bằng bước đọc trước bước ghi; tên người, kênh, thư mục hoặc tiêu đề issue chưa đủ để thay đổi trạng thái.",
+      "Phân loại hành động: chỉ đọc, tạo bản nháp, ghi sau khi duyệt, ghi ngay, lên lịch, phá hủy hoặc xuất bản ra ngoài.",
+      "Chỉ chạy theo lô khi các lời gọi độc lập; phải phân trang đến hết nếu người dùng cần toàn bộ kết quả."
     ],
     failureModes: [
-      "Tool call đúng schema nhưng sai account, sai mailbox, sai timezone hoặc sai target ID.",
-      "Long workflow không checkpoint nên partial failure không thể resume hoặc audit.",
-      "Agent tóm tắt kết quả nhưng không verify returned state với requested state."
+      "Lời gọi công cụ đúng schema nhưng sai tài khoản, hộp thư, múi giờ hoặc ID đích.",
+      "Quy trình dài không có điểm lưu giữa chừng nên khi lỗi một phần không thể tiếp tục hoặc kiểm toán.",
+      "Agent tóm tắt kết quả nhưng không đối chiếu trạng thái trả về với trạng thái được yêu cầu."
     ],
     gates: [
-      "Mọi write/destructive action có explicit approval hoặc draft-first path.",
-      "Execution note lưu app, action, permission level, artifact/source link và failure/retry state.",
-      "Không bịa tool slug, API field, account ID, channel ID, folder ID hoặc file ID."
+      "Mọi hành động ghi hoặc phá hủy đều có phê duyệt rõ ràng hoặc đi qua bản nháp trước.",
+      "Ghi chú thực thi lưu ứng dụng, hành động, mức quyền, liên kết tài liệu hoặc nguồn và trạng thái lỗi hoặc retry.",
+      "Không bịa slug công cụ, trường API, ID tài khoản, kênh, thư mục hoặc file."
     ]
   },
   "product-analytics-growth": {
-    role: "Làm như product analytics/growth lead nối instrumentation với decision, không chỉ dashboard.",
+    role: "Làm như người dẫn dắt phân tích sản phẩm và tăng trưởng, nối việc đo lường với quyết định chứ không chỉ với dashboard.",
     heuristics: [
-      "Mỗi event tồn tại vì một decision; nếu metric move/không move mà không đổi hành động thì đó là vanity.",
-      "Thiết kế identity, property taxonomy, source surface và event versioning trước khi analyze funnel.",
-      "Experiment cần primary metric, guardrails, SRM check, sample size, ramp plan và stop condition."
+      "Mỗi event tồn tại vì một quyết định; nếu metric tăng hay đứng yên mà hành động vẫn không đổi thì đó là vanity metric.",
+      "Thiết kế danh tính, bộ thuộc tính, nơi phát sinh và phiên bản sự kiện trước khi phân tích funnel.",
+      "Thử nghiệm cần metric chính, metric bảo vệ, kiểm tra SRM, cỡ mẫu, kế hoạch tăng dần tỷ lệ và điều kiện dừng."
     ],
     failureModes: [
-      "Event drift: cùng một hành vi được track bằng nhiều tên/properties khác nhau qua thời gian.",
-      "Identity contamination làm cohort, attribution và retention sai nhưng dashboard vẫn đẹp.",
-      "A/B test bị kết luận quá sớm hoặc thiếu guardrail metrics nên tăng conversion nhưng hại quality."
+      "Tên sự kiện bị trôi: cùng một hành vi được theo dõi bằng nhiều tên hoặc thuộc tính khác nhau theo thời gian.",
+      "Danh tính bị lẫn làm sai cohort, attribution và retention dù dashboard vẫn đẹp.",
+      "Thử nghiệm A/B bị kết luận quá sớm hoặc thiếu metric bảo vệ, khiến conversion tăng nhưng chất lượng giảm."
     ],
     gates: [
-      "Tracking plan có event, properties, owner, surface và privacy constraint.",
-      "Dashboard spec nói rõ decision, baseline, segment và confidence.",
-      "Không phá Do Not Track, disabled autocapture/session recording hoặc consent choices."
+      "Kế hoạch tracking có sự kiện, thuộc tính, người phụ trách, nơi phát sinh và giới hạn quyền riêng tư.",
+      "Đặc tả dashboard nêu rõ quyết định, baseline, phân nhóm và độ tin cậy.",
+      "Không phá Do Not Track, lựa chọn tắt autocapture hoặc session recording và quyết định đồng ý của người dùng."
     ]
   },
   "research-market-intelligence": {
-    role: "Nghiên cứu như analyst phân biệt evidence hierarchy, incentives, freshness và confidence.",
+    role: "Nghiên cứu như một chuyên viên phân tích biết phân biệt thứ bậc bằng chứng, động cơ của nguồn, độ mới và độ tin cậy.",
     heuristics: [
-      "Bắt đầu bằng decision question; research không có decision sẽ dễ thành collection notes.",
-      "Ưu tiên primary sources, so date, kiểm author incentive và label source trust.",
-      "Dùng Bayesian update: evidence mới làm tăng/giảm confidence thế nào, chưa đủ thì cần experiment gì."
+      "Bắt đầu bằng câu hỏi cần ra quyết định; nghiên cứu không phục vụ quyết định dễ biến thành tập ghi chú rời rạc.",
+      "Ưu tiên nguồn sơ cấp, đối chiếu ngày, xem động cơ của tác giả và ghi rõ mức tin cậy của nguồn.",
+      "Cập nhật theo Bayesian: bằng chứng mới làm độ tin cậy tăng hay giảm thế nào; nếu chưa đủ thì cần thử nghiệm gì."
     ],
     failureModes: [
-      "Secondhand/outdated claim được trình bày như current market fact.",
-      "Competitor analysis chỉ liệt kê feature mà không phân tích positioning, pricing power, wedge và switching cost.",
-      "Research mượt nhưng che contradictions, unknowns và weak signals."
+      "Nhận định truyền lại hoặc đã cũ được trình bày như sự kiện thị trường hiện tại.",
+      "Phân tích đối thủ chỉ liệt kê tính năng mà không xem định vị, quyền lực định giá, lợi thế tiếp cận thị trường và chi phí chuyển đổi.",
+      "Bản nghiên cứu trôi chảy nhưng che mâu thuẫn, điều chưa biết và tín hiệu yếu."
     ],
     gates: [
-      "Evidence table có source, date, claim, caveat và confidence.",
-      "Synthesis tách facts, inferences, speculation và recommended next experiment.",
-      "High-stakes/current claims phải verify bằng source mới và primary khi có thể."
+      "Bảng bằng chứng có nguồn, ngày, nhận định, điểm cần lưu ý và độ tin cậy.",
+      "Bản tổng hợp tách sự kiện, suy luận, suy đoán và thử nghiệm tiếp theo được khuyến nghị.",
+      "Nhận định hiện tại hoặc có hệ quả lớn phải được kiểm chứng bằng nguồn mới và nguồn sơ cấp khi có thể."
     ]
   },
   "security-privacy-threat-modeling": {
-    role: "Audit như security/privacy architect nhìn abuse economics, trust boundaries và blast radius.",
+    role: "Rà soát như một kiến trúc sư bảo mật và quyền riêng tư, xem cả động cơ lạm dụng, ranh giới tin cậy và phạm vi ảnh hưởng.",
     heuristics: [
-      "Map assets, actors, data flows, trust boundaries và privilege transitions trước khi list vulnerabilities.",
-      "Chạy STRIDE cho security và LINDDUN cho privacy; AI context cũng là data-flow surface.",
-      "Đánh giá exploitability qua preconditions, attacker capability, detection, blast radius và compensating controls."
+      "Vẽ tài sản, tác nhân, luồng dữ liệu, ranh giới tin cậy và chuyển đổi đặc quyền trước khi liệt kê lỗ hổng.",
+      "Chạy STRIDE cho bảo mật và LINDDUN cho quyền riêng tư; ngữ cảnh AI cũng là một phần của luồng dữ liệu cần được rà soát.",
+      "Đánh giá khả năng khai thác qua điều kiện tiên quyết, năng lực kẻ tấn công, khả năng phát hiện, phạm vi ảnh hưởng và biện pháp bù."
     ],
     failureModes: [
-      "Generic sanitize input advice không chỉ ra exact sink, encoder, validator hoặc boundary.",
-      "IDOR/tenant isolation leak xảy ra ở query layer dù route đã auth.",
-      "Logs, analytics properties, prompt context hoặc support tooling vô tình chứa PII/secret."
+      "Lời khuyên chung chung về làm sạch đầu vào không chỉ ra đúng sink, encoder, validator hoặc ranh giới cần xử lý.",
+      "Lỗi IDOR hoặc cách ly tenant xảy ra ở lớp truy vấn dù đường dẫn đã có xác thực.",
+      "Log, thuộc tính analytics, ngữ cảnh prompt hoặc công cụ hỗ trợ vô tình chứa PII hay bí mật."
     ],
     gates: [
-      "Finding có severity, affected location, exploit path, impact và fix/verification cụ thể.",
-      "Sensitive-data flow có minimization, retention, deletion, audit và rollback story.",
-      "Không approve write-capable AI/tooling nếu thiếu permission boundary và audit trail."
+      "Mỗi phát hiện có mức độ, vị trí bị ảnh hưởng, đường khai thác, tác động và cách sửa hoặc kiểm chứng cụ thể.",
+      "Luồng dữ liệu nhạy cảm có cách tối thiểu hóa, thời hạn giữ, xóa, kiểm toán và rollback rõ ràng.",
+      "Không chấp thuận AI hoặc công cụ có quyền ghi khi thiếu ranh giới quyền hạn và nhật ký kiểm toán."
     ]
   },
   "design-system-ui-craft": {
-    role: "Thiết kế như product UI craft lead ưu tiên workflow thật, state coverage, accessibility và visual hierarchy.",
+    role: "Thiết kế như người dẫn dắt chất lượng UI sản phẩm, ưu tiên quy trình thật, đủ trạng thái, khả năng tiếp cận và thứ bậc thị giác.",
     heuristics: [
-      "Bắt đầu từ repeated workflow, scan pattern, decision load và error recovery của user.",
-      "Dùng tokens/component library hiện có trước; nếu phá pattern phải có lý do UX rõ.",
-      "Thiết kế cho content thật: long label, empty list, dense data, mobile, hover/focus/disabled/loading/error."
+      "Bắt đầu từ quy trình lặp lại, cách quét thông tin, gánh nặng ra quyết định và cách người dùng phục hồi sau lỗi.",
+      "Dùng token và thư viện component hiện có trước; nếu phá quy ước phải có lý do UX rõ ràng.",
+      "Thiết kế cho nội dung thật: nhãn dài, danh sách trống, dữ liệu dày, di động cùng trạng thái hover, focus, vô hiệu hóa, đang tải và lỗi."
     ],
     failureModes: [
-      "UI đẹp như mock nhưng không có state matrix, keyboard path, focus management hoặc contrast đủ.",
-      "Card/gradient/decorative layer che mất job chính của tool hoặc dashboard.",
-      "Text overflow, layout shift hoặc icon-only control không tooltip làm experience thiếu polished."
+      "UI đẹp như bản mẫu nhưng thiếu ma trận trạng thái, đường đi bằng bàn phím, quản lý focus hoặc độ tương phản đủ.",
+      "Card, gradient hoặc lớp trang trí che mất công việc chính của công cụ hay dashboard.",
+      "Tràn chữ, layout shift hoặc nút chỉ có biểu tượng mà thiếu tooltip làm trải nghiệm thiếu chỉn chu."
     ],
     gates: [
-      "Có component/state inventory và responsive verification.",
-      "Không có overlap, truncation vô lý, inaccessible focus trap hoặc mobile break.",
-      "Interaction quan trọng có analytics event theo convention hiện có."
+      "Có danh sách component, đầy đủ trạng thái và kết quả kiểm tra trên nhiều kích thước màn hình.",
+      "Không còn chồng lấn, cắt chữ vô lý, focus trap không thể thoát hoặc lỗi trên di động.",
+      "Tương tác quan trọng có sự kiện analytics theo quy ước hiện có."
     ]
   },
   "mobile-platform-engineering": {
-    role: "Review như mobile platform lead chịu trách nhiệm lifecycle, device fragmentation, performance và app-store release.",
+    role: "Rà soát như người dẫn dắt nền tảng di động, chịu trách nhiệm về vòng đời, phân mảnh thiết bị, hiệu năng và release trên app store.",
     heuristics: [
-      "Thiết kế theo lifecycle: cold start, background/foreground, permission denial, offline, deep link và state restoration.",
-      "Device matrix phải phản ánh OS versions, screen sizes, Dynamic Type, TalkBack/VoiceOver và low-memory behavior.",
-      "Release plan gồm signing, provisioning, privacy labels, crash monitoring, phased rollout và rollback/kill switch."
+      "Thiết kế theo vòng đời: cold start, chuyển nền hoặc trở lại, từ chối quyền, offline, deep link và khôi phục trạng thái.",
+      "Ma trận thiết bị phải phản ánh phiên bản hệ điều hành, kích thước màn hình, Dynamic Type, TalkBack hoặc VoiceOver và hành vi khi thiếu bộ nhớ.",
+      "Kế hoạch release gồm ký ứng dụng, provisioning, nhãn quyền riêng tư, theo dõi crash, rollout theo giai đoạn và rollback hoặc kill switch."
     ],
     failureModes: [
-      "Simulator xanh nhưng device thật lag, crash do memory, gesture conflict hoặc permission edge case.",
-      "Network/offline state thiếu retry/backoff/cache nên mobile UX vỡ ngoài văn phòng.",
-      "Store metadata/privacy declaration không khớp behavior nên bị reject hoặc tạo compliance risk."
+      "Simulator chạy tốt nhưng thiết bị thật bị lag, crash do bộ nhớ, xung đột cử chỉ hoặc lỗi ở trường hợp biên của quyền truy cập.",
+      "Trạng thái mạng hoặc offline thiếu retry, backoff và cache khiến UX di động hỏng khi rời mạng ổn định.",
+      "Metadata trên store hoặc khai báo quyền riêng tư không khớp hành vi, dẫn đến bị từ chối hoặc tạo rủi ro tuân thủ."
     ],
     gates: [
-      "Có test matrix across devices/OS và evidence từ device hoặc lý do rõ nếu chỉ simulator.",
-      "Startup, scroll, image memory, battery/network usage và crash-free signal được theo dõi.",
-      "Accessibility và privacy declaration không bị xem như post-release chore."
+      "Có ma trận kiểm thử theo thiết bị và hệ điều hành, cùng bằng chứng từ thiết bị thật hoặc lý do rõ nếu chỉ dùng simulator.",
+      "Theo dõi thời gian khởi động, độ mượt khi cuộn, bộ nhớ ảnh, mức dùng pin và mạng cùng tỷ lệ phiên không crash.",
+      "Khả năng tiếp cận và khai báo quyền riêng tư không bị đẩy thành việc làm sau release."
     ]
   },
   "data-ml-science-workflow": {
-    role: "Làm như data/ML scientist thận trọng về provenance, leakage, uncertainty và reproducibility.",
+    role: "Làm như một nhà khoa học dữ liệu và ML thận trọng về nguồn gốc dữ liệu, rò rỉ dữ liệu, độ bất định và khả năng tái lập.",
     heuristics: [
-      "Định nghĩa hypothesis và decision trước notebook; analysis không thể chứng minh mọi thứ.",
-      "Audit provenance: source, license, freshness, sampling bias, missingness, schema drift, leakage và sensitive fields.",
-      "Đánh giá bằng baseline, confidence interval, calibration, ablation, error analysis và OOD checks."
+      "Xác định giả thuyết và quyết định trước khi mở notebook; một phân tích không thể chứng minh mọi thứ.",
+      "Rà soát nguồn gốc dữ liệu: nguồn, giấy phép, độ mới, sai lệch lấy mẫu, dữ liệu thiếu, schema drift, rò rỉ và trường nhạy cảm.",
+      "Đánh giá bằng baseline, khoảng tin cậy, calibration, ablation, phân tích lỗi và kiểm tra OOD."
     ],
     failureModes: [
-      "Train/test leakage hoặc temporal leakage làm model nhìn tốt nhưng fail trong production.",
-      "Correlation được kể như causality dù thiếu identification strategy hoặc experiment design.",
-      "Notebook phụ thuộc state ẩn, seed không cố định, data version không rõ nên không reproduce được."
+      "Rò rỉ giữa tập train và test hoặc rò rỉ theo thời gian làm model trông tốt nhưng thất bại trên production.",
+      "Tương quan được kể như quan hệ nhân quả dù thiếu chiến lược nhận diện hoặc thiết kế thử nghiệm.",
+      "Notebook phụ thuộc trạng thái ẩn, seed không cố định và phiên bản dữ liệu không rõ nên không thể tái lập."
     ],
     gates: [
-      "Có data dictionary, reproducible environment, seed, versioned inputs và assumption log.",
-      "Findings có uncertainty, caveats, failed approaches và domain sanity checks.",
-      "Không expose medical, financial, proprietary hoặc sensitive data trong public artifacts."
+      "Có từ điển dữ liệu, môi trường có thể tái lập, seed, đầu vào có phiên bản và nhật ký giả định.",
+      "Các phát hiện nêu độ bất định, điểm cần lưu ý, hướng đã thất bại và phép kiểm tra bằng hiểu biết miền.",
+      "Không để lộ dữ liệu y tế, tài chính, độc quyền hoặc nhạy cảm trong tài liệu công khai."
     ]
   }
 };
@@ -1362,769 +1362,959 @@ const vietnameseSkillExpertAddenda: Record<string, VietnameseSkillExpertAddendum
 const vietnameseChecklistCopies: Record<string, LocalizedChecklistCopy> = {
   "ticket-intake-to-start": {
     title: "Từ ticket đến commit đầu tiên",
-    summary: "Checklist biến ticket thành scope, context, plan và bước implementation đầu tiên.",
-    whenToUse: "Dùng trước khi code một task đến từ product, support, design hoặc engineer khác.",
-    tags: ["Ticket", "Scope", "Bắt đầu làm"]
+    summary: "Danh sách giúp biến một ticket thành phạm vi rõ ràng, kế hoạch vừa đủ và bước sửa đầu tiên có thể kiểm chứng.",
+    whenToUse: "Dùng trước khi bắt tay vào một việc đến từ sản phẩm, hỗ trợ, thiết kế hoặc đồng đội kỹ thuật.",
+    tags: ["Hạng mục", "Phạm vi", "Bắt đầu làm"]
   },
   "ai-driven-engineering-foundation-roadmap": {
-    title: "Roadmap nền tảng engineering thời AI",
-    summary: "Roadmap nhiều lớp để xây senior engineering judgment trong thời AI.",
-    whenToUse: "Dùng hằng ngày trước hoặc sau việc kỹ thuật, nhất là task chạm architecture, data, reliability hoặc rollout.",
-    tags: ["Engineering foundation", "Architecture", "Production"]
+    title: "Lộ trình nền tảng kỹ thuật trong thời đại AI",
+    summary: "Lộ trình nhiều lớp để rèn khả năng phán đoán kỹ thuật của một kỹ sư giàu kinh nghiệm khi làm việc cùng AI.",
+    whenToUse: "Dùng trước hoặc sau việc kỹ thuật, nhất là khi công việc chạm tới kiến trúc, dữ liệu, độ tin cậy hoặc rollout.",
+    tags: ["Nền tảng kỹ thuật", "Kiến trúc", "Vận hành thực tế"]
   },
   "engineering-delivery-checklist": {
-    title: "Checklist delivery engineering",
-    summary: "Checklist tám phase từ intake đến post-rollout review.",
-    whenToUse: "Dùng khi task có thể ảnh hưởng architecture, data, traffic, user, production operation hoặc handoff.",
-    tags: ["Task", "Delivery", "Rollout"]
+    title: "Danh sách kiểm tra khi giao phần mềm",
+    summary: "Tám giai đoạn từ lúc nhận việc đến khi theo dõi và rút kinh nghiệm sau rollout.",
+    whenToUse: "Dùng khi thay đổi có thể ảnh hưởng kiến trúc, dữ liệu, lưu lượng, người dùng, vận hành production hoặc việc bàn giao.",
+    tags: ["Công việc", "Bàn giao", "Rollout"]
   },
   "senior-engineer-reflex": {
-    title: "Senior engineer reflex",
-    summary: "Bộ câu hỏi compact cho mọi feature: business, product, domain, API, data, consistency, resilience, security, observability và rollout.",
-    whenToUse: "Dùng trước implementation khi task nhìn có vẻ đơn giản nhưng có thể ẩn risk production, data hoặc user.",
-    tags: ["Senior reflex", "Câu hỏi", "Risk"]
+    title: "Những câu hỏi của Senior Engineer",
+    summary: "Bộ câu hỏi gọn cho mọi tính năng, từ nhu cầu kinh doanh và domain đến API, dữ liệu, tính nhất quán, bảo mật, observability và rollout.",
+    whenToUse: "Dùng trước khi triển khai một việc tưởng đơn giản nhưng có thể ẩn rủi ro với production, dữ liệu hoặc người dùng.",
+    tags: ["Kỹ sư giàu kinh nghiệm", "Câu hỏi", "Rủi ro"]
   },
   "capstone-production-project": {
-    title: "Capstone production project",
-    summary: "Lab dài hạn mô phỏng e-commerce, subscription hoặc booking để gom architecture, data, resilience, event và observability.",
-    whenToUse: "Dùng như lab thực chiến để biến roadmap thành evidence và năng lực engineering có thể nhìn thấy.",
-    tags: ["Capstone", "Practice", "Portfolio"]
+    title: "Dự án thực hành cho production",
+    summary: "Bài thực hành dài hạn mô phỏng thương mại điện tử, thuê bao hoặc đặt chỗ để luyện kiến trúc, dữ liệu, chống lỗi, sự kiện và observability.",
+    whenToUse: "Dùng như một phòng lab thực tế để biến kiến thức trong lộ trình thành sản phẩm và bằng chứng năng lực cụ thể.",
+    tags: ["Dự án tổng kết", "Thực hành", "Hồ sơ năng lực"]
   },
   "module-creation": {
     title: "Tạo module mới",
-    summary: "Checklist thêm route, feature module, service module hoặc reusable component mà không leak responsibility.",
-    whenToUse: "Dùng khi thêm một feature surface hoặc reusable module mới.",
-    tags: ["Module", "Architecture", "Frontend", "Backend"]
+    summary: "Danh sách kiểm tra khi thêm route, module tính năng, module dịch vụ hoặc component dùng chung mà vẫn giữ trách nhiệm rõ ràng.",
+    whenToUse: "Dùng khi thêm một phần tính năng hoặc module mới có thể tái sử dụng.",
+    tags: ["Mô-đun", "Kiến trúc", "Frontend", "Backend"]
   },
   "ai-system-engineering-roadmap": {
-    title: "AI system engineering roadmap",
-    summary: "Checklist học hằng ngày cho SDLC ownership, distributed architecture, storage systems và AI-assisted engineering review.",
-    whenToUse: "Dùng như bản đồ up-skill AI hằng ngày khi mục tiêu là ra quyết định kỹ thuật tốt hơn, không chỉ code nhanh hơn.",
-    tags: ["AI up-skill", "System engineering", "Distributed systems", "Storage", "SDLC"]
+    title: "Lộ trình kỹ thuật hệ thống với AI",
+    summary: "Danh sách học hằng ngày về trách nhiệm xuyên suốt SDLC, kiến trúc phân tán, hệ thống lưu trữ và cách dùng AI để rà soát kỹ thuật.",
+    whenToUse: "Dùng như bản đồ học mỗi ngày khi mục tiêu là ra quyết định kỹ thuật tốt hơn, không chỉ viết code nhanh hơn.",
+    tags: ["Kỹ năng AI", "Kỹ thuật hệ thống", "Hệ thống phân tán", "Lưu trữ", "SDLC"]
   },
   "release-readiness": {
-    title: "Release readiness",
-    summary: "Checklist quyết định một change đã đủ sẵn sàng để rời branch hay chưa.",
-    whenToUse: "Dùng trước khi merge, tag hoặc chuẩn bị production deployment.",
+    title: "Kiểm tra trước khi release",
+    summary: "Danh sách giúp quyết định một thay đổi đã đủ an toàn để rời branch hay chưa.",
+    whenToUse: "Dùng trước khi merge, gắn tag hoặc chuẩn bị đưa lên production.",
     tags: ["Release", "QA", "Merge"]
   },
   "rollout-plan": {
     title: "Kế hoạch rollout",
-    summary: "Checklist đưa code đã merge tới production adoption có guardrails.",
-    whenToUse: "Dùng cho staged release, feature flag, customer cohort, migration hoặc UI change có impact lớn.",
-    tags: ["Rollout", "Feature flag", "Monitoring"]
+    summary: "Danh sách đưa code đã merge lên production theo từng bước, có điểm dừng và cách quay lại rõ ràng.",
+    whenToUse: "Dùng cho release theo giai đoạn, feature flag, nhóm người dùng, migration hoặc thay đổi UI có tác động lớn.",
+    tags: ["Rollout", "Feature flag", "Theo dõi"]
   },
   "daily-ai-learning-loop": {
     title: "Vòng học AI hằng ngày",
-    summary: "Một loop ngắn mỗi ngày: một practice hữu ích, một artifact được lưu và một review.",
-    whenToUse: "Dùng mỗi sáng và tối khi muốn compound AI skill đều mà không quá tải ngày làm việc.",
-    tags: ["Daily", "AI learning", "Habit"]
+    summary: "Một nhịp học ngắn mỗi ngày: thử một điều hữu ích, lưu lại một sản phẩm và dành ít phút nhìn lại.",
+    whenToUse: "Dùng vào đầu và cuối ngày khi muốn rèn kỹ năng AI đều đặn mà không làm ngày làm việc quá tải.",
+    tags: ["Hằng ngày", "Học AI", "Thói quen"]
   },
   "weekly-ai-os-review": {
-    title: "Weekly AI OS review",
-    summary: "Review tuần cho công việc, học tập, tài chính, cuộc sống và workflow AI cần tích lũy.",
-    whenToUse: "Dùng cuối tuần để biến việc dùng AI rời rạc thành hệ thống có thể dùng lại.",
-    tags: ["Weekly review", "Life OS", "Career"]
+    title: "Tổng kết hệ thống làm việc với AI hằng tuần",
+    summary: "Buổi nhìn lại công việc, học tập, tài chính, cuộc sống và những quy trình AI đáng giữ lại.",
+    whenToUse: "Dùng cuối tuần để biến những lần dùng AI rời rạc thành cách làm có thể lặp lại.",
+    tags: ["Tổng kết tuần", "Hệ thống cá nhân", "Nghề nghiệp"]
   },
   "ai-tool-routing-decision-tree": {
-    title: "Decision tree chọn AI tool",
-    summary: "Checklist chọn NotebookLM, GPT, Claude, Codex hoặc Antigravity trước khi bắt đầu.",
-    whenToUse: "Dùng khi task mơ hồ, lớn hoặc dễ rơi vào việc hỏi mọi AI tool cùng lúc.",
-    tags: ["Tool routing", "Decision", "Guardrails"]
+    title: "Cây quyết định chọn công cụ AI",
+    summary: "Danh sách giúp chọn NotebookLM, GPT, Claude, Codex hoặc Antigravity trước khi bắt đầu.",
+    whenToUse: "Dùng khi công việc còn mơ hồ, khá lớn hoặc dễ dẫn tới việc hỏi mọi công cụ AI cùng lúc.",
+    tags: ["Chọn công cụ", "Quyết định", "Nguyên tắc an toàn"]
   },
   "ai-assisted-feature-workflow": {
-    title: "Workflow feature có AI hỗ trợ",
-    summary: "Workflow đầy đủ từ idea đến spec, implementation, review, rollout và knowledge archive.",
-    whenToUse: "Dùng cho product hoặc engineering change có ý nghĩa, nơi nhiều AI tool có thể hỗ trợ mà không mất ownership.",
-    tags: ["Feature", "GPT", "Claude", "Codex", "Antigravity"]
+    title: "Quy trình làm tính năng có AI hỗ trợ",
+    summary: "Quy trình đầy đủ từ ý tưởng, đặc tả và triển khai đến rà soát, rollout rồi lưu lại kiến thức.",
+    whenToUse: "Dùng cho thay đổi sản phẩm hoặc kỹ thuật đáng kể, khi nhiều công cụ AI cùng hỗ trợ nhưng người làm vẫn giữ trách nhiệm cuối cùng.",
+    tags: ["Tính năng", "GPT", "Claude", "Codex", "Antigravity"]
   },
   "ninety-day-ai-skill-plan": {
-    title: "Kế hoạch nâng AI skill 90 ngày",
-    summary: "Kế hoạch theo phase để biến AI tool thành practice hằng ngày, engineering leverage, career asset và personal OS.",
-    whenToUse: "Dùng như quarterly roadmap để tăng AI literacy và biến stack hiện có thành leverage bền.",
-    tags: ["90 ngày", "Roadmap", "AI literacy"]
+    title: "Kế hoạch nâng kỹ năng AI trong 90 ngày",
+    summary: "Kế hoạch theo từng giai đoạn để biến công cụ AI thành thói quen làm việc, năng lực kỹ thuật, tài sản nghề nghiệp và hệ thống cá nhân.",
+    whenToUse: "Dùng như lộ trình cho một quý để hiểu AI sâu hơn và khai thác tốt bộ công cụ đang có.",
+    tags: ["90 ngày", "Lộ trình", "Hiểu biết về AI"]
   }
 };
 
 const vietnameseSectionCopies: Record<string, LocalizedSectionCopy> = {
-  understand: { title: "Hiểu task", detail: "Đảm bảo đây là một vấn đề thật, không chỉ là một yêu cầu đổi UI hoặc đổi code." },
-  prepare: { title: "Chuẩn bị trước khi làm", detail: "Giảm uncertainty trước khi mở rộng phạm vi đọc file." },
-  execute: { title: "Bắt đầu implementation", detail: "Giữ thay đổi đầu tiên nhỏ, rõ và dễ review." },
-  "code-design": { title: "Layer 1: Nền tảng thiết kế code", detail: "Xây codebase dễ test, refactor và dễ hướng dẫn AI mà không phá architecture." },
-  "data-consistency": { title: "Layer 2: Data và consistency", detail: "Nhiều vấn đề production đến từ data model, migration, query hoặc consistency assumption yếu." },
-  "distributed-resilience": { title: "Layer 3: Distributed systems và resilience", detail: "Dependency có thể fail nhưng hệ thống không nhất thiết phải sập dây chuyền." },
-  "events-cqrs": { title: "Layer 4: Event-driven architecture, CQRS và Event Sourcing", detail: "Chỉ dùng event khi phù hợp domain và vận hành, không dùng vì nghe advanced." },
-  "performance-observability": { title: "Layer 5: Performance, cache và production operation", detail: "Reliability cần signal trước rollout, không chỉ fix sau khi user than phiền." },
-  intake: { title: "Phase 1: Intake", detail: "Hiểu vấn đề thật trước khi chọn shape kỹ thuật." },
-  discovery: { title: "Phase 2: Discovery", detail: "Map hệ thống hiện tại trước khi thay đổi." },
-  design: { title: "Phase 3: Design", detail: "So sánh option và chọn design đơn giản nhất xử lý đúng risk." },
-  "implementation-plan": { title: "Phase 4: Implementation plan", detail: "Biến design thành các PR nhỏ có thể review." },
-  "coding-review": { title: "Phase 5: Coding và review", detail: "Giữ implementation đúng boundary và behavior production." },
-  "pre-rollout": { title: "Phase 6: Verification trước rollout", detail: "Chứng minh feature chịu được happy path và failure path." },
-  rollout: { title: "Phase 7: Rollout", detail: "Release từng bước nhỏ và theo dõi user impact." },
-  "post-rollout": { title: "Phase 8: Post-rollout", detail: "Biến delivery thành learning và system memory." },
-  "business-product-domain": { title: "Business, product và domain", detail: "Nối implementation với outcome thật." },
-  "api-data-consistency": { title: "API, data và consistency", detail: "Làm rõ contract và state change." },
-  "resilience-security": { title: "Resilience và security", detail: "Giả định dependency và user có thể hành xử ngoài dự đoán." },
-  "observability-rollout": { title: "Observability và rollout", detail: "Quyết định hệ thống chứng minh health bằng signal nào." },
-  "feature-set": { title: "Product surface", detail: "Chọn domain buộc phải xử lý trade-off production thật." },
-  "foundation-requirements": { title: "Foundation requirements", detail: "Chứng minh hệ thống có boundary và data decision rõ." },
-  "resilience-events": { title: "Resilience và events", detail: "Practice failure path thể hiện senior judgment." },
-  "production-requirements": { title: "Production requirements", detail: "Vận hành lab như một hệ thống thật, không chỉ demo." },
-  boundary: { title: "Định nghĩa boundary", detail: "Một module nên có một lý do chính để thay đổi." },
-  frontend: { title: "Frontend checks", detail: "Giữ UI ổn định, accessible và đo lường được." },
-  backend: { title: "Backend checks", detail: "Làm rõ contract trước khi implementation detail lan rộng." },
-  verification: { title: "Verification", detail: "Module chưa xong nếu sau này không thể thay đổi an toàn." },
-  "sdlc-ownership": { title: "Pillar 1: SDLC ownership", detail: "Giữ ownership của con người rõ ràng trong khi AI tăng tốc implementation." },
-  "distributed-resilience-advanced": { title: "Pillar 2: Distributed architecture và resilience", detail: "Học pattern giúp system đúng khi state, time và dependency trở nên phức tạp." },
-  "storage-scale": { title: "Pillar 3: Large-scale storage", detail: "Xây trực giác về storage cho performance, availability và data evolution an toàn." },
-  "ai-engineering-review": { title: "Pillar 4: Professional AI engineering workflow", detail: "Dùng AI như analyst, critic, test strategist và production reviewer, nhưng judgment cuối vẫn là của mình." },
-  quality: { title: "Quality gate", detail: "Xác nhận change đúng, có test và review được." },
-  risk: { title: "Risk gate", detail: "Làm release có thể rollback và quan sát được." },
-  handoff: { title: "Handoff", detail: "Để lại đủ context cho reviewer và operator." },
-  "during-rollout": { title: "Trong rollout", detail: "Đi từng bước nhỏ và theo dõi leading indicators." },
-  "after-rollout": { title: "Sau rollout", detail: "Đóng loop thay vì chỉ ship code." },
-  "morning-orientation": { title: "Định hướng buổi sáng", detail: "Chọn một practice AI phù hợp với việc thật trong ngày." },
-  "workday-application": { title: "Áp dụng trong ngày làm việc", detail: "Học qua task thật thay vì chỉ xem tool." },
-  "evening-review": { title: "Review buổi tối", detail: "Đóng loop khi context còn mới." },
-  "capture-week": { title: "Capture tuần", detail: "Gom đủ fact để không review chỉ bằng trí nhớ." },
-  "review-patterns": { title: "Review pattern", detail: "Tìm signal lặp lại, không chỉ task đã xong." },
-  "plan-next-week": { title: "Plan tuần tới", detail: "Biến reflection thành operating plan nhỏ." },
-  "choose-first-tool": { title: "Chọn tool đầu tiên", detail: "Bắt đầu bằng tool khớp với bottleneck chính." },
-  safety: { title: "Safety guardrails", detail: "Bảo vệ secrets, production và judgment." },
-  shape: { title: "Shape công việc", detail: "Dùng AI để clarify bài toán trước khi giao implementation." },
-  "review-release": { title: "Review và release", detail: "Tách execution khỏi review và release judgment." },
-  "week-one": { title: "Tuần 1: setup hệ thống", detail: "Tạo container trước khi tối ưu workflow." },
-  "days-eight-thirty": { title: "Ngày 8-30: productivity công việc", detail: "Biến việc lặp lại thành playbook." },
-  "days-thirty-one-sixty": { title: "Ngày 31-60: career leverage", detail: "Chuyển việc làm thành evidence và asset." },
-  "days-sixty-one-ninety": { title: "Ngày 61-90: life, finance, future", detail: "Mở rộng operating system ra ngoài code." }
+  understand: { title: "Hiểu yêu cầu", detail: "Xác nhận đây là vấn đề cần giải quyết, không chỉ là yêu cầu đổi giao diện hoặc sửa code." },
+  prepare: { title: "Chuẩn bị trước khi làm", detail: "Làm rõ phần chưa biết trước khi đọc thêm nhiều file." },
+  execute: { title: "Bắt đầu thực hiện", detail: "Giữ thay đổi đầu tiên nhỏ, rõ và dễ rà soát." },
+  "code-design": { title: "Lớp 1: Nền tảng thiết kế code", detail: "Xây codebase dễ test, refactor và dễ hướng dẫn AI mà không phá vỡ kiến trúc." },
+  "data-consistency": { title: "Lớp 2: Dữ liệu và tính nhất quán", detail: "Nhiều lỗi production bắt nguồn từ mô hình dữ liệu, migration, truy vấn hoặc giả định sai về tính nhất quán." },
+  "distributed-resilience": { title: "Lớp 3: Hệ thống phân tán và khả năng chống lỗi", detail: "Một dependency có thể lỗi mà hệ thống không nhất thiết phải sập theo dây chuyền." },
+  "events-cqrs": { title: "Lớp 4: Kiến trúc hướng sự kiện, CQRS và Event Sourcing", detail: "Chỉ dùng sự kiện khi phù hợp với domain và năng lực vận hành, không dùng chỉ vì nghe hiện đại." },
+  "performance-observability": { title: "Lớp 5: Hiệu năng, cache và vận hành production", detail: "Độ tin cậy cần được đo trước rollout, không phải chờ người dùng phản ánh mới sửa." },
+  intake: { title: "Giai đoạn 1: Tiếp nhận", detail: "Hiểu đúng vấn đề trước khi chọn giải pháp kỹ thuật." },
+  discovery: { title: "Giai đoạn 2: Khảo sát", detail: "Vẽ lại hệ thống hiện tại trước khi thay đổi." },
+  design: { title: "Giai đoạn 3: Thiết kế", detail: "So sánh các phương án và chọn thiết kế đơn giản nhất xử lý đúng rủi ro." },
+  "implementation-plan": { title: "Giai đoạn 4: Kế hoạch triển khai", detail: "Chia thiết kế thành các PR nhỏ, rõ và dễ rà soát." },
+  "coding-review": { title: "Giai đoạn 5: Viết code và rà soát", detail: "Giữ phần triển khai đúng ranh giới và đúng hành vi trên production." },
+  "pre-rollout": { title: "Giai đoạn 6: Kiểm chứng trước rollout", detail: "Chứng minh tính năng chạy đúng cả luồng bình thường lẫn tình huống lỗi." },
+  rollout: { title: "Giai đoạn 7: Rollout", detail: "Release theo từng bước nhỏ và theo dõi tác động tới người dùng." },
+  "post-rollout": { title: "Giai đoạn 8: Sau rollout", detail: "Biến kết quả bàn giao thành bài học và tri thức chung của đội ngũ." },
+  "business-product-domain": { title: "Kinh doanh, sản phẩm và domain", detail: "Nối phần triển khai với kết quả thật cần tạo ra." },
+  "api-data-consistency": { title: "API, dữ liệu và tính nhất quán", detail: "Làm rõ contract và cách trạng thái thay đổi." },
+  "resilience-security": { title: "Khả năng chống lỗi và bảo mật", detail: "Giả định dependency và người dùng có thể hành xử ngoài dự đoán." },
+  "observability-rollout": { title: "Observability và rollout", detail: "Chọn tín hiệu để hệ thống tự chứng minh đang khỏe hay có vấn đề." },
+  "feature-set": { title: "Phạm vi sản phẩm", detail: "Chọn domain buộc người làm phải xử lý những đánh đổi thật trên production." },
+  "foundation-requirements": { title: "Yêu cầu nền tảng", detail: "Chứng minh hệ thống có ranh giới và quyết định dữ liệu rõ ràng." },
+  "resilience-events": { title: "Chống lỗi và sự kiện", detail: "Luyện cách xử lý tình huống lỗi để thể hiện phán đoán của kỹ sư giàu kinh nghiệm." },
+  "production-requirements": { title: "Yêu cầu cho production", detail: "Vận hành bài thực hành như một hệ thống thật, không chỉ là bản demo." },
+  boundary: { title: "Định nghĩa ranh giới", detail: "Một module nên có một lý do chính để thay đổi." },
+  frontend: { title: "Kiểm tra frontend", detail: "Giữ UI ổn định, dễ tiếp cận và đo lường được." },
+  backend: { title: "Kiểm tra backend", detail: "Làm rõ contract trước khi chi tiết triển khai lan sang nhiều nơi." },
+  verification: { title: "Kiểm chứng", detail: "Module chưa hoàn tất nếu lần thay đổi sau vẫn không thể thực hiện an toàn." },
+  "sdlc-ownership": { title: "Trụ cột 1: Trách nhiệm xuyên suốt SDLC", detail: "Giữ trách nhiệm của con người rõ ràng trong khi AI tăng tốc triển khai." },
+  "distributed-resilience-advanced": { title: "Trụ cột 2: Kiến trúc phân tán và chống lỗi", detail: "Học các pattern giúp hệ thống vẫn đúng khi trạng thái, thời gian và dependency trở nên phức tạp." },
+  "storage-scale": { title: "Trụ cột 3: Hệ thống lưu trữ quy mô lớn", detail: "Xây trực giác về lưu trữ để cân bằng hiệu năng, tính sẵn sàng và thay đổi dữ liệu an toàn." },
+  "ai-engineering-review": { title: "Trụ cột 4: Quy trình kỹ thuật chuyên nghiệp với AI", detail: "Dùng AI để phân tích, phản biện và xây chiến lược test, nhưng giữ phán đoán cuối cùng ở người làm." },
+  quality: { title: "Cổng chất lượng", detail: "Xác nhận thay đổi đúng, có test và đủ rõ để rà soát." },
+  risk: { title: "Risk gate", detail: "Bảo đảm release có observability và rollback rõ ràng." },
+  handoff: { title: "Bàn giao", detail: "Để lại đủ ngữ cảnh cho người rà soát và người vận hành." },
+  "during-rollout": { title: "Trong rollout", detail: "Đi theo từng bước nhỏ và theo dõi những tín hiệu xuất hiện sớm." },
+  "after-rollout": { title: "Sau rollout", detail: "Khép lại đầy đủ thay vì dừng ngay sau khi đưa code lên." },
+  "morning-orientation": { title: "Định hướng buổi sáng", detail: "Chọn một cách dùng AI phù hợp với việc thật trong ngày." },
+  "workday-application": { title: "Áp dụng trong ngày làm việc", detail: "Học qua công việc thật thay vì chỉ xem công cụ." },
+  "evening-review": { title: "Nhìn lại buổi tối", detail: "Khép lại bài học khi ngữ cảnh vẫn còn mới." },
+  "capture-week": { title: "Ghi lại tuần vừa qua", detail: "Thu thập đủ dữ kiện để không tổng kết chỉ bằng trí nhớ." },
+  "review-patterns": { title: "Tìm điều lặp lại", detail: "Tìm những tín hiệu lặp lại, không chỉ đếm việc đã xong." },
+  "plan-next-week": { title: "Lên kế hoạch tuần tới", detail: "Biến phần nhìn lại thành một kế hoạch nhỏ có thể thực hiện." },
+  "choose-first-tool": { title: "Chọn công cụ đầu tiên", detail: "Bắt đầu bằng công cụ khớp với điểm nghẽn chính." },
+  safety: { title: "Nguyên tắc an toàn", detail: "Bảo vệ bí mật, production và quyền phán đoán của con người." },
+  shape: { title: "Định hình công việc", detail: "Dùng AI để làm rõ bài toán trước khi giao phần triển khai." },
+  "review-release": { title: "Rà soát và release", detail: "Tách người thực hiện khỏi bước rà soát và quyết định release." },
+  "week-one": { title: "Tuần 1: thiết lập hệ thống", detail: "Tạo nơi lưu trữ và cách làm cơ bản trước khi tối ưu quy trình." },
+  "days-eight-thirty": { title: "Ngày 8-30: làm việc hiệu quả hơn", detail: "Biến việc lặp lại thành cách làm có thể dùng lại." },
+  "days-thirty-one-sixty": { title: "Ngày 31-60: tạo giá trị nghề nghiệp", detail: "Chuyển việc đã làm thành bằng chứng và tài sản có thể dùng lâu dài." },
+  "days-sixty-one-ninety": { title: "Ngày 61-90: cuộc sống, tài chính và tương lai", detail: "Mở rộng hệ thống làm việc ra ngoài phạm vi code." }
+};
+
+const vietnameseContextualSectionCopies: Record<string, LocalizedSectionCopy> = {
+  "ticket-intake-to-start/execute": {
+    title: "Bắt đầu thực hiện",
+    detail: "Giữ thay đổi đầu tiên nhỏ, rõ và dễ review."
+  },
+  "ai-assisted-feature-workflow/execute": {
+    title: "Thực hiện",
+    detail: "Dùng đúng agent cho đúng loại công việc."
+  },
+  "engineering-delivery-checklist/pre-rollout": {
+    title: "Giai đoạn 6: Kiểm chứng trước rollout",
+    detail: "Chứng minh tính năng chạy đúng cả luồng bình thường lẫn tình huống lỗi."
+  },
+  "rollout-plan/pre-rollout": {
+    title: "Trước rollout",
+    detail: "Chuẩn bị môi trường, nhóm người dùng và phương án dự phòng."
+  },
+  "release-readiness/handoff": {
+    title: "Bàn giao",
+    detail: "Để lại đủ ngữ cảnh cho người review và người vận hành."
+  },
+  "ai-tool-routing-decision-tree/handoff": {
+    title: "Bàn giao giữa các công cụ",
+    detail: "Chỉ chuyển phần ngữ cảnh hữu ích, không bê nguyên cả cuộc trò chuyện."
+  }
 };
 
 const vietnameseStepCopies: Record<string, LocalizedStepCopy> = {
-  "read-ticket": { label: "Đọc ticket và restate mục tiêu trong một câu." },
-  "identify-user": { label: "Xác định user, route, workflow hoặc system boundary bị ảnh hưởng." },
-  acceptance: { label: "Tách acceptance criteria rõ ràng và đánh dấu phần còn thiếu." },
-  impact: { label: "Kiểm tra ảnh hưởng product, SEO, analytics, locale, accessibility và privacy." },
-  "find-patterns": { label: "Tìm pattern, test, helper và ownership boundary gần nhất." },
-  "decide-scope": { label: "Tách must-have khỏi nice-to-have cleanup." },
-  "plan-verification": { label: "Chọn command, screenshot hoặc manual check chứng minh task đã đúng." },
-  "note-risk": { label: "Ghi assumption rủi ro nhất trước khi implement." },
-  "small-diff": { label: "Bắt đầu bằng edit nhỏ nhất có thể review." },
-  "update-tests": { label: "Thêm hoặc sửa test tại đúng boundary thay đổi behavior." },
-  "update-tracking": { label: "Cập nhật PostHog khi thêm navigation, CTA, filter, form, preference hoặc route mới." },
-  checkpoint: { label: "Checkpoint nếu scope hoặc risk thay đổi." },
-  principles: { label: "Học SOLID, DRY, KISS, YAGNI, dependency direction và refactoring patterns." },
-  architecture: { label: "Practice Clean Architecture, Hexagonal Architecture, Onion Architecture và Modular Monolith trước microservices." },
-  ddd: { label: "Học DDD tactical patterns.", detail: "Entity, Value Object, Aggregate, Repository, Domain Service và Application Service." },
-  patterns: { label: "Xây pattern catalog theo ngữ cảnh.", detail: "Creational, structural, behavioral, enterprise, integration, resilience và delivery patterns." },
-  tests: { label: "Chọn testing layer đúng.", detail: "Unit, integration, contract, E2E, property-based, migration và rollback tests." },
-  modeling: { label: "Học relational modeling, constraints, normalization, denormalization, multi-tenant data, soft delete và temporal data." },
-  transactions: { label: "Hiểu ACID, isolation levels, locks, deadlocks và transaction boundaries." },
-  indexes: { label: "Practice indexing bằng evidence.", detail: "B-tree, composite, covering, partial, expression, GIN, GiST, SP-GiST, BRIN và EXPLAIN ANALYZE." },
-  migration: { label: "Thiết kế data migration và rollback trước khi code lands." },
-  replication: { label: "Học replication và availability.", detail: "Primary-replica, async lag, read-after-write, failover, split brain, RPO, RTO và disaster recovery." },
-  timeouts: { label: "Set timeout trước retry." },
-  retry: { label: "Dùng bounded retry với exponential backoff và jitter khi operation an toàn." },
-  "circuit-breaker": { label: "Hiểu Circuit Breaker sâu.", detail: "Closed, open, half-open, sliding windows, slow-call threshold, fallback và exception classification." },
-  bulkhead: { label: "Dùng Bulkhead, rate limiting, throttling, backpressure, fallback và graceful degradation khi cần." },
-  idempotency: { label: "Thiết kế idempotency, deduplication, distributed lock, DLQ và queue-based load leveling." },
-  "event-types": { label: "So sánh direct API call, queue, pub/sub, log stream, Event Sourcing và CDC." },
-  "event-sourcing": { label: "Học Event Sourcing sâu.", detail: "Domain event, event store, aggregate stream, append-only log, projection, snapshot, replay và event versioning." },
-  cqrs: { label: "Hiểu CQRS flow.", detail: "Command, handler, aggregate, event, projection handler, read model và query." },
-  outbox: { label: "Dùng Transactional Outbox, Inbox, Idempotent Consumer, Saga, DLQ, schema versioning và Anti-Corruption Layer khi vấn đề cần." },
-  "avoid-overuse": { label: "Tránh Event Sourcing cho CRUD đơn giản hoặc team chưa vận hành được event schema/projection." },
+  "read-ticket": { label: "Đọc ticket rồi diễn đạt lại mục tiêu bằng một câu." },
+  "identify-user": { label: "Xác định người dùng, route, quy trình hoặc ranh giới hệ thống bị ảnh hưởng." },
+  acceptance: { label: "Tách rõ tiêu chí nghiệm thu và đánh dấu phần còn thiếu." },
+  impact: { label: "Kiểm tra tác động tới sản phẩm, SEO, analytics, locale, khả năng tiếp cận và quyền riêng tư." },
+  "find-patterns": { label: "Tìm pattern, test, helper và ranh giới trách nhiệm gần nhất trong codebase." },
+  "decide-scope": { label: "Tách phần bắt buộc khỏi việc dọn dẹp chỉ nên làm thêm." },
+  "plan-verification": { label: "Chọn lệnh, ảnh chụp hoặc bước kiểm tra thủ công để chứng minh thay đổi đã đúng." },
+  "note-risk": { label: "Ghi lại giả định rủi ro nhất trước khi triển khai." },
+  "small-diff": { label: "Bắt đầu bằng thay đổi nhỏ nhất có thể rà soát." },
+  "update-tests": { label: "Thêm hoặc sửa test tại đúng ranh giới có hành vi thay đổi." },
+  "update-tracking": { label: "Cập nhật PostHog khi thêm điều hướng, CTA, bộ lọc, form, tùy chọn hoặc route mới." },
+  checkpoint: { label: "Dừng lại kiểm tra nếu phạm vi hoặc mức rủi ro thay đổi." },
+  principles: { label: "Học SOLID, DRY, KISS, YAGNI, hướng dependency và các pattern refactor." },
+  architecture: { label: "Thực hành Clean Architecture, Hexagonal Architecture, Onion Architecture và Modular Monolith trước khi nghĩ tới microservices." },
+  ddd: { label: "Học các pattern chiến thuật của DDD.", detail: "Entity, Value Object, Aggregate, Repository, Domain Service và Application Service." },
+  patterns: { label: "Xây danh mục pattern theo từng hoàn cảnh.", detail: "Nhóm khởi tạo, cấu trúc, hành vi, doanh nghiệp, tích hợp, chống lỗi và bàn giao." },
+  tests: { label: "Chọn đúng tầng kiểm thử.", detail: "Unit, integration, contract, E2E, property-based, migration và rollback test." },
+  unit: { label: "Viết unit test cho logic thuần và các trường hợp biên của module." },
+  integration: { label: "Viết integration test cho contract, persistence và điểm nối giữa các thành phần." },
+  modeling: { label: "Học mô hình quan hệ, constraint, chuẩn hóa, phi chuẩn hóa, dữ liệu đa tenant, soft delete và dữ liệu theo thời gian." },
+  transactions: { label: "Hiểu ACID, mức cô lập, lock, deadlock và ranh giới transaction." },
+  indexes: { label: "Đánh giá index bằng số liệu thực tế.", detail: "B-tree, composite, covering, partial, expression, GIN, GiST, SP-GiST, BRIN và EXPLAIN ANALYZE." },
+  migration: {
+    label: "Thiết kế migration dữ liệu và cách rollback trước khi code được merge.",
+    detail: "Backfill, tạo index online, CDC, audit log, backup/restore và khả năng tương thích."
+  },
+  replication: { label: "Học replication và tính sẵn sàng.", detail: "Primary-replica, độ trễ async, read-after-write, failover, split brain, RPO, RTO và khôi phục thảm họa." },
+  timeouts: { label: "Đặt timeout trước khi thêm retry." },
+  retry: { label: "Chỉ retry trong giới hạn, có exponential backoff và jitter khi thao tác đủ an toàn." },
+  "circuit-breaker": { label: "Hiểu sâu Circuit Breaker.", detail: "Trạng thái closed, open, half-open, cửa sổ đo, ngưỡng chậm, fallback và phân loại lỗi." },
+  bulkhead: { label: "Dùng Bulkhead, rate limiting, throttling, backpressure, fallback và graceful degradation khi thực sự cần." },
+  idempotency: { label: "Thiết kế idempotency, chống trùng, distributed lock, DLQ và san tải qua queue." },
+  "event-types": { label: "So sánh gọi API trực tiếp, queue, pub/sub, log stream, Event Sourcing và CDC." },
+  "event-sourcing": { label: "Học sâu Event Sourcing.", detail: "Domain event, event store, aggregate stream, log chỉ ghi thêm, projection, snapshot, replay và version sự kiện." },
+  cqrs: { label: "Hiểu luồng CQRS.", detail: "Command, handler, aggregate, event, projection handler, read model và query." },
+  outbox: { label: "Dùng Transactional Outbox, Inbox, Idempotent Consumer, Saga, DLQ, version schema và Anti-Corruption Layer khi bài toán cần." },
+  "avoid-overuse": { label: "Không dùng Event Sourcing cho CRUD đơn giản hoặc khi đội chưa đủ sức vận hành schema sự kiện và projection." },
   cache: { label: "Học cache-aside, read-through, write-through, write-behind, TTL, eviction, stampede, hot key, CDN và materialized view." },
-  scale: { label: "Practice pagination, batch processing, async jobs, load tests và đo p50/p95/p99 latency." },
-  otel: { label: "Dùng khái niệm OpenTelemetry.", detail: "Metrics, logs, traces, correlation ID, distributed tracing và spans." },
-  slo: { label: "Học SLI, SLO, SLA, error budget, RED/USE metrics, alert, runbook, incident và postmortem." },
-  "well-architected": { label: "Review operational excellence, security, reliability, performance efficiency, cost và sustainability." },
-  business: { label: "Nêu business hoặc user problem và success metric." },
-  scope: { label: "Clarify scope, out-of-scope, deadline, priority và affected users." },
-  constraints: { label: "Kiểm tra dependency, security, privacy, legal, data migration, backward compatibility và production traffic impact." },
-  questions: { label: "Nhờ AI đặt câu hỏi clarification theo business, product, data, API, security, reliability, rollout và observability." },
-  flow: { label: "Xác định service, route, job, API, event, data store, owner và pattern hiện có." },
-  history: { label: "Kiểm tra incident, bottleneck, dashboard, log và legacy constraint liên quan." },
-  "risk-register": { label: "Nhờ AI tạo dependency map, impacted components, integration points, risk và missing information." },
-  adr: { label: "Tạo ADR khi decision ảnh hưởng architecture, data, dependency hoặc rollout." },
-  options: { label: "So sánh ít nhất ba option theo complexity, scalability, consistency, cost, migration, rollback và maintainability." },
-  "technical-decisions": { label: "Quyết định sync/async, CRUD/CQRS/Event Sourcing, index, transaction boundary, cache, idempotency, retry, Circuit Breaker và security model." },
-  slice: { label: "Chia việc theo backend, database, API contract, tests, observability, rollout và documentation." },
-  compatibility: { label: "Plan migration, feature flag, backward-compatible API, monitoring, rollback và owner review." },
-  "test-plan": { label: "Định nghĩa unit, integration, contract, E2E, load, security, migration và rollback checks." },
-  boundaries: { label: "Kiểm tra architecture boundary, transaction boundary, validation, error handling và ownership." },
-  "side-effects": { label: "Đảm bảo retry không tạo duplicate side effect và sensitive data không bị log." },
-  review: { label: "Nhờ AI review như principal engineer về correctness, race, consistency, security, observability, performance, maintainability và rollback risk." },
-  signals: { label: "Chuẩn bị dashboard, alert, runbook, rollback path và customer impact checks." },
-  readiness: { label: "Nhờ AI tạo production readiness checklist với failure scenarios, monitoring, abort criteria, rollback và data validation." },
-  "dark-launch": { label: "Deploy dark nếu có thể, rồi bật internal users trước canary." },
-  monitor: { label: "Theo dõi success metric, error rate, latency, DB load, query plan, queue lag, cache hit/miss và support signal." },
-  abort: { label: "Định nghĩa success criteria, abort criteria, rollback owner, communication plan và kill switch." },
-  outcome: { label: "So sánh expected metrics với actual outcome, regression, incident, near miss và alert noise." },
-  docs: { label: "Cập nhật docs, ADR, runbook, Studio checklist và follow-up tickets." },
-  learning: { label: "Ghi lại lesson sau rollout để task sau bắt đầu tốt hơn." },
-  product: { label: "Happy path, edge case, undo behavior, pending/failed state và audit need là gì?" },
-  domain: { label: "Entity chính, aggregate boundary, state transition, invariant và domain event là gì?" },
-  api: { label: "API sync hay async, có idempotency, versioning, pagination và backward compatibility không?" },
-  data: { label: "Schema, migration, index, query scale, retention và PII concern là gì?" },
-  consistency: { label: "Cần strong consistency hay eventual consistency, có race hoặc duplicate event không?" },
-  dependency: { label: "Dependency nào có thể fail, chậm hoặc trả partial failure?" },
-  protection: { label: "Timeout, retry, Circuit Breaker, fallback, rate limit và idempotency đã có chưa?" },
-  security: { label: "Ai được dùng, authorization ra sao, input nào cần validate và dữ liệu nào không được log?" },
-  release: { label: "Có feature flag, canary, abort criteria, rollback path, migration rollback và monitoring owner chưa?" },
-  domains: { label: "Build user, catalog, cart, order, payment, inventory, notification, promotion, admin, audit và reporting flows." },
-  evidence: { label: "Lưu ADR, diagram, test evidence, rollout notes và postmortem làm portfolio artifacts." },
-  postgres: { label: "Model PostgreSQL tables, constraints, migrations, indexes, query plans và backup/restore." },
-  payment: { label: "Build payment Saga với Circuit Breaker, fallback và duplicate-payment protection." },
-  dashboard: { label: "Tạo dashboard request rate, errors, latency, DB latency, queue lag, cache hit rate, dependency failure và business metrics." },
-  owner: { label: "Nêu module sở hữu gì và phụ thuộc gì." },
-  inputs: { label: "Định nghĩa inputs, outputs và invalid states." },
-  placement: { label: "Đặt file theo pattern có sẵn thay vì tạo folder style mới." },
-  "public-api": { label: "Expose public API nhỏ và giữ internals private." },
-  states: { label: "Cover UI states." },
-  loading: { label: "Loading hoặc pending state." },
-  empty: { label: "Empty state." },
-  error: { label: "Error hoặc permission state." },
-  mobile: { label: "Mobile và narrow viewport behavior." },
-  tokens: { label: "Dùng token, icon, spacing và card rule có sẵn." },
-  tracking: { label: "Thêm event cho page, CTA, filter, search, preference hoặc outbound khi cần." },
-  a11y: { label: "Kiểm tra label, focus order, keyboard path và contrast." },
-  contract: { label: "Document API/job contract và validation rules." },
-  auth: { label: "Kiểm tra authorization, ownership và audit needs." },
-  observability: { label: "Thêm logs, metrics, alerts và business events nếu user behavior thay đổi." },
-  manual: { label: "Manual check workflow chính và một failure path." },
-  screenshots: { label: "Đính kèm screenshot cho UI changes hoặc nói rõ vì sao không cần." },
-  "ai-paradox": { label: "Theo dõi AI paradox.", detail: "Không merge code phức tạp do AI sinh nếu chưa hiểu mechanism và consequence production." },
-  "productive-friction": { label: "Giữ productive friction trong workflow.", detail: "Dùng manual review, context-seeding và no-AI zones khi học hoặc onboarding." },
-  "nine-phases": { label: "Review 9 phase SDLC.", detail: "Strategy, requirements, architecture, coding, QA, release, observability, maintenance và iteration." },
-  "telemetry-layers": { label: "Map telemetry qua 8 layer.", detail: "Edge/network, service, application, data, Kubernetes, serverless/PaaS, CI/CD và incident response." },
-  "event-sourcing-cqrs": { label: "Học Event Sourcing cộng CQRS như operational model.", detail: "Event store, aggregate stream, snapshot, projection, optimistic concurrency và read model rebuild." },
-  "schema-evolution": { label: "Practice event schema evolution.", detail: "Tolerant deserialization, upcasting, versioned events và hot/warm/cold event storage." },
-  "retry-composition": { label: "Compose retry trước Circuit Breaker có chủ ý.", detail: "Dùng bounded retry với backoff/jitter rồi ghi final outcome vào breaker." },
-  "btree-lsm": { label: "So sánh B-Tree và LSM-Tree.", detail: "Read-heavy in-place update so với write-heavy append-only, compaction và Bloom filters." },
-  "index-mastery": { label: "Master practical indexing.", detail: "Clustered, non-clustered, composite, covering index, leftmost prefix rule và index invalidation." },
-  "replication-consensus": { label: "Học replication và consensus.", detail: "Sync, async, semi-sync, Raft/Multi-Paxos quorum, physical/logical replication và replication slots." },
-  "sharding-transactions": { label: "Học sharding và distributed transactions.", detail: "Consistent hashing, virtual nodes, hotspot mitigation, 2PC trade-off và Saga." },
-  "ai-elicitation": { label: "Nhờ AI clarify requirements trước implementation.", detail: "Group câu hỏi theo business, product, data, API, security, reliability, rollout và observability." },
-  "adversarial-review": { label: "Chạy adversarial architecture review.", detail: "Challenge race condition, consistency bug, security gap, performance bottleneck và failure scenario." },
-  "test-security": { label: "Tạo test và security matrix.", detail: "Unit, integration, contract, E2E, migration, rollback, static security checks và dependency failure paths." },
-  "daily-artifact": { label: "Lưu một learning artifact mỗi ngày.", detail: "ADR, prompt, query plan, resilience note, rollout checklist, runbook hoặc postmortem lesson." },
-  "feature-flag": { label: "Dùng feature flag hoặc staged path khi blast radius cao." },
-  analytics: { label: "Xác nhận PostHog event vẫn fire và event mới đặt tên nhất quán." },
-  rollback: { label: "Viết rollback steps và owner của quyết định." },
-  summary: { label: "PR summary nêu behavior thay đổi và route bị ảnh hưởng." },
-  "target": { label: "Định nghĩa target cohort: internal, beta, percentage, tenant hoặc geography." },
-  flag: { label: "Xác nhận flag/config default và kill switch owner." },
-  baseline: { label: "Ghi baseline metrics, conversion, error rate và support signal." },
-  comms: { label: "Chuẩn bị release note, support note và owner escalation path." },
-  phases: { label: "Roll out theo phase." },
-  "phase-internal": { label: "Internal hoặc dogfood users." },
-  "phase-beta": { label: "Small beta cohort." },
-  "phase-percent": { label: "10%, 25%, 50%, rồi 100% nếu khỏe." },
-  "phase-enterprise": { label: "Named tenants chỉ khi support đã sẵn sàng." },
-  observe: { label: "Theo dõi errors, latency, conversion, PostHog events và support tickets." },
-  pause: { label: "Pause rollout nếu chạm rollback trigger." },
-  log: { label: "Log mỗi phase change với timestamp, owner và reason." },
-  compare: { label: "So sánh post-rollout metrics với baseline." },
-  cleanup: { label: "Gỡ stale flags, temporary code và support workaround." },
-  learn: { label: "Ghi điều làm team bất ngờ." },
-  "follow-up": { label: "Tạo follow-up ticket cho debt, docs và analytics gaps." },
-  energy: { label: "Ghi energy hiện tại, obligations và open loops." },
-  "top-three": { label: "Chọn top 3 outcomes cho ngày." },
-  practice: { label: "Chọn một AI skill để practice.", detail: "Ví dụ: chia task cho Codex tốt hơn, Claude critique, NotebookLM source synthesis hoặc GPT decision framing." },
-  "time-block": { label: "Giữ một time block nhỏ cho practice." },
-  "route-tool": { label: "Route task tới đúng tool trước khi prompt." },
-  "write-prompt": { label: "Viết prompt có role, goal, context, output và guardrails." },
-  "save-artifact": { label: "Lưu một artifact.", detail: "Prompt, checklist, decision note, diff, screenshot hoặc lesson." },
-  "avoid-noise": { label: "Dừng lại nếu AI loop rộng hơn task thật." },
+  scale: { label: "Thực hành phân trang, xử lý theo lô, job bất đồng bộ, load test và đo độ trễ p50/p95/p99." },
+  otel: { label: "Dùng OpenTelemetry đúng mục đích.", detail: "Metric, log, trace, correlation ID, distributed tracing và span." },
+  slo: { label: "Học SLI, SLO, SLA, error budget, RED/USE metrics, cảnh báo, runbook, sự cố và postmortem." },
+  "well-architected": { label: "Rà soát vận hành, bảo mật, độ tin cậy, hiệu năng, chi phí và tính bền vững." },
+  business: { label: "Nêu vấn đề kinh doanh hoặc vấn đề của người dùng cùng chỉ số thành công." },
+  scope: { label: "Làm rõ phạm vi, phần không làm, thời hạn, mức ưu tiên và nhóm người dùng bị ảnh hưởng." },
+  constraints: { label: "Kiểm tra dependency, bảo mật, quyền riêng tư, pháp lý, migration dữ liệu, tương thích ngược và tác động tới lưu lượng production." },
+  questions: { label: "Nhờ AI đặt câu hỏi làm rõ về kinh doanh, sản phẩm, dữ liệu, API, bảo mật, độ tin cậy, rollout và observability." },
+  flow: { label: "Xác định service, route, job, API, sự kiện, kho dữ liệu, người phụ trách và pattern hiện có." },
+  history: { label: "Kiểm tra sự cố, điểm nghẽn, dashboard, log và ràng buộc hệ thống cũ có liên quan." },
+  "risk-register": { label: "Nhờ AI lập bản đồ dependency, thành phần bị ảnh hưởng, điểm tích hợp, rủi ro và thông tin còn thiếu." },
+  adr: { label: "Tạo ADR khi quyết định ảnh hưởng kiến trúc, dữ liệu, dependency hoặc rollout." },
+  options: { label: "So sánh ít nhất ba phương án về độ phức tạp, khả năng mở rộng, tính nhất quán, chi phí, migration, rollback và khả năng bảo trì." },
+  "technical-decisions": { label: "Chốt đồng bộ hay bất đồng bộ, CRUD/CQRS/Event Sourcing, index, ranh giới transaction, cache, idempotency, retry, Circuit Breaker và mô hình bảo mật." },
+  slice: { label: "Chia việc theo backend, database, API contract, test, observability, rollout và tài liệu." },
+  compatibility: { label: "Lập kế hoạch migration, feature flag, API tương thích ngược, theo dõi, rollback và người rà soát." },
+  "test-plan": { label: "Xác định các kiểm tra unit, integration, contract, E2E, tải, bảo mật, migration và rollback." },
+  boundaries: { label: "Kiểm tra ranh giới kiến trúc, transaction, validation, xử lý lỗi và trách nhiệm sở hữu." },
+  "side-effects": { label: "Đảm bảo retry không tạo tác dụng phụ trùng lặp và dữ liệu nhạy cảm không bị ghi log." },
+  review: { label: "Nhờ AI rà soát như một Principal Engineer về tính đúng đắn, race condition, tính nhất quán, bảo mật, observability, hiệu năng, khả năng bảo trì và rủi ro rollback." },
+  signals: { label: "Chuẩn bị dashboard, cảnh báo, runbook, đường rollback và cách kiểm tra tác động tới khách hàng." },
+  readiness: { label: "Nhờ AI tạo danh sách sẵn sàng cho production gồm tình huống lỗi, theo dõi, điều kiện dừng, rollback và kiểm tra dữ liệu." },
+  "dark-launch": { label: "Nếu có thể, deploy ở trạng thái chưa mở cho người dùng rồi bật nội bộ trước khi canary." },
+  monitor: { label: "Theo dõi chỉ số thành công, tỷ lệ lỗi, độ trễ, tải DB, query plan, độ trễ queue, tỷ lệ cache hit/miss và phản hồi hỗ trợ." },
+  abort: { label: "Định nghĩa điều kiện thành công, điều kiện dừng, người quyết định rollback, kế hoạch thông báo và kill switch." },
+  outcome: { label: "So sánh số liệu kỳ vọng với kết quả thực tế, regression, sự cố, lần suýt lỗi và cảnh báo nhiễu." },
+  docs: { label: "Cập nhật tài liệu, ADR, runbook, checklist Studio và ticket theo dõi." },
+  learning: { label: "Ghi lại bài học sau rollout để công việc sau có điểm bắt đầu tốt hơn." },
+  product: { label: "Luồng chính, trường hợp biên, cách hoàn tác, trạng thái chờ/lỗi và nhu cầu audit là gì?" },
+  domain: { label: "Entity chính, ranh giới aggregate, chuyển trạng thái, invariant và domain event là gì?" },
+  api: { label: "API đồng bộ hay bất đồng bộ; đã có idempotency, version, phân trang và tương thích ngược chưa?" },
+  data: { label: "Schema, migration, index, quy mô truy vấn, thời gian lưu và rủi ro PII là gì?" },
+  consistency: { label: "Cần strong consistency hay eventual consistency; có race condition hoặc sự kiện trùng không?" },
+  dependency: { label: "Dependency nào có thể lỗi, phản hồi chậm hoặc chỉ hoàn tất một phần?" },
+  protection: { label: "Đã có timeout, retry, Circuit Breaker, fallback, rate limit và idempotency chưa?" },
+  security: { label: "Ai được phép dùng, authorization ra sao, đầu vào nào cần kiểm tra và dữ liệu nào không được ghi log?" },
+  release: { label: "Đã có feature flag, canary, điều kiện dừng, đường rollback, cách hoàn tác migration và người theo dõi chưa?" },
+  domains: { label: "Xây các luồng người dùng, danh mục, giỏ hàng, đơn hàng, thanh toán, tồn kho, thông báo, khuyến mãi, quản trị, audit và báo cáo." },
+  evidence: { label: "Lưu ADR, sơ đồ, bằng chứng test, ghi chú rollout và postmortem vào hồ sơ năng lực." },
+  postgres: { label: "Mô hình hóa bảng PostgreSQL, constraint, migration, index, query plan và quy trình backup/restore." },
+  payment: { label: "Xây payment Saga có Circuit Breaker, fallback và cơ chế chống thanh toán trùng." },
+  dashboard: { label: "Tạo dashboard theo dõi lượng request, lỗi, độ trễ, DB, queue, tỷ lệ cache hit, lỗi dependency và chỉ số kinh doanh." },
+  rollout: { label: "Dùng feature flag, migration không downtime, load test, runbook, cảnh báo, diễn tập rollback và nhìn lại sau rollout." },
+  owner: { label: "Nêu rõ module chịu trách nhiệm phần nào và phụ thuộc vào đâu." },
+  inputs: { label: "Định nghĩa đầu vào, đầu ra và trạng thái không hợp lệ." },
+  placement: { label: "Đặt file theo pattern đang có thay vì tự tạo một kiểu thư mục mới." },
+  "public-api": { label: "Chỉ mở API công khai vừa đủ và giữ chi tiết bên trong ở chế độ riêng tư." },
+  states: { label: "Bao phủ đầy đủ các trạng thái của UI." },
+  loading: { label: "Trạng thái đang tải hoặc đang chờ." },
+  empty: { label: "Trạng thái chưa có dữ liệu." },
+  error: { label: "Trạng thái lỗi hoặc thiếu quyền." },
+  mobile: { label: "Hành vi trên mobile và màn hình hẹp." },
+  tokens: { label: "Dùng token, icon, khoảng cách và quy tắc card đang có." },
+  tracking: { label: "Thêm event cho trang, CTA, bộ lọc, tìm kiếm, tùy chọn hoặc liên kết ra ngoài khi cần." },
+  a11y: { label: "Kiểm tra nhãn, thứ tự focus, thao tác bàn phím và độ tương phản." },
+  contract: { label: "Ghi rõ contract API/job và quy tắc validation." },
+  auth: { label: "Kiểm tra authorization, quyền sở hữu và nhu cầu audit." },
+  observability: { label: "Thêm log, metric, cảnh báo và sự kiện kinh doanh nếu hành vi người dùng thay đổi." },
+  manual: { label: "Kiểm tra thủ công luồng chính và ít nhất một tình huống lỗi." },
+  screenshots: { label: "Đính kèm ảnh chụp cho thay đổi UI hoặc nói rõ vì sao không cần." },
+  verification: { label: "Danh sách kiểm chứng ghi rõ lệnh cần chạy và bước kiểm tra thủ công." },
+  "ai-paradox": { label: "Để ý nghịch lý khi dùng AI.", detail: "Không merge code phức tạp do AI tạo nếu chưa hiểu cơ chế và hậu quả trên production." },
+  "productive-friction": { label: "Giữ lại những bước chậm cần thiết.", detail: "Rà soát thủ công, cung cấp ngữ cảnh có chủ đích và dành vùng không dùng AI khi học hoặc onboarding." },
+  "nine-phases": { label: "Rà soát chín giai đoạn của SDLC.", detail: "Chiến lược, yêu cầu, kiến trúc, viết code, QA, release, observability, bảo trì và cải tiến." },
+  "telemetry-layers": { label: "Lập bản đồ telemetry qua tám lớp.", detail: "Edge/mạng, service, ứng dụng, dữ liệu, Kubernetes, serverless/PaaS, CI/CD và xử lý sự cố." },
+  "event-sourcing-cqrs": { label: "Học Event Sourcing và CQRS như một mô hình vận hành.", detail: "Event store, aggregate stream, snapshot, projection, optimistic concurrency và dựng lại read model." },
+  "schema-evolution": { label: "Thực hành thay đổi schema sự kiện.", detail: "Tolerant deserialization, upcasting, sự kiện có version và lưu trữ nóng/ấm/lạnh." },
+  "retry-composition": { label: "Sắp xếp retry trước Circuit Breaker có chủ đích.", detail: "Retry trong giới hạn với backoff/jitter, rồi ghi kết quả cuối vào breaker." },
+  "btree-lsm": { label: "So sánh B-Tree và LSM-Tree.", detail: "Cập nhật tại chỗ thiên về đọc so với ghi nối tiếp thiên về ghi, cùng compaction và Bloom filter." },
+  "index-mastery": { label: "Rèn kỹ năng dùng index trong thực tế.", detail: "Clustered, non-clustered, composite, covering index, quy tắc tiền tố trái và lúc index mất tác dụng." },
+  "replication-consensus": { label: "Học replication và consensus.", detail: "Đồng bộ, bất đồng bộ, bán đồng bộ, quorum Raft/Multi-Paxos, replication vật lý/logic và replication slot." },
+  "sharding-transactions": { label: "Học sharding và transaction phân tán.", detail: "Consistent hashing, virtual node, giảm hotspot, đánh đổi của 2PC và Saga." },
+  "ai-elicitation": { label: "Nhờ AI làm rõ yêu cầu trước khi triển khai.", detail: "Nhóm câu hỏi theo kinh doanh, sản phẩm, dữ liệu, API, bảo mật, độ tin cậy, rollout và observability." },
+  "adversarial-review": { label: "Phản biện kiến trúc theo hướng tìm điểm vỡ.", detail: "Thách thức race condition, lỗi nhất quán, lỗ hổng bảo mật, điểm nghẽn hiệu năng và tình huống lỗi." },
+  "test-security": { label: "Tạo ma trận kiểm thử và bảo mật.", detail: "Unit, integration, contract, E2E, migration, rollback, kiểm tra bảo mật tĩnh và lỗi dependency." },
+  "daily-artifact": { label: "Lưu một thành quả học tập mỗi ngày.", detail: "ADR, prompt, query plan, ghi chú chống lỗi, checklist rollout, runbook hoặc bài học postmortem." },
+  "feature-flag": { label: "Dùng feature flag hoặc rollout theo giai đoạn khi phạm vi ảnh hưởng lớn." },
+  analytics: { label: "Xác nhận event PostHog vẫn được gửi và event mới có tên nhất quán." },
+  rollback: { label: "Viết rõ các bước rollback và người có quyền quyết định." },
+  summary: { label: "Phần tóm tắt PR nêu hành vi thay đổi và route bị ảnh hưởng." },
+  "target": { label: "Xác định nhóm rollout: nội bộ, beta, theo tỷ lệ, tenant hoặc khu vực." },
+  flag: { label: "Xác nhận giá trị mặc định của flag/config và người phụ trách kill switch." },
+  baseline: { label: "Ghi số liệu gốc về chuyển đổi, tỷ lệ lỗi và phản hồi hỗ trợ." },
+  comms: { label: "Chuẩn bị release note, ghi chú cho hỗ trợ và đường báo động tới người phụ trách." },
+  phases: { label: "Rollout theo từng giai đoạn." },
+  "phase-internal": { label: "Người dùng nội bộ hoặc nhóm dogfood." },
+  "phase-beta": { label: "Một nhóm beta nhỏ." },
+  "phase-percent": { label: "Mở 10%, 25%, 50%, rồi 100% nếu các tín hiệu vẫn khỏe." },
+  "phase-enterprise": { label: "Chỉ mở cho tenant cụ thể khi đội hỗ trợ đã sẵn sàng." },
+  observe: { label: "Theo dõi lỗi, độ trễ, chuyển đổi, event PostHog và ticket hỗ trợ." },
+  pause: { label: "Tạm dừng rollout khi chạm điều kiện rollback." },
+  log: { label: "Ghi mỗi lần đổi giai đoạn cùng thời điểm, người phụ trách và lý do." },
+  compare: { label: "So sánh số liệu sau rollout với mốc ban đầu." },
+  cleanup: { label: "Gỡ flag cũ, code tạm và những cách xử lý tạm mà đội hỗ trợ đang dùng." },
+  learn: { label: "Ghi lại điều khiến cả đội bất ngờ." },
+  "follow-up": { label: "Tạo ticket theo dõi cho technical debt, tài liệu và phần analytics còn thiếu." },
+  energy: { label: "Ghi mức năng lượng hiện tại, việc bắt buộc và những đầu việc còn mở." },
+  "top-three": { label: "Chọn ba kết quả quan trọng nhất trong ngày." },
+  practice: { label: "Chọn một kỹ năng AI để luyện.", detail: "Ví dụ: chia việc cho Codex rõ hơn, nhờ Claude phản biện, tổng hợp nguồn bằng NotebookLM hoặc dùng GPT để đóng khung quyết định." },
+  "time-block": { label: "Dành một khoảng thời gian nhỏ cho việc luyện tập." },
+  "route-tool": { label: "Chọn đúng công cụ cho công việc trước khi viết prompt." },
+  "write-prompt": { label: "Viết prompt có vai trò, mục tiêu, ngữ cảnh, kết quả mong muốn và nguyên tắc an toàn." },
+  "save-artifact": { label: "Lưu lại một sản phẩm cụ thể.", detail: "Prompt, checklist, ghi chú quyết định, diff, ảnh chụp hoặc bài học." },
+  "avoid-noise": { label: "Dừng lại nếu vòng làm việc với AI rộng hơn việc thật cần giải quyết." },
   done: { label: "Liệt kê việc đã xong, chưa xong và lý do." },
-  "tool-signal": { label: "Ghi tool AI nào giúp và chỗ nào gây nhiễu." },
-  "prompt-improvement": { label: "Viết một cải tiến prompt cho ngày mai." },
-  archive: { label: "Archive lesson vào NotebookLM, ChatGPT Project hoặc Studio." },
-  work: { label: "Tóm tắt shipped work, PRs, blockers, incidents và team moments." },
-  "life-finance": { label: "Ghi health, energy, finance, relationships và admin signals." },
-  sources: { label: "Đưa docs/notes hữu ích vào NotebookLM khi cần source grounding." },
-  "wins-losses": { label: "Viết wins, losses và điều thay đổi từ tuần trước." },
-  avoidance: { label: "Nêu một quyết định hoặc cuộc trò chuyện đang bị né." },
-  "ai-leverage": { label: "Xác định nơi AI tạo leverage và nơi tạo rework." },
-  "hard-truth": { label: "Viết một hard truth ảnh hưởng tuần tới." },
-  priorities: { label: "Chọn top 5 priorities cho tuần tới." },
-  "one-workflow": { label: "Chọn một AI workflow để cải thiện có chủ ý." },
-  "one-artifact": { label: "Commit một artifact nhìn thấy được.", detail: "Blog draft, RFC, automation demo, checklist hoặc portfolio note." },
-  "one-boundary": { label: "Đặt một boundary để bảo vệ attention và data safety." },
-  source: { label: "Nếu câu trả lời phải dựa trên docs/notes upload, bắt đầu bằng NotebookLM." },
-  research: { label: "Nếu cần web research nhiều nguồn, bắt đầu bằng GPT Deep Research." },
-  decision: { label: "Nếu là strategy, planning hoặc trade-off analysis, bắt đầu bằng GPT." },
-  critique: { label: "Nếu cần critique sâu, architecture review hoặc sensitive writing, bắt đầu bằng Claude." },
-  repo: { label: "Nếu task đổi code trong repo, bắt đầu bằng Codex hoặc Claude Code." },
-  prototype: { label: "Nếu task cần UI/browser verification hoặc prototype end-to-end, bắt đầu bằng Antigravity." },
-  brief: { label: "Viết brief ngắn: goal, constraints, sources, acceptance criteria và guardrails." },
-  "execute-review": { label: "Cho một AI execute và AI khác review khi quality risk đáng kể." },
-  artifact: { label: "Yêu cầu artifact có thể inspect.", detail: "Diff, checklist, report, screenshot, decision matrix hoặc test evidence." },
-  redact: { label: "Redact secrets, private keys, customer data và sensitive company details." },
-  "no-destructive": { label: "Không để agent chạy destructive command hoặc production migration nếu chưa review rõ." },
-  "human-decision": { label: "Giữ medical, legal, financial và production-risk decisions cho human owner." },
-  "gpt-prd": { label: "Nhờ GPT tạo problem statement, user stories, acceptance criteria, non-goals, risks, rollout và test plan." },
-  "claude-review": { label: "Nhờ Claude challenge architecture, assumptions, failure modes và minimum viable scope." },
-  codex: { label: "Dùng Codex cho repo tasks có tests, clean diff, refactor, migration và PR-ready work." },
-  antigravity: { label: "Dùng Antigravity cho UI-heavy prototype, browser verification, screenshot và end-to-end artifact." },
-  "ai-review": { label: "Dùng Claude hoặc GPT review diff về correctness, security, edge cases, test gaps và migration risk." },
-  "human-review": { label: "Human owner review trade-off và quyết định merge cuối." },
-  "release-note": { label: "Dùng GPT cho release note, stakeholder update và rollout checklist." },
-  projects: { label: "Tạo năm ChatGPT Projects.", detail: "PhongOS, Engineering Leadership, Finance & Investment, Learning & Research, Writing / Personal Brand." },
-  notebooks: { label: "Tạo năm NotebookLM notebooks.", detail: "Career Archive, Finance Library, Learning AI/Systems, Life Archive, Work Knowledge Base." },
-  templates: { label: "Lưu prompt templates cho Codex, Claude, Antigravity, NotebookLM và GPT." },
-  logs: { label: "Tạo decision_log, career_roadmap, finance_snapshot và folder AI Operating System." },
-  "pr-review": { label: "Tạo PR review playbook." },
-  incident: { label: "Tạo incident và postmortem workflow." },
-  feature: { label: "Tạo workflow từ feature spec đến implementation." },
-  ship: { label: "Ship một AI-assisted feature và một refactor hoặc test improvement." },
-  portfolio: { label: "Draft evidence cho Staff Engineer portfolio." },
-  writing: { label: "Draft ba bài technical writing." },
-  "internal-proposal": { label: "Viết một internal proposal về AI-assisted engineering workflow." },
-  demo: { label: "Build một demo automation bằng Codex hoặc Antigravity." },
-  finance: { label: "Tạo finance dashboard và investment checklist." },
-  "career-strategy": { label: "Tạo career strategy 3 năm với ba scenario." },
-  "learning-roadmap": { label: "Tạo 12-month learning roadmap và weekly review habit ổn định." }
+  "tool-signal": { label: "Ghi công cụ AI nào có ích và chỗ nào gây nhiễu." },
+  "prompt-improvement": { label: "Ghi một cách cải thiện prompt cho ngày mai." },
+  archive: { label: "Lưu bài học vào NotebookLM, ChatGPT Project hoặc Studio." },
+  work: { label: "Tóm tắt phần đã giao, PR, điểm nghẽn, sự cố và những khoảnh khắc đáng nhớ của đội." },
+  "life-finance": { label: "Ghi lại sức khỏe, năng lượng, tài chính, các mối quan hệ và việc hành chính cần chú ý." },
+  sources: { label: "Đưa tài liệu và ghi chú hữu ích vào NotebookLM khi câu trả lời cần bám sát nguồn." },
+  "wins-losses": { label: "Ghi điều làm tốt, điều chưa tốt và thay đổi so với tuần trước." },
+  avoidance: { label: "Nêu một quyết định hoặc cuộc trò chuyện mình đang né tránh." },
+  "ai-leverage": { label: "Xác định nơi AI thực sự giúp tiết kiệm công sức và nơi nó làm phát sinh việc sửa lại." },
+  "hard-truth": { label: "Viết một sự thật khó chịu nhưng cần nhìn thẳng cho tuần tới." },
+  priorities: { label: "Chọn năm ưu tiên cho tuần tới." },
+  "one-workflow": { label: "Chọn một quy trình AI để cải thiện có chủ đích." },
+  "one-artifact": { label: "Cam kết hoàn thành một sản phẩm nhìn thấy được.", detail: "Bản nháp blog, RFC, demo tự động hóa, checklist hoặc ghi chú cho hồ sơ năng lực." },
+  "one-boundary": { label: "Đặt một ranh giới để bảo vệ sự tập trung và an toàn dữ liệu." },
+  source: { label: "Nếu câu trả lời phải dựa trên tài liệu đã tải lên, bắt đầu bằng NotebookLM." },
+  research: { label: "Nếu cần nghiên cứu web từ nhiều nguồn, bắt đầu bằng GPT Deep Research." },
+  decision: { label: "Nếu cần lập chiến lược, kế hoạch hoặc phân tích đánh đổi, bắt đầu bằng GPT." },
+  critique: { label: "Nếu cần phản biện sâu, rà soát kiến trúc hoặc chỉnh một nội dung nhạy cảm, bắt đầu bằng Claude." },
+  repo: { label: "Nếu công việc thay đổi code trong repo, bắt đầu bằng Codex hoặc Claude Code." },
+  prototype: { label: "Nếu cần kiểm tra UI trên trình duyệt hoặc làm prototype xuyên suốt, bắt đầu bằng Antigravity." },
+  brief: { label: "Viết bản giao việc ngắn gồm mục tiêu, ràng buộc, nguồn, tiêu chí nghiệm thu và nguyên tắc an toàn." },
+  "execute-review": { label: "Để một AI thực hiện và AI khác rà soát khi rủi ro chất lượng đáng kể." },
+  artifact: { label: "Yêu cầu kết quả có thể kiểm tra được.", detail: "Diff, checklist, báo cáo, ảnh chụp, ma trận quyết định hoặc bằng chứng test." },
+  redact: { label: "Che bí mật, private key, dữ liệu khách hàng và thông tin nội bộ nhạy cảm." },
+  "no-destructive": { label: "Không để agent chạy lệnh phá hủy hoặc migration production khi chưa được rà soát rõ ràng." },
+  "human-decision": { label: "Giữ các quyết định về y tế, pháp lý, tài chính và rủi ro production cho người có trách nhiệm." },
+  "gpt-prd": { label: "Nhờ GPT soạn mô tả vấn đề, user story, tiêu chí nghiệm thu, phần không làm, rủi ro, rollout và kế hoạch test." },
+  "claude-review": { label: "Nhờ Claude phản biện kiến trúc, giả định, tình huống lỗi và phạm vi nhỏ nhất đủ giá trị." },
+  codex: { label: "Dùng Codex cho việc trong repo cần test, diff sạch, refactor, migration và kết quả sẵn sàng mở PR." },
+  antigravity: { label: "Dùng Antigravity cho prototype nặng về UI, kiểm tra trình duyệt, ảnh chụp và sản phẩm xuyên suốt." },
+  "ai-review": { label: "Dùng Claude hoặc GPT rà soát diff về tính đúng đắn, bảo mật, trường hợp biên, phần test còn thiếu và rủi ro migration." },
+  "human-review": { label: "Người phụ trách xem lại các đánh đổi và đưa ra quyết định merge cuối cùng." },
+  "release-note": { label: "Dùng GPT để soạn release note, cập nhật cho bên liên quan và checklist rollout." },
+  projects: { label: "Tạo năm ChatGPT Project.", detail: "PhongOS, Lãnh đạo kỹ thuật, Tài chính và đầu tư, Học tập và nghiên cứu, Viết lách và thương hiệu cá nhân." },
+  notebooks: { label: "Tạo năm notebook trong NotebookLM.", detail: "Hồ sơ nghề nghiệp, Thư viện tài chính, Học AI và hệ thống, Lưu trữ cuộc sống, Kho kiến thức công việc." },
+  templates: { label: "Lưu mẫu prompt cho Codex, Claude, Antigravity, NotebookLM và GPT." },
+  logs: { label: "Tạo decision_log, career_roadmap, finance_snapshot và thư mục cho hệ thống làm việc với AI." },
+  "pr-review": { label: "Tạo cẩm nang rà soát PR." },
+  incident: { label: "Tạo quy trình xử lý sự cố và viết postmortem." },
+  feature: { label: "Tạo quy trình từ đặc tả tính năng đến triển khai." },
+  ship: { label: "Hoàn thành một tính năng có AI hỗ trợ và một lần refactor hoặc cải thiện test." },
+  portfolio: { label: "Soạn bằng chứng cho hồ sơ năng lực ở cấp Staff Engineer." },
+  writing: { label: "Soạn ba bài viết kỹ thuật." },
+  "internal-proposal": { label: "Viết một đề xuất nội bộ về quy trình kỹ thuật có AI hỗ trợ." },
+  demo: { label: "Làm một demo tự động hóa bằng Codex hoặc Antigravity." },
+  finance: { label: "Tạo dashboard tài chính và checklist đầu tư." },
+  "career-strategy": { label: "Lập chiến lược nghề nghiệp ba năm với ba kịch bản." },
+  "learning-roadmap": { label: "Tạo lộ trình học 12 tháng và thói quen tổng kết tuần ổn định." }
+};
+
+const vietnameseContextualStepCopies: Record<string, LocalizedStepCopy> = {
+  "ticket-intake-to-start/understand/impact": {
+    label: "Kiểm tra tác động tới sản phẩm, SEO, analytics, locale, accessibility và quyền riêng tư."
+  },
+  "release-readiness/handoff/impact": {
+    label: "Nêu rõ tác động tới SEO, locale, analytics, nội dung và deployment."
+  },
+  "ticket-intake-to-start/execute/checkpoint": {
+    label: "Dừng lại cập nhật tình hình nếu phạm vi hoặc mức rủi ro thay đổi."
+  },
+  "ai-assisted-feature-workflow/execute/checkpoint": {
+    label: "Sau mỗi phần việc nhỏ, dừng lại kiểm tra trước khi mở rộng phạm vi."
+  },
+  "ai-driven-engineering-foundation-roadmap/code-design/principles": {
+    label: "Học SOLID, DRY, KISS, YAGNI, hướng dependency và các pattern refactor."
+  },
+  "ninety-day-ai-skill-plan/days-sixty-one-ninety/principles": {
+    label: "Viết ra nguyên tắc làm việc và ranh giới cá nhân."
+  },
+  "ai-driven-engineering-foundation-roadmap/code-design/architecture": {
+    label: "Thực hành Clean Architecture, Hexagonal Architecture, Onion Architecture và Modular Monolith trước khi nghĩ tới microservices."
+  },
+  "capstone-production-project/foundation-requirements/architecture": {
+    label: "Tổ chức hệ thống theo kiến trúc phân lớp hoặc hexagonal, với trách nhiệm rõ cho từng module."
+  },
+  "ai-driven-engineering-foundation-roadmap/code-design/tests": {
+    label: "Chọn đúng tầng kiểm thử.",
+    detail: "Unit, integration, contract, E2E, property-based, migration và rollback test."
+  },
+  "engineering-delivery-checklist/pre-rollout/tests": {
+    label: "Chạy unit, integration, contract, E2E, load, security, migration dry-run và kiểm tra tương thích ngược khi cần."
+  },
+  "capstone-production-project/foundation-requirements/tests": {
+    label: "Bổ sung unit, integration, contract, E2E, migration và rollback test."
+  },
+  "release-readiness/quality/tests": {
+    label: "Chạy typecheck, test, lint và lệnh build phù hợp."
+  },
+  "ai-tool-routing-decision-tree/safety/tests": {
+    label: "Mọi thay đổi code đều phải có test hoặc cách kiểm chứng phù hợp."
+  },
+  "ai-driven-engineering-foundation-roadmap/data-consistency/migration": {
+    label: "Thiết kế migration dữ liệu và cách rollback trước khi code được merge.",
+    detail: "Backfill, tạo index online, CDC, audit log, backup/restore và khả năng tương thích."
+  },
+  "release-readiness/risk/migration": {
+    label: "Xác nhận migration và thay đổi dữ liệu vẫn tương thích ngược."
+  },
+  "ai-driven-engineering-foundation-roadmap/distributed-resilience/circuit-breaker": {
+    label: "Học các trạng thái của Circuit Breaker.",
+    detail: "Closed, open và half-open."
+  },
+  "ai-system-engineering-roadmap/distributed-resilience-advanced/circuit-breaker": {
+    label: "Hiểu sâu Circuit Breaker.",
+    detail: "Trạng thái closed, open, half-open, cửa sổ đo, ngưỡng chậm, fallback và phân loại lỗi."
+  },
+  "ai-driven-engineering-foundation-roadmap/events-cqrs/event-sourcing": {
+    label: "Học sâu Event Sourcing.",
+    detail: "Domain event, event store, aggregate stream, log chỉ ghi thêm, projection, snapshot, replay và version sự kiện."
+  },
+  "capstone-production-project/resilience-events/event-sourcing": {
+    label: "Dùng Event Sourcing cho vòng đời đơn hàng và read model CQRS cho trang quản trị hoặc báo cáo."
+  },
+  "ai-driven-engineering-foundation-roadmap/events-cqrs/outbox": {
+    label: "Dùng Transactional Outbox, Inbox, Idempotent Consumer, Saga, DLQ, version schema và Anti-Corruption Layer khi bài toán cần."
+  },
+  "capstone-production-project/resilience-events/outbox": {
+    label: "Dùng Outbox, queue worker, retry, DLQ, runbook cho poison message và idempotent consumer."
+  },
+  "ai-driven-engineering-foundation-roadmap/performance-observability/cache": {
+    label: "Học cache-aside, read-through, write-through, write-behind, TTL, eviction, stampede, hot key, CDN và materialized view."
+  },
+  "capstone-production-project/resilience-events/cache": {
+    label: "Thêm Redis cache với cơ chế invalidation, TTL, theo dõi hit rate và cách xử lý khi cache lỗi."
+  },
+  "ai-driven-engineering-foundation-roadmap/performance-observability/otel": {
+    label: "Dùng OpenTelemetry đúng mục đích.",
+    detail: "Metric, log, trace, correlation ID, distributed tracing và span."
+  },
+  "capstone-production-project/production-requirements/otel": {
+    label: "Gắn OpenTelemetry cho trace, metric, log và correlation ID."
+  },
+  "engineering-delivery-checklist/intake/business": {
+    label: "Nêu vấn đề kinh doanh hoặc vấn đề của người dùng cùng chỉ số thành công."
+  },
+  "senior-engineer-reflex/business-product-domain/business": {
+    label: "Metric kinh doanh, nhóm người dùng và thời hạn nào quan trọng trong việc này?"
+  },
+  "engineering-delivery-checklist/intake/scope": {
+    label: "Làm rõ phạm vi, phần không làm, thời hạn, mức ưu tiên và nhóm người dùng bị ảnh hưởng."
+  },
+  "capstone-production-project/feature-set/scope": {
+    label: "Bắt đầu bằng Modular Monolith trước khi tách service."
+  },
+  "release-readiness/quality/scope": {
+    label: "Xác nhận phạm vi PR khớp với ticket và không giấu việc dọn dẹp ngoài yêu cầu."
+  },
+  "engineering-delivery-checklist/implementation-plan/slice": {
+    label: "Chia việc theo backend, database, API contract, test, observability, rollout và tài liệu."
+  },
+  "ai-assisted-feature-workflow/shape/slice": {
+    label: "Chia thành các phần việc nhỏ cho Codex hoặc Antigravity, mỗi phần có thể review độc lập."
+  },
+  "engineering-delivery-checklist/coding-review/review": {
+    label: "Nhờ AI review như một Principal Engineer về tính đúng đắn, race condition, tính nhất quán, bảo mật, observability, hiệu năng, khả năng bảo trì và rủi ro rollback."
+  },
+  "engineering-delivery-checklist/post-rollout/review": {
+    label: "Nhờ AI review sau rollout, gồm kết quả, metric, vấn đề, tác động tới người dùng, technical debt, việc cần làm và bài học."
+  },
+  "engineering-delivery-checklist/pre-rollout/signals": {
+    label: "Chuẩn bị dashboard, alert, runbook, rollback path và cách kiểm tra tác động tới khách hàng."
+  },
+  "senior-engineer-reflex/observability-rollout/signals": {
+    label: "Metric kinh doanh, metric kỹ thuật, trace, log, correlation ID, dashboard và alert nào chứng minh tính năng đang chạy đúng?"
+  },
+  "engineering-delivery-checklist/rollout/monitor": {
+    label: "Theo dõi metric thành công, tỷ lệ lỗi, độ trễ, tải DB, query plan, độ trễ queue, tỷ lệ cache hit/miss và phản hồi hỗ trợ."
+  },
+  "release-readiness/handoff/monitor": {
+    label: "Chốt rõ thời gian theo dõi và tín hiệu thành công."
+  },
+  "engineering-delivery-checklist/post-rollout/docs": {
+    label: "Cập nhật tài liệu, ADR, runbook, checklist Studio và ticket theo dõi."
+  },
+  "module-creation/verification/docs": {
+    label: "Cập nhật tài liệu, ghi chú PR và ảnh chụp khi thay đổi xuất hiện trước người dùng."
+  },
+  "senior-engineer-reflex/api-data-consistency/data": {
+    label: "Schema, migration, index, quy mô truy vấn, thời gian lưu và rủi ro PII là gì?"
+  },
+  "module-creation/backend/data": {
+    label: "Lập kế hoạch schema, index, migration, backfill và thời gian lưu dữ liệu."
+  },
+  "senior-engineer-reflex/observability-rollout/learning": {
+    label: "Sau rollout cần lưu lại điều gì để công việc sau có điểm bắt đầu tốt hơn?"
+  },
+  "weekly-ai-os-review/capture-week/learning": {
+    label: "Liệt kê công cụ AI đã dùng, prompt đã lưu và workflow được lặp lại."
+  },
+  "module-creation/verification/manual": {
+    label: "Kiểm tra thủ công luồng chính và ít nhất một tình huống lỗi."
+  },
+  "release-readiness/quality/manual": {
+    label: "Kiểm tra thủ công route hoặc workflow quan trọng."
+  },
+  "daily-ai-learning-loop/evening-review/archive": {
+    label: "Lưu bài học vào NotebookLM, ChatGPT Project hoặc Studio."
+  },
+  "ai-tool-routing-decision-tree/handoff/archive": {
+    label: "Lưu prompt cuối, sản phẩm tạo ra và bài học để dùng lại."
+  },
+  "ai-assisted-feature-workflow/review-release/archive": {
+    label: "Lưu PRD, RFC, quyết định, bằng chứng test và ghi chú postmortem vào NotebookLM."
+  }
 };
 
 const vietnameseFlowGroupCopies: Record<string, LocalizedFlowGroupCopy> = {
   architecture: {
-    title: "Kiến trúc & System Design",
-    subtitle: "Chốt quyết định trước khi vẽ box.",
+    title: "Kiến trúc và thiết kế hệ thống",
+    subtitle: "Chốt điều cần quyết định trước khi vẽ sơ đồ.",
     description:
-      "Các flow dành cho system design, architecture review và những quyết định khó ở ranh giới module, dữ liệu, team và vận hành."
+      "Các quy trình giúp thiết kế hệ thống, rà soát kiến trúc và xử lý những quyết định khó ở ranh giới giữa module, dữ liệu, đội ngũ và vận hành."
   },
   production: {
-    title: "Production & Delivery",
-    subtitle: "Cẩn thận hơn khi đã có người dùng thật.",
+    title: "Vận hành và phát hành",
+    subtitle: "Thận trọng hơn khi hệ thống đã phục vụ người dùng thật.",
     description:
-      "Các flow dành cho incident, release readiness, rollout gate và handoff vận hành, để bảo vệ reliability mà không làm mọi thay đổi bị nặng nề."
+      "Các quy trình giúp xử lý sự cố, kiểm tra trước khi release, đặt chốt an toàn cho rollout và bàn giao vận hành mà không khiến mọi thay đổi trở nên nặng nề."
   },
   "ai-and-career": {
-    title: "AI Delivery & Career Proof",
-    subtitle: "Biến công việc thành leverage.",
+    title: "Làm phần mềm với AI và ghi lại năng lực",
+    subtitle: "Biến việc đã làm thành bằng chứng có giá trị.",
     description:
-      "Các flow dành cho delivery có AI hỗ trợ và câu chuyện portfolio, giúp engineering judgment hiện rõ mà không biến thành copy marketing."
+      "Các quy trình giúp làm phần mềm với AI và kể lại dự án trong hồ sơ năng lực, để khả năng phán đoán kỹ thuật hiện rõ mà không biến câu chuyện thành lời quảng cáo."
   },
   "react-flow-library": {
-    title: "React Flow",
-    subtitle: "Đổi các dạng example trước khi chọn sơ đồ.",
+    title: "Thư viện React Flow",
+    subtitle: "So sánh từng cách biểu diễn trước khi chọn sơ đồ.",
     description:
-      "Một showcase React Flow cho nhiều nhóm example: node mặc định, custom architecture shape, grouping, layout, validation, annotation, edge style, label, marker, minimap, control, background và blueprint hệ thống lớn."
+      "Bộ ví dụ React Flow gồm các nút mặc định, hình khối kiến trúc tùy chỉnh, cách gom nhóm, bố cục, kiểm tra hợp lệ, chú thích, kiểu đường nối, nhãn, marker, MiniMap, bộ điều khiển, nền và một bản thiết kế hệ thống lớn."
   }
 };
 
 const vietnameseFlowCopies: Record<string, LocalizedFlowCopy> = {
   "system-design": {
-    title: "Flow System Design",
+    title: "Quy trình thiết kế hệ thống",
     summary:
-      "Một đường đi bình tĩnh từ đề bài còn rộng tới kiến trúc rõ: requirement, capacity, data, API, failure modes và trade-off đi đúng thứ tự.",
-    seoTitle: "Flow system design cho senior software engineer",
+      "Một cách đi mạch lạc từ đề bài còn rộng đến kiến trúc rõ ràng: làm rõ yêu cầu, ước lượng tải, xác định dữ liệu, API, tình huống lỗi và các đánh đổi theo đúng thứ tự.",
+    seoTitle: "Quy trình thiết kế hệ thống cho kỹ sư phần mềm giàu kinh nghiệm",
     seoDescription:
-      "Flow system design thực dụng để làm rõ requirement, chọn boundary, model dữ liệu, xử lý scale và giải thích trade-off mạch lạc.",
+      "Quy trình thiết kế hệ thống thực tế để làm rõ yêu cầu, xác định ranh giới, mô hình hóa dữ liệu, chuẩn bị cho việc mở rộng và giải thích các đánh đổi một cách mạch lạc.",
     useWhen:
-      "Dùng khi đề bài còn rộng, ví dụ thiết kế notification system, booking platform, feed hoặc một workflow nội bộ.",
+      "Dùng khi đề bài còn rộng, chẳng hạn thiết kế hệ thống thông báo, nền tảng đặt chỗ, bảng tin hoặc một quy trình nội bộ.",
     outcome:
-      "Một narrative có thể share, thể hiện judgment senior: điều gì quan trọng, điều gì có thể chờ, rủi ro nằm ở đâu và hệ thống sẽ tiến hóa thế nào.",
+      "Một bản trình bày có thể chia sẻ, cho thấy khả năng phán đoán của kỹ sư giàu kinh nghiệm: điều gì cần ưu tiên, điều gì có thể chờ, rủi ro nằm ở đâu và hệ thống nên phát triển theo hướng nào.",
     officeExample:
-      "Product manager muốn thêm flow onboarding đối tác. Thay vì nhảy ngay vào service và queue, flow này bắt đầu từ ai đổi dữ liệu nào, bước nào cần duyệt và rollback quan trọng ở đâu.",
-    tags: ["System Design", "Architecture", "Trade-off", "Interview"],
+      "Quản lý sản phẩm muốn thêm quy trình tiếp nhận đối tác. Thay vì vội chọn dịch vụ hay queue, nhóm bắt đầu từ việc ai được thay đổi dữ liệu nào, bước nào cần phê duyệt và lúc nào phải rollback.",
+    tags: ["Thiết kế hệ thống", "Kiến trúc", "Đánh đổi", "Phỏng vấn"],
     steps: {
       "frame-problem": {
         title: "Đóng khung bài toán",
-        detail: "Nói lại user, job, constraint và non-goal trước khi gọi tên công nghệ.",
-        evidence: "Mục tiêu business, actor, read/write path, latency hoặc reliability expectation.",
-        output: "Problem frame ngắn và danh sách assumption cần confirm."
+        detail: "Nêu rõ người dùng, nhu cầu, ràng buộc và điều không làm trước khi gọi tên công nghệ.",
+        evidence: "Mục tiêu kinh doanh, các bên tham gia, luồng đọc ghi, độ trễ và mức độ tin cậy mong đợi.",
+        output: "Bản mô tả bài toán ngắn cùng danh sách giả định cần xác nhận."
       },
       "shape-interfaces": {
-        title: "Định hình interface",
-        detail: "Phác API, event, user action và admin action quanh workflow thật.",
-        evidence: "Request mẫu, tên event, idempotency, permission và error path.",
-        output: "Ghi chú API/event contract cùng các boundary đầu tiên."
+        title: "Định hình giao diện hệ thống",
+        detail: "Phác API, sự kiện và thao tác của người dùng hoặc quản trị viên quanh quy trình thực tế.",
+        evidence: "Mẫu yêu cầu API, tên sự kiện, khả năng xử lý lặp an toàn, quyền truy cập và cách trả lỗi.",
+        output: "Ghi chú về hợp đồng API, sự kiện và các ranh giới ban đầu."
       },
       "model-data": {
-        title: "Model dữ liệu",
-        detail: "Chọn ownership, consistency rule, index, retention và hướng migration.",
-        evidence: "Entity chính, invariant, query pattern, lifecycle state và nhu cầu audit.",
-        output: "Data sketch kèm consistency và migration note."
+        title: "Mô hình hóa dữ liệu",
+        detail: "Xác định nơi sở hữu dữ liệu, quy tắc nhất quán, chỉ mục, thời gian lưu giữ và hướng migration.",
+        evidence: "Thực thể chính, điều bất biến, kiểu truy vấn, trạng thái trong vòng đời và nhu cầu kiểm tra lịch sử.",
+        output: "Bản phác dữ liệu kèm quy tắc nhất quán và ghi chú migration."
       },
       "design-runtime": {
-        title: "Thiết kế runtime",
-        detail: "Đặt service, queue, cache, worker và gateway chỉ khi chúng giải quyết một áp lực rõ.",
-        evidence: "Capacity estimate, fan-out, dependency limit, hot path và deploy constraint.",
-        output: "Runtime architecture có lý do cho từng phần chuyển động."
+        title: "Thiết kế cách hệ thống vận hành",
+        detail: "Chỉ thêm dịch vụ, queue, cache, tiến trình xử lý và cổng API khi từng thành phần giải quyết một áp lực cụ thể.",
+        evidence: "Ước lượng tải, số nhánh xử lý, giới hạn của hệ thống phụ thuộc, luồng quan trọng và ràng buộc khi triển khai.",
+        output: "Kiến trúc vận hành giải thích rõ lý do tồn tại của từng thành phần."
       },
       "stress-failures": {
-        title: "Stress failure modes",
-        detail: "Đi qua dependency chậm, request trùng, partial write, deploy lỗi và stale read.",
-        evidence: "Timeout, retry budget, DLQ, backpressure, observability và rollback trigger.",
-        output: "Failure-mode table với mitigation và monitoring hook."
+        title: "Rà soát tình huống lỗi",
+        detail: "Xem xét hệ thống phụ thuộc phản hồi chậm, yêu cầu trùng, ghi dữ liệu dở dang, triển khai lỗi và đọc phải dữ liệu cũ.",
+        evidence: "Timeout, giới hạn retry, DLQ, backpressure, observability và điều kiện kích hoạt rollback.",
+        output: "Bảng tình huống lỗi, cách giảm thiệt hại và tín hiệu cần theo dõi."
       },
       "explain-evolution": {
-        title: "Giải thích hướng tiến hóa",
-        detail: "Nói rõ bản đầu tiên thực tế, điểm gãy và design tiếp theo khi traffic hoặc team lớn hơn.",
-        evidence: "Sức team hiện tại, đường tăng traffic, độ trưởng thành vận hành và trần chi phí.",
-        output: "Roadmap theo phiên bản: v1, trigger scale và alternative đã từ chối."
+        title: "Mô tả hướng mở rộng",
+        detail: "Nêu rõ phiên bản đầu tiên phù hợp với hiện tại, điểm bắt đầu quá tải và bước thiết kế tiếp theo khi lưu lượng hoặc đội ngũ tăng lên.",
+        evidence: "Năng lực hiện tại của đội ngũ, dự báo tăng lưu lượng, độ trưởng thành trong vận hành và giới hạn chi phí.",
+        output: "Lộ trình theo phiên bản, điều kiện cần mở rộng và các phương án đã cân nhắc nhưng không chọn."
       }
     },
-    artifacts: ["Problem frame", "API/event notes", "Data ownership sketch", "Runtime diagram", "Failure-mode table", "Evolution roadmap"],
-    cvSignals: ["System design judgment", "Backend và platform thinking", "Giao tiếp trade-off", "Operational maturity"]
+    artifacts: ["Mô tả bài toán", "Ghi chú API và sự kiện", "Sơ đồ sở hữu dữ liệu", "Sơ đồ vận hành", "Bảng tình huống lỗi", "Lộ trình mở rộng"],
+    cvSignals: ["Khả năng phán đoán khi thiết kế hệ thống", "Tư duy backend và nền tảng", "Giải thích các đánh đổi", "Năng lực vận hành"]
   },
   "architecture-decision": {
-    title: "Flow quyết định kiến trúc",
+    title: "Quy trình ra quyết định kiến trúc",
     summary:
-      "Một đường RFC/ADR gọn để biến nhiều lựa chọn rối thành một recommendation rõ, có trade-off và rollback.",
-    seoTitle: "Flow quyết định kiến trúc với tư duy RFC và ADR",
+      "Một quy trình RFC/ADR gọn để biến nhiều lựa chọn khó so sánh thành một đề xuất rõ ràng, có đánh đổi và phương án rollback.",
+    seoTitle: "Quy trình ra quyết định kiến trúc bằng RFC và ADR",
     seoDescription:
-      "Flow quyết định kiến trúc để so sánh option, cân trade-off, ghi rủi ro và align team trước khi implement.",
+      "Quy trình so sánh phương án kiến trúc, cân nhắc đánh đổi, ghi lại rủi ro và thống nhất trong đội ngũ trước khi triển khai.",
     useWhen:
-      "Dùng trước khi feature vượt ranh giới module, đổi ownership dữ liệu, thêm integration mới hoặc kéo theo dependency khó quay lại.",
+      "Dùng trước khi một tính năng vượt qua ranh giới module, thay đổi nơi sở hữu dữ liệu, thêm tích hợp mới hoặc tạo ra quan hệ phụ thuộc khó gỡ bỏ.",
     outcome:
-      "Một decision note giúp teammate hiểu không chỉ chọn gì, mà vì sao các hướng khác bị loại.",
+      "Một bản ghi quyết định giúp đồng đội hiểu không chỉ phương án được chọn mà cả lý do các hướng khác không phù hợp.",
     officeExample:
-      "Team đang tranh luận có nên thêm queue cho partner sync. Flow này tách nhu cầu thật, hành vi khi lỗi, chi phí support của team và thời điểm async processing thật sự đáng giá.",
-    tags: ["RFC", "ADR", "Architecture Review", "Decision Matrix"],
+      "Đội ngũ đang cân nhắc có nên thêm queue để đồng bộ dữ liệu đối tác. Quy trình này làm rõ nhu cầu thật, hành vi khi có lỗi, chi phí hỗ trợ vận hành và thời điểm xử lý bất đồng bộ thực sự đem lại lợi ích.",
+    tags: ["RFC", "ADR", "Rà soát kiến trúc", "Ma trận quyết định"],
     steps: {
       "name-decision": {
-        title: "Gọi tên quyết định",
-        detail: "Viết quyết định thành một câu và thu scope đủ nhỏ để có thể approve.",
-        evidence: "Nỗi đau hiện tại, hệ thống bị ảnh hưởng, owner, deadline và phần ngoài scope.",
-        output: "Decision statement có scope và non-goal."
+        title: "Gọi đúng tên quyết định",
+        detail: "Viết điều cần quyết định thành một câu và thu hẹp phạm vi đến mức có thể phê duyệt.",
+        evidence: "Vấn đề hiện tại, hệ thống bị ảnh hưởng, người phụ trách, thời hạn và phần không thuộc lần quyết định này.",
+        output: "Phát biểu quyết định với phạm vi và điều không làm được ghi rõ."
       },
       "extract-invariants": {
-        title: "Rút invariant",
-        detail: "Liệt kê điều luôn phải đúng với user, tiền, permission, data, audit và support.",
-        evidence: "Domain rule, compliance, support workflow và incident production.",
-        output: "Danh sách invariant mà mọi option phải giữ được."
+        title: "Rút ra các điều bất biến",
+        detail: "Liệt kê những điều luôn phải đúng đối với người dùng, tiền, quyền truy cập, dữ liệu, lịch sử thay đổi và hỗ trợ vận hành.",
+        evidence: "Quy tắc nghiệp vụ, yêu cầu tuân thủ, quy trình hỗ trợ và các sự cố từng xảy ra trên production.",
+        output: "Danh sách điều bất biến mà mọi phương án đều phải giữ được."
       },
       "compare-options": {
-        title: "So sánh option thật",
-        detail: "Đánh giá hai hoặc ba hướng thực dụng, không dựng một design hoàn hảo để thắng strawman.",
-        evidence: "Chi phí delivery, reversibility, performance, reliability, fit với team và migration về sau.",
-        output: "Option table với trade-off trung thực."
+        title: "So sánh phương án thực tế",
+        detail: "Đánh giá hai hoặc ba hướng có thể triển khai, không tô đẹp một phương án rồi cố ý làm các hướng còn lại trông kém thuyết phục.",
+        evidence: "Chi phí thực hiện, khả năng quay lại, hiệu năng, độ tin cậy, mức phù hợp với đội ngũ và migration về sau.",
+        output: "Bảng phương án với các đánh đổi được trình bày trung thực."
       },
       "risk-gates": {
-        title: "Đặt risk gate",
-        detail: "Chốt validation, telemetry, rollout và rollback trước khi implementation bắt đầu.",
-        evidence: "Test, dashboard, feature flag, migration script, runbook và owner sign-off.",
-        output: "Decision gate và launch condition."
+        title: "Đặt các chốt an toàn",
+        detail: "Chốt cách kiểm chứng, tín hiệu theo dõi, rollout và rollback trước khi bắt đầu triển khai.",
+        evidence: "Test, dashboard, feature flag, script migration, runbook và xác nhận của người chịu trách nhiệm.",
+        output: "Các điều kiện cần đạt trước khi thông qua và đưa thay đổi vào sử dụng."
       },
       "write-decision": {
-        title: "Viết decision note",
-        detail: "Giữ note đủ ngắn để đọc lúc review, nhưng đủ đầy để sống qua handoff.",
-        evidence: "Option được chọn, alternative bị loại, accepted debt và revisit trigger.",
-        output: "ADR/RFC entry sẵn sàng review."
+        title: "Viết bản ghi quyết định",
+        detail: "Giữ tài liệu đủ ngắn để đọc trong buổi rà soát nhưng đủ rõ để người nhận bàn giao hiểu được sau này.",
+        evidence: "Phương án được chọn, hướng đã loại, phần nợ kỹ thuật chấp nhận được và điều kiện cần xem xét lại.",
+        output: "Bản ADR hoặc RFC sẵn sàng để rà soát."
       }
     },
-    artifacts: ["Decision statement", "Invariant list", "Option matrix", "Risk gates", "ADR/RFC note"],
-    cvSignals: ["Architecture leadership", "Làm rõ requirement", "Align cross-team", "Quản trị rủi ro"]
+    artifacts: ["Phát biểu quyết định", "Danh sách điều bất biến", "Ma trận phương án", "Các chốt an toàn", "Bản ghi ADR hoặc RFC"],
+    cvSignals: ["Dẫn dắt quyết định kiến trúc", "Làm rõ yêu cầu", "Thống nhất giữa các đội ngũ", "Quản trị rủi ro"]
   },
   "incident-response": {
-    title: "Flow xử lý incident",
+    title: "Quy trình xử lý sự cố",
     summary:
-      "Một đường xử lý incident từ signal đầu tiên tới rollback, communication, root cause và follow-up thật sự.",
-    seoTitle: "Flow xử lý production incident cho engineering team",
+      "Một trình tự rõ ràng từ dấu hiệu đầu tiên của sự cố đến việc giảm thiệt hại, rollback, cập nhật tình hình, tìm nguyên nhân gốc và theo dõi việc khắc phục.",
+    seoTitle: "Quy trình xử lý sự cố production cho đội ngũ kỹ thuật",
     seoDescription:
-      "Flow incident cho triage, kiểm soát blast radius, rollback, communication, root cause analysis và follow-up.",
+      "Quy trình phân loại sự cố, giới hạn phạm vi ảnh hưởng, rollback, cập nhật tình hình, phân tích nguyên nhân gốc và theo dõi việc phòng ngừa tái diễn.",
     useWhen:
-      "Dùng khi alert, phản hồi khách hàng, deploy regression hoặc lỗi đối tác tạo áp lực và team cần một thứ tự bình tĩnh.",
+      "Dùng khi cảnh báo, phản hồi của khách hàng, lỗi phát sinh sau khi triển khai hoặc sự cố từ đối tác khiến đội ngũ cần một thứ tự xử lý bình tĩnh.",
     outcome:
-      "Incident được kiểm soát: decision visible, user được bảo vệ và postmortem tạo ra prevention work thật.",
+      "Sự cố được kiểm soát, quyết định được ghi lại rõ ràng, người dùng được bảo vệ và postmortem dẫn đến những việc phòng ngừa cụ thể.",
     officeExample:
-      "Sau release, checkout latency tăng và support nhận complaint trùng lặp. Flow này giữ team khỏi đoán mò bằng cách tách signal, mitigation, rollback và root cause.",
-    tags: ["Incident", "SRE", "Rollback", "Postmortem"],
+      "Sau một release, thời gian phản hồi ở bước thanh toán tăng cao và bộ phận hỗ trợ nhận nhiều phản ánh giống nhau. Quy trình này giúp đội ngũ không đoán mò bằng cách tách rõ dấu hiệu, hành động giảm thiệt hại, rollback và việc tìm nguyên nhân gốc.",
+    tags: ["Sự cố", "SRE", "Rollback", "Postmortem"],
     steps: {
       "confirm-signal": {
-        title: "Xác nhận signal",
-        detail: "Tách incident có impact thật khỏi metric nhiễu hoặc một dependency chập chờn.",
-        evidence: "Alert, dashboard, log, trace, customer report, timeline deploy và segment bị ảnh hưởng.",
-        output: "Trạng thái incident, severity và owner ban đầu."
+        title: "Xác nhận dấu hiệu",
+        detail: "Phân biệt sự cố thực sự ảnh hưởng đến người dùng với chỉ số nhiễu hoặc một hệ thống phụ thuộc đang chập chờn.",
+        evidence: "Cảnh báo, dashboard, log, trace, phản hồi của khách hàng, mốc triển khai và nhóm người dùng bị ảnh hưởng.",
+        output: "Trạng thái sự cố, mức độ nghiêm trọng và người phụ trách ban đầu."
       },
       "contain-blast-radius": {
-        title: "Giới hạn blast radius",
-        detail: "Bảo vệ user trước bằng flag, rate limit, rollback, shift traffic hoặc tạm disable.",
-        evidence: "Feature flag, release version, dependency health, error budget và rollback path an toàn.",
-        output: "Mitigation action kèm impact dự kiến."
+        title: "Giới hạn phạm vi ảnh hưởng",
+        detail: "Ưu tiên bảo vệ người dùng bằng feature flag, giới hạn tần suất, rollback, chuyển lưu lượng hoặc tạm tắt phần gây lỗi.",
+        evidence: "Feature flag, phiên bản release, tình trạng hệ thống phụ thuộc, error budget và cách rollback an toàn.",
+        output: "Hành động giảm thiệt hại cùng tác động dự kiến."
       },
       "coordinate-room": {
-        title: "Điều phối phòng incident",
-        detail: "Chia incident lead, comms, investigation và verification để team không giẫm chân nhau.",
-        evidence: "Owner, timestamp, hypothesis hiện tại, message cho khách hàng và mốc update tiếp theo.",
-        output: "Timeline incident và cadence communication chung."
+        title: "Điều phối nhóm xử lý",
+        detail: "Phân công người điều phối, người cập nhật tình hình, người điều tra và người kiểm chứng để mọi người không làm trùng nhau.",
+        evidence: "Người phụ trách, mốc thời gian, giả thuyết hiện tại, thông báo cho khách hàng và giờ cập nhật tiếp theo.",
+        output: "Dòng thời gian sự cố và nhịp cập nhật chung."
       },
       "verify-recovery": {
-        title: "Xác nhận recovery",
-        detail: "Đừng đóng incident chỉ vì một graph đẹp hơn; kiểm user path và downstream queue.",
-        evidence: "SLO, synthetic check, real traffic, queue depth, support signal và error-rate recovery.",
-        output: "Recovery confirmation và watch window."
+        title: "Xác nhận hệ thống đã phục hồi",
+        detail: "Không đóng sự cố chỉ vì một biểu đồ đã đẹp hơn; cần kiểm tra hành trình thật của người dùng và các queue phía sau.",
+        evidence: "SLO, kiểm tra mô phỏng, lưu lượng thật, độ sâu queue, phản hồi từ bộ phận hỗ trợ và tỷ lệ lỗi sau khi phục hồi.",
+        output: "Xác nhận phục hồi cùng khoảng thời gian tiếp tục theo dõi."
       },
       "write-postmortem": {
-        title: "Viết follow-up",
-        detail: "Biến incident thành prevention work mà không đổ lỗi cho người chạm deploy.",
-        evidence: "Root cause, contributing factor, missed detection và prevention option.",
-        output: "Postmortem, action item, owner và due date."
+        title: "Ghi lại và theo dõi việc khắc phục",
+        detail: "Biến sự cố thành việc phòng ngừa cụ thể mà không đổ lỗi cho người thực hiện lần triển khai gần nhất.",
+        evidence: "Nguyên nhân gốc, yếu tố góp phần, dấu hiệu đã bị bỏ lỡ và các cách ngăn tái diễn.",
+        output: "Postmortem, việc cần làm, người phụ trách và thời hạn hoàn thành."
       }
     },
-    artifacts: ["Severity note", "Mitigation log", "Incident timeline", "Recovery checklist", "Postmortem actions"],
-    cvSignals: ["Production ownership", "Reliability thinking", "Stakeholder communication", "Bình tĩnh khi áp lực"]
+    artifacts: ["Ghi chú mức độ nghiêm trọng", "Nhật ký giảm thiệt hại", "Dòng thời gian sự cố", "Danh sách kiểm tra phục hồi", "Việc cần làm sau postmortem"],
+    cvSignals: ["Trách nhiệm với production", "Tư duy về độ tin cậy", "Cập nhật rõ ràng cho các bên liên quan", "Giữ bình tĩnh khi có áp lực"]
   },
   "release-readiness": {
-    title: "Flow release readiness",
+    title: "Quy trình Release Readiness",
     summary:
-      "Một rollout gate để kiểm scope, test, observability, migration safety, communication và rollback trước khi release.",
-    seoTitle: "Flow release readiness cho rollout phần mềm an toàn",
+      "Bộ tiêu chí giúp kiểm tra phạm vi, test, observability, độ an toàn của migration, cách cập nhật tình hình và phương án rollback trước khi release.",
+    seoTitle: "Quy trình kiểm tra để rollout phần mềm an toàn",
     seoDescription:
-      "Flow release readiness để kiểm test, analytics, migration safety, observability, communication, rollout gate và rollback plan.",
+      "Quy trình kiểm tra test, analytics, độ an toàn của migration, observability, cách cập nhật tình hình, điều kiện rollout và phương án rollback.",
     useWhen:
-      "Dùng trước khi feature lên production, nhất là khi chạm checkout, authentication, data migration, integration hoặc route public.",
+      "Dùng trước khi đưa một tính năng lên production, nhất là khi thay đổi bước thanh toán, xác thực, migration dữ liệu, tích hợp hoặc đường dẫn công khai.",
     outcome:
-      "Một release có thể giải thích, quan sát, pause và rollback mà không cần dọn dẹp kiểu chữa cháy sau đó.",
+      "Một release có thể giải thích, theo dõi, tạm dừng và rollback mà không phải xử lý hậu quả theo kiểu chữa cháy.",
     officeExample:
-      "Team chuẩn bị ship một dashboard filter mới có analytics và SEO. Flow này kiểm behavior, tracking, empty state và rollback trước khi nút deploy trở nên quá hấp dẫn.",
-    tags: ["Release", "Rollout", "QA", "Observability"],
+      "Đội ngũ chuẩn bị phát hành bộ lọc mới trên dashboard có liên quan đến analytics và SEO. Quy trình này kiểm tra hành vi, tracking, trạng thái trống và rollback trước khi bấm nút triển khai.",
+    tags: ["Release", "Rollout", "Kiểm thử", "Observability"],
     steps: {
       "confirm-scope": {
-        title: "Xác nhận scope",
-        detail: "So release với ticket, acceptance criteria, non-goal và behavior user thấy được.",
-        evidence: "Ticket, diff summary, screenshot, copy change và route bị ảnh hưởng.",
-        output: "Scope release và non-goal rõ ràng."
+        title: "Xác nhận phạm vi",
+        detail: "Đối chiếu release với ticket, tiêu chí nghiệm thu, điều không làm và hành vi mà người dùng thực sự nhìn thấy.",
+        evidence: "Ticket, tóm tắt phần thay đổi, ảnh chụp màn hình, nội dung được sửa và đường dẫn bị ảnh hưởng.",
+        output: "Phạm vi release và điều không làm được ghi rõ."
       },
       "verify-behavior": {
-        title: "Verify behavior",
-        detail: "Chạy check đúng với risk: unit, integration, E2E, accessibility, typecheck và smoke thủ công.",
-        evidence: "Command output, test coverage, browser check, mobile check và gap còn lại.",
-        output: "Verification note kèm residual risk."
+        title: "Kiểm chứng hành vi",
+        detail: "Chọn cách kiểm tra tương xứng với rủi ro: unit test, integration test, E2E, khả năng tiếp cận, typecheck và kiểm tra nhanh bằng tay.",
+        evidence: "Kết quả lệnh, mức bao phủ của test, kiểm tra trên trình duyệt và thiết bị di động cùng những điểm chưa kiểm được.",
+        output: "Ghi chú kiểm chứng kèm rủi ro còn lại."
       },
       "check-data": {
-        title: "Kiểm data và migration",
-        detail: "Review schema change, backfill, index, cache, analytics event và SEO path.",
-        evidence: "Migration plan, rollback script, data volume, event name, canonical URL và sitemap impact.",
-        output: "Checklist sẵn sàng cho data và tracking."
+        title: "Kiểm tra dữ liệu và migration",
+        detail: "Rà soát thay đổi schema, backfill, chỉ mục, cache, sự kiện analytics và đường dẫn SEO.",
+        evidence: "Kế hoạch migration, script rollback, khối lượng dữ liệu, tên sự kiện, URL canonical và ảnh hưởng đến sitemap.",
+        output: "Danh sách kiểm tra mức sẵn sàng của dữ liệu và tracking."
       },
       "prepare-observability": {
         title: "Chuẩn bị observability",
-        detail: "Đảm bảo release quan sát được bằng signal có thể hành động, không chỉ graph đẹp.",
-        evidence: "Dashboard, alert, log, trace, feature flag và owner coverage.",
-        output: "Watch plan và escalation path."
+        detail: "Đảm bảo release có những tín hiệu đủ rõ để hành động, không chỉ có biểu đồ đẹp.",
+        evidence: "Dashboard, cảnh báo, log, trace, feature flag và người trực theo dõi.",
+        output: "Kế hoạch theo dõi và cách chuyển cấp khi có vấn đề."
       },
       "rollout-decision": {
-        title: "Chốt rollout decision",
-        detail: "Chọn gradual rollout, release ngay, hold hoặc rollback dựa trên evidence.",
-        evidence: "Risk score, user segment, support readiness, deploy window và rollback confidence.",
-        output: "Go/hold decision kèm rollback trigger."
+        title: "Chốt quyết định rollout",
+        detail: "Chọn rollout theo từng giai đoạn, release ngay, tạm dừng hoặc rollback dựa trên thông tin đã kiểm chứng.",
+        evidence: "Mức rủi ro, nhóm người dùng, khả năng hỗ trợ, khung giờ triển khai và độ tin cậy của phương án rollback.",
+        output: "Quyết định tiếp tục hoặc tạm dừng, kèm điều kiện kích hoạt rollback."
       }
     },
-    artifacts: ["Scope note", "Verification evidence", "Data và analytics checklist", "Watch plan", "Rollout decision"],
-    cvSignals: ["End-to-end delivery", "QA judgment", "SEO và analytics awareness", "Release ownership"]
+    artifacts: ["Ghi chú phạm vi", "Kết quả kiểm chứng", "Danh sách kiểm tra dữ liệu và analytics", "Kế hoạch theo dõi", "Quyết định rollout"],
+    cvSignals: ["Khả năng giao phần mềm từ đầu đến cuối", "Phán đoán về QA", "Hiểu biết về SEO và analytics", "Trách nhiệm với release"]
   },
   "ai-delivery": {
-    title: "Flow delivery có AI hỗ trợ",
+    title: "Quy trình AI-assisted Delivery",
     summary:
-      "Một cách dùng AI agent có kiểm soát cho implementation, không mất scope, privacy, test và judgment của engineer.",
-    seoTitle: "Flow delivery phần mềm có AI hỗ trợ và human review",
+      "Cách dùng agent AI có kiểm soát khi làm phần mềm, vẫn giữ vững phạm vi, quyền riêng tư, việc kiểm thử và khả năng phán đoán của kỹ sư.",
+    seoTitle: "Quy trình làm phần mềm với AI và con người rà soát",
     seoDescription:
-      "Flow AI-assisted delivery để scope task, đóng gói context, apply change, verify behavior và handoff công việc sẵn sàng review.",
+      "Quy trình chốt phạm vi, chuẩn bị ngữ cảnh, thực hiện thay đổi, kiểm chứng hành vi và bàn giao công việc có AI hỗ trợ để sẵn sàng rà soát.",
     useWhen:
-      "Dùng khi AI agent hỗ trợ coding, review, research, docs, refactor hoặc sinh test trong một codebase thật.",
+      "Dùng khi agent AI hỗ trợ viết code, rà soát, nghiên cứu, soạn tài liệu, refactor hoặc tạo test trong một codebase thật.",
     outcome:
-      "Một change sẵn sàng review, trong đó AI giúp tăng tốc và tăng coverage, còn engineer vẫn giữ ownership về scope, correctness và release risk.",
+      "Một thay đổi sẵn sàng để rà soát: AI giúp làm nhanh hơn và kiểm tra rộng hơn, còn kỹ sư vẫn chịu trách nhiệm về phạm vi, tính đúng đắn và rủi ro của release.",
     officeExample:
-      "Một teammate yêu cầu feature mới trong Studio. Flow này biến request thành context có ranh giới, nói rõ phần không được đụng, verify analytics/SEO rồi review diff trước khi commit.",
-    tags: ["AI Delivery", "Agents", "Code Review", "Verification"],
+      "Một đồng đội đề nghị thêm tính năng mới vào Studio. Quy trình này biến yêu cầu thành ngữ cảnh có ranh giới rõ, chỉ ra phần không được chạm tới, kiểm chứng analytics và SEO rồi đọc lại diff trước khi commit.",
+    tags: ["Làm phần mềm với AI", "Agent AI", "Rà soát mã nguồn", "Kiểm chứng"],
     steps: {
       "scope-task": {
-        title: "Scope task",
-        detail: "Dịch request thành acceptance criteria, surface bị ảnh hưởng, non-goal và privacy boundary.",
-        evidence: "User request, repo instruction, local constraint, analytics rule và quyền deploy.",
-        output: "Task brief có ranh giới rõ."
+        title: "Chốt phạm vi công việc",
+        detail: "Chuyển yêu cầu thành tiêu chí nghiệm thu, phần hệ thống bị ảnh hưởng, điều không làm và ranh giới về quyền riêng tư.",
+        evidence: "Yêu cầu của người dùng, hướng dẫn trong repository, ràng buộc tại máy, quy tắc analytics và quyền triển khai.",
+        output: "Bản giao việc ngắn với ranh giới rõ ràng."
       },
       "package-context": {
-        title: "Đóng gói context",
-        detail: "Đưa cho agent file, example, convention, test và cảnh báo thật sự liên quan.",
-        evidence: "Pattern hiện có, component tương tự, data model, locale behavior và test.",
-        output: "Context pack và implementation hint."
+        title: "Chuẩn bị ngữ cảnh",
+        detail: "Cung cấp cho agent những file, ví dụ, quy ước, test và cảnh báo thực sự liên quan.",
+        evidence: "Cách làm đang có, component tương tự, mô hình dữ liệu, hành vi theo ngôn ngữ và test liên quan.",
+        output: "Gói ngữ cảnh cùng gợi ý triển khai vừa đủ."
       },
       "execute-small": {
-        title: "Làm theo lát nhỏ",
-        detail: "Giữ edit hẹp, dùng abstraction sẵn có và verify từng boundary rủi ro trước khi đi tiếp.",
-        evidence: "Diff chunk, compile feedback, UI behavior và file ngoài scope không đổi.",
-        output: "Implementation diff tập trung."
+        title: "Thực hiện theo từng phần nhỏ",
+        detail: "Giữ phần sửa gọn, dùng cấu trúc sẵn có và kiểm chứng từng ranh giới rủi ro trước khi đi tiếp.",
+        evidence: "Từng phần diff, phản hồi khi biên dịch, hành vi giao diện và việc các file ngoài phạm vi vẫn nguyên vẹn.",
+        output: "Bản thay đổi tập trung, không kéo theo phần việc ngoài yêu cầu."
       },
       "verify-review": {
-        title: "Verify và review",
-        detail: "Chạy test, đọc diff, kiểm chất lượng copy, analytics wiring và security/privacy implication.",
-        evidence: "Test output, manual check, changed-file list và residual risk.",
-        output: "Verification summary và review note."
+        title: "Kiểm chứng và rà soát",
+        detail: "Chạy test, đọc diff, kiểm tra nội dung hiển thị, kết nối analytics cùng ảnh hưởng đến bảo mật và quyền riêng tư.",
+        evidence: "Kết quả test, kiểm tra thủ công, danh sách file đã đổi và rủi ro còn lại.",
+        output: "Bản tóm tắt kiểm chứng và ghi chú rà soát."
       },
       "handoff-clean": {
-        title: "Handoff sạch",
-        detail: "Chuẩn bị commit, PR, release note hoặc deploy chỉ khi request của người dùng cho phép.",
-        evidence: "Git status, staged diff, commit message, PR checklist và trạng thái approval.",
-        output: "Handoff sẵn sàng cho commit/PR/deploy."
+        title: "Bàn giao gọn gàng",
+        detail: "Chỉ chuẩn bị commit, PR, ghi chú release hoặc triển khai khi yêu cầu của người dùng cho phép.",
+        evidence: "Git status, phần diff đã stage, nội dung commit, danh sách kiểm tra PR và trạng thái phê duyệt.",
+        output: "Phần bàn giao sẵn sàng cho commit, PR hoặc triển khai."
       }
     },
-    artifacts: ["Task brief", "Context pack", "Focused diff", "Verification note", "Review handoff"],
-    cvSignals: ["AI fluency", "Engineering judgment", "Privacy awareness", "Modern delivery practice"]
+    artifacts: ["Bản giao việc ngắn", "Gói ngữ cảnh", "Diff tập trung", "Ghi chú kiểm chứng", "Phần bàn giao để rà soát"],
+    cvSignals: ["Khả năng làm việc với AI", "Phán đoán kỹ thuật", "Ý thức về quyền riêng tư", "Cách làm và bàn giao phần mềm hiện đại"]
   },
   "portfolio-story": {
-    title: "Flow kể câu chuyện portfolio",
+    title: "Quy trình kể lại công việc trong hồ sơ năng lực",
     summary:
-      "Một cách biến công việc kỹ thuật thật thành câu chuyện CV, blog hoặc phỏng vấn rõ ràng mà không đánh bóng quá mức.",
-    seoTitle: "Flow kể câu chuyện engineering portfolio cho CV và phỏng vấn",
+      "Cách biến công việc kỹ thuật đã làm thành câu chuyện rõ ràng cho CV, bài viết hoặc buổi phỏng vấn mà không tô vẽ quá mức.",
+    seoTitle: "Quy trình kể lại dự án kỹ thuật cho CV và phỏng vấn",
     seoDescription:
-      "Flow portfolio story để biến công việc engineering thành context, action, trade-off, impact, evidence và bài học tiếp theo.",
+      "Quy trình ghi lại hoàn cảnh, hành động, đánh đổi, tác động, bằng chứng và bài học từ một dự án kỹ thuật để dùng trong hồ sơ năng lực.",
     useWhen:
-      "Dùng sau một project, incident, migration, release, khoảnh khắc leadership hoặc trade-off khó đáng để trở thành career evidence.",
+      "Dùng sau một dự án, sự cố, migration, release, lần dẫn dắt đội ngũ hoặc quyết định đánh đổi đáng được lưu lại như một bằng chứng năng lực nghề nghiệp.",
     outcome:
-      "Một câu chuyện grounded có thể chuyển thành CV bullet, blog post, câu trả lời phỏng vấn hoặc portfolio case study.",
+      "Một câu chuyện có dữ kiện cụ thể, có thể chuyển thành dòng mô tả trong CV, bài viết, câu trả lời phỏng vấn hoặc case study trong hồ sơ năng lực.",
     officeExample:
-      "Một refactor làm giảm support noise nhưng không có headline quá kịch tính. Flow này giữ lại before/after, áp lực quyết định và giá trị vận hành âm thầm.",
-    tags: ["CV", "Portfolio", "Writing", "Career"],
+      "Một lần refactor giúp giảm các yêu cầu hỗ trợ lặp lại nhưng không tạo ra con số gây chú ý. Quy trình này vẫn ghi lại tình trạng trước và sau, áp lực khi ra quyết định cùng giá trị vận hành ít người nhìn thấy.",
+    tags: ["CV", "Hồ sơ năng lực", "Viết", "Nghề nghiệp"],
     steps: {
       "capture-context": {
-        title: "Ghi lại context",
-        detail: "Nói rõ tình huống team, pain của user, constraint và vì sao việc này quan trọng lúc đó.",
-        evidence: "Ticket, incident note, stakeholder request, metric, support theme hoặc code-health signal.",
-        output: "Context paragraph cụ thể, không phóng đại."
+        title: "Ghi lại hoàn cảnh",
+        detail: "Nêu rõ tình hình của đội ngũ, vấn đề người dùng gặp phải, các ràng buộc và lý do công việc này quan trọng ở thời điểm đó.",
+        evidence: "Ticket, ghi chú sự cố, yêu cầu của bên liên quan, chỉ số, nhóm phản hồi hỗ trợ hoặc dấu hiệu về tình trạng codebase.",
+        output: "Một đoạn mô tả hoàn cảnh cụ thể, không phóng đại."
       },
       "show-actions": {
         title: "Cho thấy hành động",
-        detail: "Mô tả điều anh đổi, quyết định, phối hợp hoặc làm đơn giản hơn bằng ngôn ngữ engineering rõ.",
-        evidence: "Diff, design note, PR discussion, rollout plan, test evidence hoặc migration record.",
-        output: "Action list có cả technical detail và collaboration detail."
+        detail: "Mô tả điều tôi đã thay đổi, quyết định, phối hợp hoặc làm đơn giản hơn bằng ngôn ngữ kỹ thuật rõ ràng.",
+        evidence: "Diff, ghi chú thiết kế, trao đổi trong PR, kế hoạch rollout, kết quả test hoặc lịch sử migration.",
+        output: "Danh sách hành động gồm cả chi tiết kỹ thuật và cách phối hợp."
       },
       "name-tradeoffs": {
-        title: "Gọi tên trade-off",
-        detail: "Giải thích constraint làm công việc này đáng chú ý: thời gian, reliability, UX, cost, privacy hoặc sức team.",
-        evidence: "Option bị từ chối, accepted debt, rollback plan hoặc future trigger.",
-        output: "Trade-off note thể hiện judgment."
+        title: "Nêu rõ các đánh đổi",
+        detail: "Giải thích những ràng buộc khiến công việc này đáng chú ý: thời gian, độ tin cậy, trải nghiệm người dùng, chi phí, quyền riêng tư hoặc năng lực đội ngũ.",
+        evidence: "Phương án đã loại, phần nợ kỹ thuật chấp nhận được, kế hoạch rollback hoặc điều kiện cần xem xét lại trong tương lai.",
+        output: "Ghi chú về đánh đổi, cho thấy cách cân nhắc và ra quyết định."
       },
       "prove-impact": {
-        title: "Chứng minh impact",
-        detail: "Dùng số liệu khi có, nhưng vẫn ghi lại risk giảm, handoff sạch hơn, reliability tốt hơn hoặc support nhanh hơn.",
-        evidence: "Before/after metric, customer signal, deploy health, incident giảm hoặc adoption của team.",
-        output: "Impact statement có evidence và caveat."
+        title: "Chứng minh tác động",
+        detail: "Dùng số liệu khi có, đồng thời ghi lại rủi ro đã giảm, việc bàn giao rõ hơn, hệ thống đáng tin cậy hơn hoặc thời gian hỗ trợ được rút ngắn.",
+        evidence: "Chỉ số trước và sau, phản hồi của khách hàng, tình trạng sau triển khai, số sự cố giảm hoặc mức độ sử dụng trong đội ngũ.",
+        output: "Mô tả tác động có căn cứ và nêu rõ giới hạn của kết luận."
       },
       "shape-story": {
-        title: "Định dạng câu chuyện",
-        detail: "Biến raw material thành đúng format cho CV, interview, blog hoặc portfolio page.",
-        evidence: "Audience, keyword, role đang nhắm tới, proof link và boundary bảo mật.",
-        output: "CV bullet, STAR answer, blog outline hoặc case-study draft."
+        title: "Định hình câu chuyện",
+        detail: "Biến tư liệu thô thành hình thức phù hợp cho CV, phỏng vấn, bài viết hoặc trang hồ sơ năng lực.",
+        evidence: "Người đọc, từ khóa, vai trò hướng tới, liên kết kiểm chứng và giới hạn bảo mật.",
+        output: "Dòng mô tả trong CV, câu trả lời theo STAR, dàn ý bài viết hoặc bản nháp case study."
       }
     },
-    artifacts: ["Context paragraph", "Action list", "Trade-off note", "Impact statement", "Story draft"],
-    cvSignals: ["Giao tiếp impact", "Senior engineer narrative", "Business awareness", "Reflective practice"]
+    artifacts: ["Đoạn mô tả hoàn cảnh", "Danh sách hành động", "Ghi chú về đánh đổi", "Mô tả tác động", "Bản nháp câu chuyện"],
+    cvSignals: ["Trình bày rõ tác động", "Kể lại công việc ở cấp kỹ sư giàu kinh nghiệm", "Hiểu nhu cầu kinh doanh", "Khả năng nhìn lại và rút kinh nghiệm"]
   },
   "react-flow-architecture-demo": {
-    title: "Example",
+    title: "Bộ ví dụ React Flow",
     summary:
-      "Một canvas kiểu thư viện demo, cho thấy @xyflow/react có thể biểu diễn overview, interaction, grouping, layout, styling, whiteboard và software architecture example.",
-    seoTitle: "React Flow Example cho nhiều dạng sơ đồ kỹ thuật",
+      "Một canvas dạng thư viện, cho thấy @xyflow/react có thể trình bày toàn cảnh, tương tác, cách gom nhóm, bố cục, kiểu hiển thị, bảng vẽ và nhiều dạng sơ đồ kiến trúc phần mềm.",
+    seoTitle: "Bộ ví dụ React Flow cho nhiều dạng sơ đồ kỹ thuật",
     seoDescription:
-      "Studio demo React Flow với node mặc định, custom architecture shape, grouping, layout, validation, whiteboard annotation, edge type, label, marker, minimap, control và background.",
+      "Bộ ví dụ React Flow trong Studio với các nút mặc định, hình khối kiến trúc tùy chỉnh, cách gom nhóm, bố cục, kiểm tra hợp lệ, chú thích trên bảng vẽ, kiểu đường nối, nhãn, marker, MiniMap, bộ điều khiển và nền.",
     useWhen:
-      "Dùng khi cần chọn cách mô hình hóa system architecture, service map, platform topology, event flow, deployment boundary hoặc graph-editor interaction bằng React Flow.",
+      "Dùng khi cần chọn cách biểu diễn kiến trúc hệ thống, sơ đồ dịch vụ, cấu trúc liên kết nền tảng, luồng sự kiện, ranh giới triển khai hoặc tương tác trong trình sửa sơ đồ bằng React Flow.",
     outcome:
-      "Một catalog trực quan các node, edge, grouping, layout, interaction, whiteboard và architecture pattern của React Flow, không lẫn với use case map sản phẩm.",
+      "Một bộ mẫu trực quan về nút, đường nối, cách gom nhóm, bố cục, tương tác, bảng vẽ và các mẫu kiến trúc trong React Flow, tách biệt với sơ đồ nghiệp vụ của sản phẩm.",
     officeExample:
-      "Một team muốn chọn hình thái sơ đồ kỹ thuật trước khi vẽ hệ thống thật. Gallery này cho phép so sánh overview, subflow, layout, validation, whiteboard, event-driven, topology và data-lineage view trong cùng một React Flow canvas.",
-    tags: ["React Flow", "XYFlow", "Architecture Diagram", "Node Shapes", "Edge Types"],
+      "Một đội ngũ muốn chọn cách trình bày sơ đồ kỹ thuật trước khi vẽ hệ thống thật. Thư viện này cho phép so sánh toàn cảnh, luồng con, bố cục, kiểm tra hợp lệ, bảng vẽ, kiến trúc hướng sự kiện, cấu trúc liên kết và dòng dữ liệu ngay trên một canvas React Flow.",
+    tags: ["React Flow", "XYFlow", "Sơ đồ kiến trúc", "Hình dạng nút", "Kiểu đường nối"],
     steps: {
       "show-node-primitives": {
-        title: "Hiện node primitive",
-        detail: "Render input, default, output và group-style node trước khi thêm vocabulary kiến trúc riêng.",
-        evidence: "Built-in node role, label, badge, handle và grouping boundary.",
-        output: "Một canvas baseline cho thấy primitive React Flow bắt đầu từ đâu."
+        title: "Hiển thị các nút cơ bản",
+        detail: "Dựng các loại nút đầu vào, mặc định, đầu ra và nút nhóm trước khi thêm bộ hình khối kiến trúc riêng.",
+        evidence: "Vai trò của loại nút có sẵn, nhãn, huy hiệu, điểm nối và ranh giới nhóm.",
+        output: "Một canvas nền cho thấy những thành phần cơ bản của React Flow."
       },
       "add-architecture-shapes": {
-        title: "Thêm shape kiến trúc",
+        title: "Thêm hình khối kiến trúc",
         detail: "Dùng custom node cho API gateway, service, worker, database, cache, queue, topic, external system, decision, risk và note.",
-        evidence: "Entity kiến trúc phần mềm, deployment boundary, data flow và operational risk.",
-        output: "Một shape catalog tái dùng cho system diagram."
+        evidence: "Thành phần kiến trúc phần mềm, ranh giới triển khai, luồng dữ liệu và rủi ro vận hành.",
+        output: "Một bộ hình khối có thể dùng lại cho sơ đồ hệ thống."
       },
       "compare-edge-types": {
-        title: "So sánh edge type",
-        detail: "Hiện default, straight, step, smoothstep và simplebezier edge với label, arrow và async path có animation.",
-        evidence: "Sync call, async event, retry path, projection, observability và rollback relationship.",
-        output: "Một edge language giúp sơ đồ architecture dễ đọc hơn."
+        title: "So sánh các kiểu đường nối",
+        detail: "Hiển thị đường nối default, straight, step, smoothstep và simplebezier với nhãn, mũi tên và hiệu ứng chuyển động cho luồng bất đồng bộ.",
+        evidence: "Lời gọi đồng bộ, sự kiện bất đồng bộ, đường retry, projection, observability và quan hệ rollback.",
+        output: "Một quy ước đường nối giúp sơ đồ kiến trúc dễ đọc hơn."
       },
       "use-canvas-controls": {
-        title: "Dùng canvas control",
-        detail: "Giữ Background, Controls, MiniMap, fitView, zoom và pan để architecture map lớn vẫn inspect được.",
-        evidence: "Kích thước graph, zone được group, zoom level dễ đọc và position ổn định.",
-        output: "Một diagram surface dùng được cho cả overview lẫn inspect chi tiết."
+        title: "Dùng bộ điều khiển canvas",
+        detail: "Giữ Background, Controls, MiniMap, fitView, zoom và pan để sơ đồ kiến trúc lớn vẫn dễ xem xét.",
+        evidence: "Kích thước sơ đồ, các vùng đã gom nhóm, mức zoom dễ đọc và vị trí ổn định.",
+        output: "Một không gian sơ đồ dùng được cho cả toàn cảnh lẫn phần chi tiết."
       },
       "model-system-architecture": {
-        title: "Model system architecture",
-        detail: "Đặt client, edge, domain, data, external và operations zone vào cùng một câu chuyện kiến trúc.",
-        evidence: "Bounded context, service ownership, persistence, integration, telemetry và rollout safety.",
-        output: "Một checkout-style reference architecture dùng để demo toàn bộ shape set."
+        title: "Mô hình hóa kiến trúc hệ thống",
+        detail: "Đặt các vùng phía người dùng, lớp biên, domain, dữ liệu, hệ thống bên ngoài và vận hành vào cùng một câu chuyện kiến trúc.",
+        evidence: "Ranh giới nghiệp vụ, nơi sở hữu dịch vụ, lưu trữ bền vững, tích hợp, tín hiệu đo lường và độ an toàn của rollout.",
+        output: "Một kiến trúc tham khảo cho hệ thống thanh toán, dùng để minh họa toàn bộ bộ hình khối."
       },
       "turn-demo-into-template": {
-        title: "Biến demo thành template",
-        detail: "Dùng demo làm điểm bắt đầu cho architecture review, RFC, ADR, onboarding hoặc giải thích incident.",
-        evidence: "Node kind tái dùng, edge tone, zone layout và copy gọi đúng trade-off engineering.",
-        output: "Một React Flow architecture template sẵn để adapt."
+        title: "Biến ví dụ thành mẫu dùng lại",
+        detail: "Dùng bộ ví dụ làm điểm bắt đầu cho buổi rà soát kiến trúc, RFC, ADR, hướng dẫn người mới hoặc giải thích sự cố.",
+        evidence: "Loại nút có thể dùng lại, quy ước đường nối, bố cục từng vùng và nội dung nêu đúng các đánh đổi kỹ thuật.",
+        output: "Một mẫu kiến trúc React Flow sẵn sàng điều chỉnh cho hệ thống khác."
       }
     },
     artifacts: [
-      "Catalog node shape React Flow",
-      "Canvas software architecture",
-      "So sánh edge type",
-      "Ví dụ group và boundary",
-      "Demo minimap và control",
-      "Architecture template tái dùng"
+      "Bộ hình dạng nút React Flow",
+      "Canvas kiến trúc phần mềm",
+      "Bảng so sánh kiểu đường nối",
+      "Ví dụ về nhóm và ranh giới",
+      "Ví dụ MiniMap và bộ điều khiển",
+      "Mẫu kiến trúc có thể dùng lại"
     ],
-    cvSignals: ["React Flow implementation", "Software architecture visualization", "Diagram system design", "Platform communication"]
+    cvSignals: ["Triển khai React Flow", "Trực quan hóa kiến trúc phần mềm", "Thiết kế hệ thống sơ đồ", "Trình bày kiến trúc nền tảng"]
   },
   "react-flow-system-blueprint": {
-    title: "System Design Blueprint",
+    title: "Bản thiết kế hệ thống bằng React Flow",
     summary:
-      "Một bản đồ system design cỡ poster bằng React Flow, thể hiện DNS, edge policy, load balancing, backend service, cache, data store, media queue, worker và fan-out service.",
-    seoTitle: "React Flow System Design Blueprint Example",
+      "System design map cỡ lớn bằng React Flow, thể hiện DNS, edge policy, load balancing, backend services, cache, data stores, media queue, workers và downstream services.",
+    seoTitle: "Bản thiết kế hệ thống cỡ lớn bằng React Flow",
     seoDescription:
-      "Blueprint system design lớn bằng React Flow với architecture zone được group, custom node, edge có label, async path có animation, minimap, control và focused view.",
+      "Bản thiết kế hệ thống lớn bằng React Flow với các vùng kiến trúc được gom nhóm, nút tùy chỉnh, đường nối có nhãn, hiệu ứng cho luồng bất đồng bộ, MiniMap, bộ điều khiển và từng góc nhìn tập trung.",
     useWhen:
-      "Dùng khi cần chứng minh React Flow có thể gánh diagram system design dày đặc như poster kỹ thuật, không chỉ workflow chart nhỏ.",
+      "Dùng khi cần trình bày một sơ đồ thiết kế hệ thống dày thông tin như poster kỹ thuật bằng React Flow, thay vì chỉ dùng nó cho các quy trình nhỏ.",
     outcome:
-      "Một architecture canvas mạnh nhưng vẫn inspect được: overview cho toàn cảnh, focused view cho DNS, runtime, storage, media processing và fan-out.",
+      "Một canvas kiến trúc nhiều thông tin nhưng vẫn dễ xem: có góc nhìn toàn cảnh và từng góc nhìn riêng cho DNS, vận hành, lưu trữ, xử lý tệp đa phương tiện và fan-out.",
     officeExample:
-      "Một team muốn có một poster kiến trúc cho buổi review. Example này giữ diagram tương tác được, zoom được và tách được theo zone thay vì đóng băng thành ảnh tĩnh.",
-    tags: ["React Flow", "System Design", "Blueprint", "Distributed Systems", "Media Pipeline"],
+      "Một đội ngũ cần poster kiến trúc cho buổi rà soát. Bản thiết kế này vẫn cho phép tương tác, zoom và xem riêng từng vùng, thay vì đóng băng mọi thứ trong một ảnh tĩnh.",
+    tags: ["React Flow", "Thiết kế hệ thống", "Bản thiết kế", "Hệ thống phân tán", "Xử lý tệp đa phương tiện"],
     steps: {
       "map-edge-entry": {
-        title: "Map edge entry",
-        detail: "Cho thấy domain lookup, resolver, CDN, request metadata, security policy và API gateway nối với nhau trước khi traffic vào service.",
-        evidence: "DNS record, edge cache behavior, header, auth token, WAF policy, request ID và response metadata.",
-        output: "Ingress path rõ ràng để đọc được hành trình request."
+        title: "Mô tả điểm vào tại lớp biên",
+        detail: "Cho thấy bước tra cứu domain, resolver, CDN, thông tin kèm theo yêu cầu, chính sách bảo mật và API gateway nối với nhau trước khi lưu lượng vào dịch vụ.",
+        evidence: "Bản ghi DNS, hành vi cache tại lớp biên, header, token xác thực, chính sách WAF, ID của yêu cầu và metadata trong phản hồi.",
+        output: "Luồng yêu cầu đi vào hệ thống được trình bày rõ ràng."
       },
       "show-runtime-topology": {
-        title: "Hiện runtime topology",
-        detail: "Tách load balancing, frontend server, backend service, message dispatch và connection ownership thành các vùng dễ đọc.",
-        evidence: "Balancing strategy, connection table, live session transport, server ownership và routing rule.",
-        output: "Runtime zone giải thích traffic được nhận, route và dispatch ở đâu."
+        title: "Mô tả cấu trúc vận hành",
+        detail: "Tách load balancer, frontend servers, backend services, message dispatch và connection ownership thành các vùng dễ đọc.",
+        evidence: "Chiến lược cân bằng tải, bảng kết nối, cách truyền phiên trực tiếp, máy chủ phụ trách và quy tắc định tuyến.",
+        output: "Vùng vận hành giải thích lưu lượng được tiếp nhận, định tuyến và chuyển tiếp ở đâu."
       },
       "surface-coordination": {
-        title: "Đưa coordination lên bề mặt",
-        detail: "Biến distributed ID, lock, concurrency choice và metadata table thành thành phần chính của diagram.",
-        evidence: "ID strategy, lock provider, retry model, checksum, timestamp, server mapping và object pointer.",
-        output: "Coordination layer cho thấy write và streaming chunk ổn định bằng cách nào."
+        title: "Làm rõ cơ chế phối hợp",
+        detail: "Đưa ID phân tán, khóa, cách xử lý đồng thời và bảng metadata thành những thành phần chính trên sơ đồ.",
+        evidence: "Cách tạo ID, nơi cung cấp khóa, quy tắc retry, checksum, timestamp, ánh xạ máy chủ và con trỏ đến đối tượng.",
+        output: "Lớp phối hợp cho thấy thao tác ghi và các phần dữ liệu truyền liên tục được giữ ổn định như thế nào."
       },
       "trace-storage-media": {
-        title: "Trace storage và media",
-        detail: "Nối database chính, shard, replica, cache, object storage, queue, processing worker và encoded output.",
+        title: "Theo dõi dữ liệu và tệp đa phương tiện",
+        detail: "Nối primary database, shard, replica, cache, object storage, queue, processing worker và encoded file.",
         evidence: "Storage type, cache policy, queue depth, worker cost, checksum validation và compression output.",
-        output: "Data và media pipeline có thể inspect ngay trong canvas."
+        output: "Luồng dữ liệu và xử lý tệp có thể được xem xét ngay trên canvas."
       },
       "fan-out-downstream": {
-        title: "Fan out downstream",
-        detail: "Hiện các consumer như notification, recommendation, log processing, search, analytics và payment charge.",
-        evidence: "Pub/sub topic, idempotent key, blocked card, service-down state và third-party dependency.",
-        output: "Fan-out zone làm rõ secondary effect thay vì giấu sau một box."
+        title: "Làm rõ các nhánh xử lý phía sau",
+        detail: "Hiển thị downstream consumers như notification, recommendation, logging, search, analytics và payment service.",
+        evidence: "Topic pub/sub, khóa idempotent, thẻ bị chặn, trạng thái dịch vụ ngừng hoạt động và hệ thống bên thứ ba phụ thuộc.",
+        output: "Vùng fan-out làm rõ những tác động phát sinh thay vì giấu chúng sau một ô duy nhất."
       }
     },
-    artifacts: ["Full blueprint canvas", "DNS and request path view", "Runtime and balancing view", "Storage and coordination view", "Media upload and fan-out view"],
-    cvSignals: ["React Flow advanced usage", "System design depth", "Distributed systems vocabulary", "Architecture communication"]
+    artifacts: ["Canvas bản thiết kế đầy đủ", "Góc nhìn DNS và luồng yêu cầu", "Góc nhìn vận hành và cân bằng tải", "Góc nhìn lưu trữ và phối hợp", "Góc nhìn tải tệp và fan-out"],
+    cvSignals: ["Sử dụng React Flow nâng cao", "Chiều sâu trong thiết kế hệ thống", "Kiến thức về hệ thống phân tán", "Trình bày kiến trúc rõ ràng"]
   }
 };
 
@@ -2134,7 +2324,7 @@ function isVietnameseLocale(locale: string): boolean {
 
 function buildVietnameseSkillMarkdown(skillId: string, skill: LocalizedSkillCopy): string {
   const sections = [
-    `# ${skill.title} Skill`,
+    `# ${skill.title}`,
     "",
     skill.summary,
     "",
@@ -2144,10 +2334,10 @@ function buildVietnameseSkillMarkdown(skillId: string, skill: LocalizedSkillCopy
     "## Quy trình",
     ...skill.process.map((item, index) => `${index + 1}. ${item}`),
     "",
-    "## Output format",
+    "## Kết quả cần có",
     ...skill.output.map((item) => `- ${item}`),
     "",
-    "## Guardrails",
+    "## Nguyên tắc an toàn",
     ...skill.guardrails.map((item) => `- ${item}`)
   ];
   const expertAddendum = vietnameseSkillExpertAddenda[skillId];
@@ -2159,23 +2349,29 @@ function buildVietnameseSkillMarkdown(skillId: string, skill: LocalizedSkillCopy
   return sections.join("\n");
 }
 
-function localizeChecklistStep(step: StudioChecklistStep): StudioChecklistStep {
-  const copy = vietnameseStepCopies[step.id];
+function localizeChecklistStep(
+  step: StudioChecklistStep,
+  checklistId: string,
+  sectionId: string
+): StudioChecklistStep {
+  const contextualKey = `${checklistId}/${sectionId}/${step.id}`;
+  const copy = vietnameseContextualStepCopies[contextualKey] ?? vietnameseStepCopies[step.id];
   return {
     ...step,
     label: copy?.label ?? step.label,
     detail: copy?.detail ?? step.detail,
-    children: step.children?.map(localizeChecklistStep)
+    children: step.children?.map((child) => localizeChecklistStep(child, checklistId, sectionId))
   };
 }
 
-function localizeChecklistSection(section: StudioChecklistSection): StudioChecklistSection {
-  const copy = vietnameseSectionCopies[section.id];
+function localizeChecklistSection(section: StudioChecklistSection, checklistId: string): StudioChecklistSection {
+  const contextualKey = `${checklistId}/${section.id}`;
+  const copy = vietnameseContextualSectionCopies[contextualKey] ?? vietnameseSectionCopies[section.id];
   return {
     ...section,
     title: copy?.title ?? section.title,
     detail: copy?.detail ?? section.detail,
-    steps: section.steps.map(localizeChecklistStep)
+    steps: section.steps.map((step) => localizeChecklistStep(step, checklistId, section.id))
   };
 }
 
@@ -2250,7 +2446,7 @@ export function getLocalizedStudioWorkflowChecklists(locale: string): StudioWork
       summary: copy?.summary ?? checklist.summary,
       whenToUse: copy?.whenToUse ?? checklist.whenToUse,
       tags: copy?.tags ?? checklist.tags,
-      sections: checklist.sections.map(localizeChecklistSection)
+      sections: checklist.sections.map((section) => localizeChecklistSection(section, checklist.id))
     };
   });
 }

--- a/src/app/[locale]/studio/studio.localized-demos.ts
+++ b/src/app/[locale]/studio/studio.localized-demos.ts
@@ -1,0 +1,1293 @@
+import type {
+  StudioFlow,
+  StudioFlowArchitectureDemo,
+  StudioFlowArchitectureEdgeSpec,
+  StudioFlowArchitectureNodeSpec,
+  StudioFlowArchitectureViewSpec
+} from "./studio.data";
+
+type LocalizedNodeCopy = {
+  title: string;
+  detail: string;
+};
+
+type LocalizedViewCopy = {
+  title: string;
+  description: string;
+  notes: string[];
+};
+
+type LocalizedSectionCopy = {
+  title: string;
+  items: string[];
+};
+
+type LocalizedDemoCopy = {
+  sections: LocalizedSectionCopy[];
+  views: Record<string, LocalizedViewCopy>;
+  nodes: Record<string, LocalizedNodeCopy>;
+  edges: Record<string, string>;
+};
+
+const vietnameseBadgeCopies: Record<string, string> = {
+  analytics: "phân tích",
+  async: "bất đồng bộ",
+  audit: "kiểm toán",
+  base: "nền",
+  blocked: "bị chặn",
+  branch: "nhánh",
+  "built-in": "có sẵn",
+  child: "nút con",
+  chunk: "phần dữ liệu",
+  client: "máy khách",
+  cluster: "cụm",
+  cold: "lưu trữ lạnh",
+  collapsed: "đã thu gọn",
+  control: "kiểm soát",
+  cost: "chi phí",
+  custom: "tùy chỉnh",
+  data: "dữ liệu",
+  database: "database",
+  db: "CSDL",
+  decision: "quyết định",
+  dispatch: "điều phối",
+  done: "hoàn tất",
+  edge: "lớp biên",
+  event: "sự kiện",
+  expanded: "đã mở rộng",
+  external: "bên ngoài",
+  flag: "đánh dấu",
+  gate: "chốt kiểm tra",
+  gateway: "cổng",
+  group: "nhóm",
+  guide: "căn chỉnh",
+  headers: "header",
+  ingest: "tiếp nhận",
+  input: "đầu vào",
+  job: "tác vụ",
+  lasso: "vùng chọn",
+  leaf: "nút lá",
+  "level 2": "tầng 2",
+  lock: "khóa",
+  logs: "nhật ký",
+  mart: "kho theo miền",
+  media: "đa phương tiện",
+  metrics: "chỉ số",
+  model: "mô hình",
+  node: "nút",
+  note: "ghi chú",
+  notify: "thông báo",
+  ops: "vận hành",
+  outbox: "outbox",
+  output: "kết quả",
+  owned: "thuộc sở hữu",
+  panel: "bảng điều khiển",
+  pay: "thanh toán",
+  platform: "nền tảng",
+  pod: "pod",
+  policy: "chính sách",
+  process: "xử lý",
+  pubsub: "pub/sub",
+  queue: "queue",
+  raw: "dữ liệu thô",
+  read: "mô hình đọc",
+  "read model": "mô hình đọc",
+  rectangle: "khung",
+  region: "khu vực",
+  release: "release",
+  replica: "bản sao",
+  response: "phản hồi",
+  risk: "rủi ro",
+  root: "gốc",
+  search: "tìm kiếm",
+  security: "bảo mật",
+  select: "đã chọn",
+  service: "dịch vụ",
+  shard: "phân mảnh",
+  source: "nguồn",
+  state: "trạng thái",
+  storage: "lưu trữ",
+  "sub-flow": "luồng con",
+  summary: "tóm tắt",
+  table: "bảng",
+  topic: "topic",
+  valid: "hợp lệ",
+  warehouse: "kho dữ liệu",
+  worker: "tiến trình xử lý",
+  zone: "vùng"
+};
+
+const architectureSectionCopies: LocalizedSectionCopy[] = [
+  {
+    title: "Các thành phần có sẵn",
+    items: [
+      "các loại nút đầu vào, mặc định, đầu ra và nút nhóm",
+      "điểm nối nguồn và đích ở nhiều phía của nút",
+      "nhãn, huy hiệu, dòng giải thích và sắc thái trạng thái của nút"
+    ]
+  },
+  {
+    title: "Các nhóm ví dụ React Flow",
+    items: [
+      "góc nhìn toàn cảnh, tương tác, gom nhóm, bố cục, kiểu trình bày, bảng vẽ và kiến trúc",
+      "mẫu luồng con, mở hoặc thu nhánh, kiểm tra hợp lệ, đường căn chỉnh và chú thích",
+      "chuyển góc nhìn bằng danh sách chọn ngay trong một mục Studio"
+    ]
+  },
+  {
+    title: "Các nút kiến trúc phần mềm",
+    items: [
+      "dịch vụ, API gateway, tiến trình xử lý và hệ thống phụ thuộc bên ngoài",
+      "database, cache, queue, event topic và ghi chú telemetry",
+      "quyết định, rủi ro, chốt chính sách và ranh giới rollout"
+    ]
+  },
+  {
+    title: "Quy ước đường nối",
+    items: [
+      "các kiểu đường nối default, straight, step, smoothstep và simplebezier",
+      "hiệu ứng chuyển động cho luồng bất đồng bộ, mũi tên và nhãn đường nối",
+      "màu nét khác nhau cho luồng đồng bộ, bất đồng bộ, dữ liệu, rủi ro và observability"
+    ]
+  },
+  {
+    title: "Bộ điều khiển canvas",
+    items: [
+      "lưới Background, Controls, MiniMap và fitView",
+      "sơ đồ kiến trúc lớn nằm gọn trong khu vực Studio có giới hạn",
+      "vị trí nút ổn định để chụp ảnh và trao đổi"
+    ]
+  }
+];
+
+const architectureViewCopies: Record<string, LocalizedViewCopy> = {
+  "feature-overview": {
+    title: "Tổng quan tính năng",
+    description: "Bản tóm lược các vai trò nút có sẵn, thẻ tùy chỉnh, nhãn, điểm nối, marker và công cụ hỗ trợ trên canvas.",
+    notes: ["Các nút đầu vào, mặc định và đầu ra có sẵn", "Thẻ tùy chỉnh với nhiều điểm nối", "MiniMap, Controls, Background, marker và nhãn"]
+  },
+  "subflows-grouping": {
+    title: "Luồng con và cách gom nhóm",
+    description: "Thể hiện ranh giới nhóm, thứ tự đọc từ cha đến con và hệ thống lồng nhau mà không che mất các nút quan trọng bên trong.",
+    notes: ["Nút nhóm dành cho ranh giới nghiệp vụ", "Đặt nút con bên trong một ranh giới nhìn thấy được", "Đường nối đi từ luồng con này sang luồng con khác"]
+  },
+  "layout-dagre-tree": {
+    title: "Cây phân tầng kiểu Dagre",
+    description: "Cây phân tầng từ trái sang phải dành cho sơ đồ phụ thuộc, cấu trúc giống sơ đồ tổ chức và các nhánh quyết định có thể lần theo.",
+    notes: ["Đọc thứ bậc từ trái sang phải", "Các nút cùng cấp nằm trên những hàng riêng", "Phù hợp để giải thích quan hệ phụ thuộc trong kiến trúc"]
+  },
+  "expand-collapse": {
+    title: "Mở rộng và thu gọn",
+    description: "Mẫu cây biểu diễn nhánh đang mở và nhánh đã thu gọn bằng các trạng thái hiển thị riêng.",
+    notes: ["Hữu ích với sơ đồ kiến trúc lớn", "Nhánh thu gọn giúp sơ đồ dễ đọc", "Chỉ hiện nút con khi thực sự cần"]
+  },
+  "validation-helper-lines": {
+    title: "Kiểm tra hợp lệ và đường căn chỉnh",
+    description: "Góc nhìn mô hình hóa các kết nối được phép, kết nối bị từ chối và đường hỗ trợ căn chỉnh.",
+    notes: ["Đường màu xanh cho kết nối hợp lệ", "Nút rủi ro màu đỏ cho kết nối bị từ chối", "Ghi chú dẫn hướng đánh dấu hàng và khoảng cách"]
+  },
+  "whiteboard-annotation": {
+    title: "Bảng vẽ và chú thích",
+    description: "Bề mặt vẽ sơ đồ có ghi chú dán, vùng đóng khung, mũi tên chú thích và dấu hiệu rà soát theo kiểu phác thảo.",
+    notes: ["Các thành phần bảng vẽ là mẫu tùy chỉnh dựng trên React Flow", "Ghi chú và khung giúp buổi rà soát thiết kế dễ theo dõi", "Nút phác thảo có thể đứng cùng nút kiến trúc thật"]
+  },
+  "styling-dark-turbo": {
+    title: "Kiểu trình bày và giao diện",
+    description: "Góc nhìn tập trung vào ngôn ngữ hình khối, màu sắc, huy hiệu, nút nét đứt, nút chấm và cách nhấn mạnh trạng thái.",
+    notes: ["Nút React Flow có thể dùng CSS thuần hoặc component của design system", "Bảng sắc thái giúp mã hóa ý nghĩa nhất quán", "Hữu ích trước khi xây một bộ thành phần sơ đồ dùng lại"]
+  },
+  "system-design-icon-map": {
+    title: "Sơ đồ thiết kế hệ thống bằng biểu tượng",
+    description: "Sơ đồ gọn theo phong cách thiết kế hệ thống, trong đó mỗi nút gồm một biểu tượng, tên hệ thống ngắn và một ghi chú vận hành.",
+    notes: ["Nút biểu tượng gọn cho phần thiết kế hệ thống trong phỏng vấn", "Các làn rộng giúp giảm đường nối giao nhau", "Bao quát máy khách, lớp biên, dịch vụ, dữ liệu, xử lý bất đồng bộ, hệ thống ngoài và observability"]
+  },
+  "layered-platform-icon-map": {
+    title: "Sơ đồ nền tảng theo từng lớp",
+    description: "Sơ đồ thiết kế hệ thống hướng nền tảng, dùng biểu tượng gọn và gom chúng theo ranh giới sở hữu cùng môi trường vận hành.",
+    notes: ["Khung nhóm cho biết từng hệ thống nằm ở đâu", "Các lớp tách máy khách, lớp biên, dịch vụ, dữ liệu, vận hành và hệ thống phụ thuộc bên ngoài", "Hữu ích khi rà soát kiến trúc, hướng dẫn người mới và trao đổi về refactor"]
+  },
+  "architecture-service-map": {
+    title: "Sơ đồ dịch vụ phần mềm",
+    description: "Sơ đồ kiến trúc đầy đủ hơn, gồm các vùng máy khách, lớp biên, domain, dữ liệu, hệ thống bên ngoài và vận hành.",
+    notes: ["Dành cho rà soát kiến trúc và hướng dẫn người mới", "Sử dụng toàn bộ hình khối kiến trúc tùy chỉnh", "Bố cục chia theo vùng để tránh nút và đường nối chồng lên nhau"]
+  },
+  "event-driven-architecture": {
+    title: "Kiến trúc hướng sự kiện",
+    description: "Các đường đi từ nơi phát sự kiện qua broker, queue, tiến trình xử lý, projection, audit và thông báo, với hiệu ứng chuyển động cho luồng bất đồng bộ.",
+    notes: ["Phù hợp để giải thích fan-out bất đồng bộ", "Đường nối chuyển động giúp nhận ra luồng sự kiện", "DLQ và audit là những nút độc lập, không bị giấu đi"]
+  },
+  "deployment-topology": {
+    title: "Cấu trúc triển khai",
+    description: "Khu vực, VPC, cụm máy, dịch vụ, kho dữ liệu và hệ thống phụ thuộc tại lớp biên trong cùng một sơ đồ triển khai.",
+    notes: ["Dùng nút nhóm cho ranh giới triển khai", "Các vùng rõ ràng giúp trao đổi về trách nhiệm sở hữu", "Hệ thống phụ thuộc bên ngoài nằm ngoài ranh giới vận hành"]
+  },
+  "data-lineage": {
+    title: "Dòng dữ liệu",
+    description: "Theo dõi hệ thống nguồn, bước tiếp nhận, biến đổi, lưu trữ, kho dữ liệu theo miền, BI và trách nhiệm audit.",
+    notes: ["Hữu ích cho kiến trúc phân tích dữ liệu", "Tách operational database khỏi analytics warehouse và data mart", "Cho thấy ranh giới audit và quyền riêng tư"]
+  }
+};
+
+const blueprintSectionCopies: LocalizedSectionCopy[] = [
+  {
+    title: "Canvas cỡ bản thiết kế",
+    items: [
+      "sơ đồ thiết kế hệ thống nhiều vùng, lấy cảm hứng từ poster kiến trúc production",
+      "DNS, metadata của yêu cầu, cân bằng tải, lưu trữ, xử lý tệp đa phương tiện, queue và dịch vụ fan-out",
+      "sơ đồ lớn vẫn dễ xem nhờ MiniMap, Controls, fitView, pan, zoom và chế độ toàn màn hình"
+    ]
+  },
+  {
+    title: "Khả năng nâng cao của React Flow",
+    items: [
+      "custom node cho gateway, service, database, cache, queue, worker, risk, note và external system",
+      "nút nhóm tạo vùng trực quan mà không làm phẳng kiến trúc",
+      "nhãn đường nối, mũi tên marker, luồng bất đồng bộ có chuyển động và nhiều kiểu đường nối"
+    ]
+  },
+  {
+    title: "Cách dùng khi phỏng vấn và rà soát",
+    items: [
+      "dùng sơ đồ đầy đủ để trao đổi về chiều sâu kiến trúc",
+      "chuyển sang góc nhìn tập trung khi người xem muốn đi sâu vào DNS, vận hành, lưu trữ hoặc xử lý tệp",
+      "giữ nội dung nút ngắn gọn để sơ đồ vẫn dễ dùng thay vì trở thành một poster tĩnh"
+    ]
+  }
+];
+
+const blueprintViewCopies: Record<string, LocalizedViewCopy> = {
+  "blueprint-full": {
+    title: "Bản thiết kế hệ thống đầy đủ",
+    description: "Sơ đồ dày thông tin theo phong cách production, gom DNS, edge policy, load balancing, backend services, cache, database, media processing, queue và fan-out services trên một canvas React Flow.",
+    notes: ["Canvas lớn gồm nhiều vùng", "Kết hợp nhiều hình dạng nút và ranh giới nhóm", "Đường bất đồng bộ có chuyển động, nhãn, marker, MiniMap, bộ điều khiển và chế độ toàn màn hình"]
+  },
+  "blueprint-dns-request": {
+    title: "Từ DNS đến luồng yêu cầu",
+    description: "Đi sâu vào cách một lần tra cứu domain trở thành yêu cầu tại lớp biên, đi qua kiểm tra chính sách, metadata của yêu cầu và metadata của phản hồi.",
+    notes: ["Các bước truy vấn DNS resolver", "Ranh giới CDN và gateway", "Ghi chú bảo mật và observability nằm gần luồng yêu cầu"]
+  },
+  "blueprint-runtime": {
+    title: "Vận hành và cân bằng tải",
+    description: "Tập trung vào traffic từ API Gateway qua load balancer, frontend servers, CDN/Edge, backend cluster, message dispatcher và connection state.",
+    notes: ["Chiến lược cân bằng tải là một phần chính của sơ đồ", "Trách nhiệm của frontend và backend được trình bày rõ", "Bảng kết nối và đường điều phối tách khỏi điểm nhận yêu cầu"]
+  },
+  "blueprint-storage": {
+    title: "Lưu trữ, cache và phối hợp",
+    description: "Xem độ ổn định khi backend ghi dữ liệu, distributed ID, lock, metadata, primary data, shard, replica, cold storage và cache policy.",
+    notes: ["Cơ chế coordination nằm cạnh storage", "Lựa chọn cache không bị giấu sau database", "Metadata table hiện rõ như một thành phần routing"]
+  },
+  "blueprint-media-fanout": {
+    title: "Tải tệp và fan-out",
+    description: "Theo dõi từng raw chunk qua queue validation, processing workers, encoded media storage và các fan-out service như notification, search, analytics và payment.",
+    notes: ["Xử lý tệp dựa trên queue", "Chi phí tiến trình xử lý và tín hiệu retry", "Các dịch vụ phía sau được thể hiện như những bên nhận fan-out"]
+  }
+};
+
+const architectureNodeCopies: Record<string, LocalizedNodeCopy> = {
+  "client-zone": {
+    title: "Ranh giới máy khách",
+    detail: "Vùng lớn, dễ nhận biết dành cho các ứng dụng hướng tới người dùng."
+  },
+  "internet-user": {
+    title: "Nút đầu vào",
+    detail: "Khách hàng, webhook từ đối tác, lịch chạy tự động hoặc sự kiện từ ứng dụng di động."
+  },
+  "web-app": {
+    title: "Nút mặc định",
+    detail: "Ứng dụng web, BFF, dashboard hoặc giao diện nội bộ."
+  },
+  "edge-zone": {
+    title: "Ranh giới lớp biên và chính sách",
+    detail: "Điểm tiếp nhận, kiểm soát bảo mật, định tuyến và các chốt phê duyệt."
+  },
+  "api-gateway": {
+    title: "API Gateway",
+    detail: "Tiếp nhận yêu cầu, giới hạn tần suất, bàn giao xác thực, định tuyến và chuẩn hóa yêu cầu."
+  },
+  "auth-service": {
+    title: "Dịch vụ xác thực",
+    detail: "Trao đổi token, xác định tenant và kiểm tra phiên."
+  },
+  "policy-decision": {
+    title: "Chính sách nào?",
+    detail: "Rẽ nhánh theo quyền truy cập, rollout, tuân thủ hoặc tenant."
+  },
+  "rate-limit-risk": {
+    title: "Chốt kiểm soát rủi ro",
+    detail: "Hạn chế lạm dụng, cô lập lỗi và bảo vệ các luồng quan trọng."
+  },
+  "ops-zone": {
+    title: "Vận hành và độ tin cậy",
+    detail: "Chốt release, observability, audit và cơ chế rollback."
+  },
+  observability: {
+    title: "Ghi chú telemetry",
+    detail: "Log, trace, chỉ số, người phụ trách, dashboard và đường cảnh báo."
+  },
+  rollback: {
+    title: "Kế hoạch rollback",
+    detail: "Feature flag, đường quay lại của migration và giới hạn phạm vi ảnh hưởng."
+  },
+  "audit-log": {
+    title: "Nhật ký audit",
+    detail: "Bản ghi chỉ nối thêm dành cho thao tác quản trị, tiền và quyền riêng tư."
+  },
+  "domain-zone": {
+    title: "Các dịch vụ domain",
+    detail: "Ranh giới nghiệp vụ gồm dịch vụ, luồng sự kiện, tiến trình xử lý và đường retry."
+  },
+  "order-service": {
+    title: "Dịch vụ đơn hàng",
+    detail: "Xử lý lệnh, kiểm tra hợp lệ, bảo đảm idempotency và sở hữu aggregate."
+  },
+  "inventory-service": {
+    title: "Dịch vụ tồn kho",
+    detail: "Dịch vụ ngang hàng chịu trách nhiệm giữ chỗ và hoàn lại tồn kho."
+  },
+  "domain-events": {
+    title: "Topic sự kiện",
+    detail: "Luồng pub/sub dành cho projection và các bên nhận dữ liệu phía sau."
+  },
+  worker: {
+    title: "Tiến trình xử lý",
+    detail: "Xử lý bất đồng bộ các tác động phụ và tác vụ chạy lâu."
+  },
+  "order-queue": {
+    title: "Queue",
+    detail: "Luồng lệnh có bộ đệm, giới hạn retry, DLQ và backpressure."
+  },
+  "data-zone": {
+    title: "Lớp dữ liệu",
+    detail: "Nguồn giao dịch, cache và mô hình đọc được tách biệt."
+  },
+  "primary-db": {
+    title: "Cơ sở dữ liệu chính",
+    detail: "Nơi lưu giao dịch, đóng vai trò nguồn dữ liệu chuẩn."
+  },
+  "redis-cache": {
+    title: "Cache",
+    detail: "Redis, cache CDN, cache cục bộ hoặc bảng tra cứu đã tính sẵn."
+  },
+  warehouse: {
+    title: "Kho dữ liệu",
+    detail: "Mô hình đọc, bảng BI, lakehouse hoặc kho lưu trữ audit."
+  },
+  "payment-provider": {
+    title: "Dịch vụ SaaS bên ngoài",
+    detail: "Nhà cung cấp thanh toán, API đối tác, đơn vị KYC hoặc dịch vụ đám mây."
+  },
+  response: {
+    title: "Nút đầu ra",
+    detail: "Trạng thái cuối, biên nhận, thông báo cho người dùng hoặc phản hồi công khai."
+  },
+  "overview-input": {
+    title: "Đầu vào",
+    detail: "Tác nhân khởi đầu với quy ước điểm nối theo hướng từ trái sang phải."
+  },
+  "overview-default": {
+    title: "Mặc định",
+    detail: "Nút chữ nhật đơn giản để phác nhanh một quy trình."
+  },
+  "overview-service": {
+    title: "Nút tùy chỉnh",
+    detail: "Nút React dạng component, có huy hiệu, phần mô tả và trạng thái theo giao diện."
+  },
+  "overview-output": {
+    title: "Đầu ra",
+    detail: "Trạng thái cuối, phản hồi cho người dùng, dữ liệu xuất ra hoặc tín hiệu hoàn tất."
+  },
+  "overview-note": {
+    title: "Bảng phủ trên canvas",
+    detail: "Dùng giao diện cố định nằm ngoài nút cho bộ chọn và các nút điều khiển sơ đồ."
+  },
+  "overview-risk": {
+    title: "Trạng thái được nhấn mạnh",
+    detail: "Sắc thái có thể đánh dấu lỗi, cảnh báo, phần cần rà soát hoặc trạng thái bị chặn."
+  },
+  "group-client": {
+    title: "Nhóm máy khách",
+    detail: "Ranh giới trực quan đóng vai trò như một nút cha."
+  },
+  "group-api": {
+    title: "Nhóm API",
+    detail: "Khu vực dịch vụ được lồng bên trong."
+  },
+  "group-mobile": {
+    title: "Ứng dụng di động",
+    detail: "Nút con nằm bên trong nhóm máy khách."
+  },
+  "group-web": {
+    title: "Ứng dụng web",
+    detail: "Nút con cùng cấp trong một ranh giới."
+  },
+  "group-gateway": {
+    title: "Gateway",
+    detail: "Điểm bắt đầu đi qua ranh giới nhóm."
+  },
+  "group-service": {
+    title: "Dịch vụ hồ sơ",
+    detail: "Dịch vụ nằm bên trong nhóm API."
+  },
+  "group-db": {
+    title: "Cơ sở dữ liệu hồ sơ",
+    detail: "Nơi lưu dữ liệu có thể nằm trong hoặc ngoài nhóm."
+  },
+  "tree-root": {
+    title: "Yêu cầu gốc",
+    detail: "Điểm vào duy nhất của cây bố cục."
+  },
+  "tree-router": {
+    title: "Bộ định tuyến",
+    detail: "Rẽ nhánh yêu cầu theo đường dẫn hoặc tenant."
+  },
+  "tree-a": {
+    title: "Dịch vụ A",
+    detail: "Nhánh thứ nhất ở cùng một độ sâu."
+  },
+  "tree-b": {
+    title: "Dịch vụ B",
+    detail: "Nhánh thứ hai giữ khoảng cách theo chiều ngang."
+  },
+  "tree-a-db": {
+    title: "Cơ sở dữ liệu A",
+    detail: "Nút lá nằm dưới Dịch vụ A."
+  },
+  "tree-a-cache": {
+    title: "Cache A",
+    detail: "Leaf node cùng cấp với database A."
+  },
+  "tree-b-worker": {
+    title: "Tiến trình xử lý B",
+    detail: "Nút lá bất đồng bộ nằm dưới Dịch vụ B."
+  },
+  "tree-b-topic": {
+    title: "Topic B",
+    detail: "Nút lá sự kiện nằm dưới Dịch vụ B."
+  },
+  "expand-root": {
+    title: "Nút gốc",
+    detail: "Chủ đề hoặc hệ thống chính."
+  },
+  "expand-open": {
+    title: "Nhánh đang mở",
+    detail: "Các nút con đang hiển thị bên dưới nút này."
+  },
+  "expand-closed": {
+    title: "Nhánh đã thu gọn",
+    detail: "Các nút con được thay bằng một nút tóm tắt."
+  },
+  "expand-child-a": {
+    title: "Nút con A",
+    detail: "Nút con đang hiển thị trong nhánh mở."
+  },
+  "expand-child-b": {
+    title: "Nút con B",
+    detail: "Nút con đang hiển thị trong nhánh mở."
+  },
+  "expand-summary": {
+    title: "+ 4 nút đang ẩn",
+    detail: "Nút giữ chỗ giúp canvas vẫn gọn khi nhánh được thu lại."
+  },
+  "expand-output": {
+    title: "Nhánh đã chọn",
+    detail: "Một nhánh đang được tập trung vẫn có thể đi đến kết quả cuối."
+  },
+  "validation-source": {
+    title: "Điểm nối nguồn",
+    detail: "Chỉ những đích đã được cho phép mới có thể kết nối."
+  },
+  "validation-service": {
+    title: "Đích được phép",
+    detail: "Đường kết nối hợp lệ."
+  },
+  "validation-risk": {
+    title: "Đích bị từ chối",
+    detail: "Đường nối không hợp lệ hoặc quan hệ phụ thuộc bị cấm."
+  },
+  "validation-db": {
+    title: "Nơi lưu trữ được phép",
+    detail: "Dịch vụ chịu trách nhiệm với quan hệ phụ thuộc này."
+  },
+  "validation-guide-x": {
+    title: "Đường căn chỉnh",
+    detail: "Cho biết các nút đã thẳng hàng khi được di chuyển."
+  },
+  "validation-output": {
+    title: "Sơ đồ được chấp nhận",
+    detail: "Chỉ những đường hợp lệ mới trở thành một phần của sơ đồ."
+  },
+  "whiteboard-frame": {
+    title: "Khung rà soát",
+    detail: "Vùng đóng khung dành cho một buổi làm việc chung hoặc chủ đề cần rà soát."
+  },
+  "whiteboard-note": {
+    title: "Ghi chú dán",
+    detail: "Câu hỏi còn mở, ý kiến của người rà soát hoặc lời nhắc về quyết định."
+  },
+  "whiteboard-service": {
+    title: "Phương án đang cân nhắc",
+    detail: "Nút thật vẫn hoạt động như một phần của sơ đồ."
+  },
+  "whiteboard-lasso": {
+    title: "Vùng chọn",
+    detail: "Ranh giới kiểu lasso có thể mô tả thao tác áp dụng cho nhiều nút."
+  },
+  "whiteboard-a": {
+    title: "Nút A đã chọn",
+    detail: "Nút đầu tiên trong vùng chọn."
+  },
+  "whiteboard-b": {
+    title: "Nút B đã chọn",
+    detail: "Nút thứ hai trong vùng chọn."
+  },
+  "whiteboard-risk": {
+    title: "Đánh dấu của người rà soát",
+    detail: "Mũi tên chú thích chỉ vào điểm cần lưu ý."
+  },
+  "whiteboard-output": {
+    title: "Quyết định",
+    detail: "Thay đổi được chấp thuận hoặc việc cần làm tiếp theo."
+  },
+  "style-source": {
+    title: "Sắc thái nguồn",
+    detail: "Nhóm đầu vào dùng màu xanh lam."
+  },
+  "style-process": {
+    title: "Sắc thái xử lý",
+    detail: "Dịch vụ hoặc hành động cốt lõi."
+  },
+  "style-event": {
+    title: "Sắc thái sự kiện",
+    detail: "Luồng sự kiện dùng nét chấm."
+  },
+  "style-storage": {
+    title: "Sắc thái lưu trữ",
+    detail: "Hình trụ thể hiện nơi sở hữu dữ liệu."
+  },
+  "style-external": {
+    title: "Sắc thái bên ngoài",
+    detail: "Nét đứt dành cho ranh giới của hệ thống phụ thuộc."
+  },
+  "style-risk": {
+    title: "Sắc thái rủi ro",
+    detail: "Trạng thái cần được chú ý cao."
+  },
+  "style-output": {
+    title: "Sắc thái kết quả",
+    detail: "Kết quả đã hoàn thành hoặc được chấp nhận."
+  },
+  "sys-users": {
+    title: "Người dùng",
+    detail: "Lưu lượng từ web và ứng dụng di động"
+  },
+  "sys-admin": {
+    title: "Quản trị viên",
+    detail: "Các thao tác vận hành nội bộ"
+  },
+  "sys-cdn": {
+    title: "CDN",
+    detail: "Tài nguyên tĩnh"
+  },
+  "sys-gateway": {
+    title: "API Gateway",
+    detail: "Xác thực, giới hạn tần suất và định tuyến"
+  },
+  "sys-auth": {
+    title: "Xác thực",
+    detail: "Token và tenant"
+  },
+  "sys-api": {
+    title: "API cốt lõi",
+    detail: "Lệnh và truy vấn đọc"
+  },
+  "sys-order": {
+    title: "Đơn hàng",
+    detail: "Nơi sở hữu aggregate"
+  },
+  "sys-inventory": {
+    title: "Tồn kho",
+    detail: "Trạng thái giữ chỗ"
+  },
+  "sys-bus": {
+    title: "Bus sự kiện",
+    detail: "Fan-out bất đồng bộ"
+  },
+  "sys-worker": {
+    title: "Các tiến trình xử lý",
+    detail: "Retry và tác động phụ"
+  },
+  "sys-postgres": {
+    title: "Postgres",
+    detail: "Nguồn dữ liệu chuẩn"
+  },
+  "sys-redis": {
+    title: "Redis",
+    detail: "Dữ liệu đọc thường xuyên và khóa"
+  },
+  "sys-warehouse": {
+    title: "Kho dữ liệu",
+    detail: "Mô hình đọc"
+  },
+  "sys-observe": {
+    title: "Telemetry",
+    detail: "Log, chỉ số và trace"
+  },
+  "sys-payment": {
+    title: "API thanh toán",
+    detail: "Ranh giới nhà cung cấp"
+  },
+  "sys-output": {
+    title: "Biên nhận",
+    detail: "Trạng thái người dùng nhìn thấy"
+  },
+  "layer-client": {
+    title: "Nền tảng máy khách",
+    detail: "Các điểm vào công khai và nội bộ."
+  },
+  "layer-edge": {
+    title: "Nền tảng lớp biên",
+    detail: "Ranh giới phân phối, định danh, chính sách và định tuyến."
+  },
+  "layer-services": {
+    title: "Nền tảng dịch vụ",
+    detail: "Các dịch vụ domain cùng phần thực thi bất đồng bộ."
+  },
+  "layer-data": {
+    title: "Nền tảng dữ liệu",
+    detail: "Mô hình giao dịch, cache và phân tích."
+  },
+  "layer-ops": {
+    title: "Nền tảng vận hành",
+    detail: "Telemetry, audit và cơ chế kiểm soát release."
+  },
+  "layer-external": {
+    title: "Ranh giới bên ngoài",
+    detail: "API của nhà cung cấp và kết quả người dùng nhìn thấy."
+  },
+  "layer-users": {
+    title: "Người dùng",
+    detail: "Lưu lượng từ web và ứng dụng di động"
+  },
+  "layer-admin": {
+    title: "Quản trị viên",
+    detail: "Giao diện vận hành"
+  },
+  "layer-cdn": {
+    title: "CDN",
+    detail: "Phân phối tài nguyên tĩnh"
+  },
+  "layer-gateway": {
+    title: "Gateway",
+    detail: "Giới hạn tần suất và định tuyến"
+  },
+  "layer-auth": {
+    title: "Xác thực",
+    detail: "Phiên và tenant"
+  },
+  "layer-api": {
+    title: "API cốt lõi",
+    detail: "Ranh giới nhận lệnh"
+  },
+  "layer-order": {
+    title: "Đơn hàng",
+    detail: "Nơi sở hữu aggregate"
+  },
+  "layer-inventory": {
+    title: "Tồn kho",
+    detail: "Nơi sở hữu trạng thái giữ chỗ"
+  },
+  "layer-bus": {
+    title: "Bus sự kiện",
+    detail: "Fan-out bất đồng bộ"
+  },
+  "layer-worker": {
+    title: "Các tiến trình xử lý",
+    detail: "Retry và tác động phụ"
+  },
+  "layer-postgres": {
+    title: "Postgres",
+    detail: "Nguồn dữ liệu chuẩn"
+  },
+  "layer-redis": {
+    title: "Redis",
+    detail: "Dữ liệu đọc thường xuyên và khóa"
+  },
+  "layer-warehouse": {
+    title: "Kho dữ liệu",
+    detail: "Mô hình đọc"
+  },
+  "layer-telemetry": {
+    title: "Telemetry",
+    detail: "Chỉ số và trace"
+  },
+  "layer-audit": {
+    title: "Audit",
+    detail: "Lịch sử chỉ nối thêm"
+  },
+  "layer-rollout": {
+    title: "Rollout",
+    detail: "Feature flag và rollback"
+  },
+  "layer-payment": {
+    title: "API thanh toán",
+    detail: "Hợp đồng với nhà cung cấp"
+  },
+  "layer-receipt": {
+    title: "Biên nhận",
+    detail: "Trạng thái người dùng nhìn thấy"
+  },
+  "eda-client": {
+    title: "Yêu cầu thanh toán",
+    detail: "Lệnh đi vào hệ thống đúng một lần."
+  },
+  "eda-command": {
+    title: "Dịch vụ nhận lệnh",
+    detail: "Kiểm tra hợp lệ rồi ghi lệnh."
+  },
+  "eda-outbox": {
+    title: "Outbox",
+    detail: "Bản ghi sự kiện nằm trong cùng giao dịch."
+  },
+  "eda-topic": {
+    title: "Topic đơn hàng",
+    detail: "Luồng sự kiện fan-out."
+  },
+  "eda-worker-a": {
+    title: "Tiến trình thanh toán",
+    detail: "Nhận và xử lý các sự kiện thanh toán."
+  },
+  "eda-worker-b": {
+    title: "Tiến trình gửi email",
+    detail: "Nhận và xử lý các sự kiện thông báo."
+  },
+  "eda-dlq": {
+    title: "DLQ",
+    detail: "Thông điệp lỗi cùng người chịu trách nhiệm phát lại."
+  },
+  "eda-provider": {
+    title: "API thanh toán",
+    detail: "Hệ thống phụ thuộc bên ngoài được bảo vệ bằng retry."
+  },
+  "eda-projection": {
+    title: "Projection",
+    detail: "Mô hình đọc được cập nhật từ sự kiện."
+  },
+  "eda-output": {
+    title: "Cập nhật cho người dùng",
+    detail: "Biên nhận, email hoặc trang trạng thái."
+  },
+  "deploy-region": {
+    title: "Khu vực ap-southeast-1",
+    detail: "Ranh giới cao nhất của hạ tầng đám mây hoặc trung tâm dữ liệu."
+  },
+  "deploy-cluster": {
+    title: "Cụm Kubernetes",
+    detail: "Ranh giới tài nguyên tính toán bên trong khu vực."
+  },
+  "deploy-edge": {
+    title: "Điểm tiếp nhận",
+    detail: "Bộ cân bằng tải, WAF, gateway hoặc đường định tuyến tại lớp biên."
+  },
+  "deploy-api": {
+    title: "Pod API",
+    detail: "Tải ứng dụng có thể mở rộng theo chiều ngang."
+  },
+  "deploy-worker": {
+    title: "Pod xử lý nền",
+    detail: "Tải công việc chạy nền."
+  },
+  "deploy-cache": {
+    title: "Redis",
+    detail: "Cache dùng chung trong mạng riêng."
+  },
+  "deploy-db": {
+    title: "Cơ sở dữ liệu được quản lý",
+    detail: "Dịch vụ có trạng thái do nhà cung cấp quản lý."
+  },
+  "deploy-observe": {
+    title: "Observability",
+    detail: "Log, chỉ số, trace và người phụ trách cảnh báo."
+  },
+  "deploy-cdn": {
+    title: "CDN",
+    detail: "Cache công khai và tài nguyên tĩnh."
+  },
+  "deploy-third-party": {
+    title: "API bên thứ ba",
+    detail: "Hệ thống phụ thuộc bên ngoài có giới hạn timeout."
+  },
+  "deploy-output": {
+    title: "Release ổn định",
+    detail: "Lưu lượng, cảnh báo và đường rollback đều nhìn thấy được."
+  },
+  "lineage-app": {
+    title: "Sự kiện sản phẩm",
+    detail: "Lượt nhấp, đơn hàng, phiên và sự kiện vận hành."
+  },
+  "lineage-db": {
+    title: "Cơ sở dữ liệu vận hành",
+    detail: "Hệ thống nguồn cho dữ liệu giao dịch."
+  },
+  "lineage-ingest": {
+    title: "Tiếp nhận dữ liệu",
+    detail: "Ranh giới tiếp nhận theo lô hoặc theo luồng."
+  },
+  "lineage-raw": {
+    title: "Hồ dữ liệu thô",
+    detail: "Vùng dữ liệu thô không thay đổi."
+  },
+  "lineage-transform": {
+    title: "Tác vụ biến đổi",
+    detail: "Tác vụ dbt, Spark, SQL hoặc tiến trình chạy theo lịch."
+  },
+  "lineage-warehouse": {
+    title: "Kho dữ liệu",
+    detail: "Mô hình phân tích sạch, dùng chung."
+  },
+  "lineage-mart": {
+    title: "Kho dữ liệu theo miền",
+    detail: "Các bảng chỉ số do từng đội ngũ sở hữu."
+  },
+  "lineage-bi": {
+    title: "Dashboard BI",
+    detail: "Nơi người đọc xem dữ liệu để ra quyết định."
+  },
+  "lineage-audit": {
+    title: "Rà soát quyền riêng tư",
+    detail: "Thời gian lưu giữ, quyền truy cập, PII, người phụ trách dòng dữ liệu và lịch sử audit."
+  }
+};
+
+const architectureEdgeCopies: Record<string, string> = {
+  "user-web": "đường nối thẳng",
+  "web-gateway": "yêu cầu smoothstep",
+  "gateway-auth": "kiểm tra xác thực theo bậc",
+  "gateway-policy": "quyết định mặc định",
+  "gateway-risk": "nhánh rủi ro",
+  "policy-order": "lệnh được cho phép",
+  "order-inventory": "lời gọi đồng bộ",
+  "order-db": "giao dịch",
+  "order-cache": "đọc xuyên qua cache",
+  "order-events": "phát sự kiện có chuyển động",
+  "events-worker": "nhận bất đồng bộ",
+  "worker-queue": "retry / DLQ",
+  "events-warehouse": "projection",
+  "order-payment": "API đối tác",
+  "provider-response": "trạng thái cuối",
+  "gateway-observability": "chỉ số / trace",
+  "order-audit": "ghi nối tiếp vào audit",
+  "rollback-audit": "bằng chứng release",
+  "overview-edge-1": "smoothstep",
+  "overview-edge-2": "mặc định",
+  "overview-edge-3": "đường thẳng",
+  "overview-edge-4": "theo bậc",
+  "overview-edge-5": "simplebezier",
+  "group-mobile-gateway": "lời gọi từ máy khách",
+  "group-web-gateway": "cùng nhóm cha",
+  "group-gateway-service": "đi qua ranh giới nhóm",
+  "group-service-db": "sở hữu dữ liệu",
+  "tree-root-router": "yêu cầu",
+  "tree-router-a": "nhánh A",
+  "tree-router-b": "nhánh B",
+  "tree-a-db": "đọc / ghi",
+  "tree-a-cache": "cache",
+  "tree-b-worker": "tác vụ",
+  "tree-b-topic": "phát sự kiện",
+  "expand-root-open": "mở",
+  "expand-root-closed": "đã thu gọn",
+  "expand-open-a": "đang hiển thị",
+  "expand-open-b": "đang hiển thị",
+  "expand-closed-summary": "tóm tắt",
+  "expand-a-output": "đã chọn",
+  "expand-b-output": "đã chọn",
+  "validation-valid": "hợp lệ",
+  "validation-invalid": "bị chặn",
+  "validation-service-db": "thuộc sở hữu",
+  "validation-guide": "đã căn chỉnh",
+  "validation-db-output": "được chấp nhận",
+  "whiteboard-note-service": "nhận xét",
+  "whiteboard-service-a": "so sánh",
+  "whiteboard-a-b": "cùng vùng chọn",
+  "whiteboard-risk-output": "đã xử lý",
+  "style-1": "chính",
+  "style-2": "phát sự kiện",
+  "style-3": "tạo mô hình đọc",
+  "style-4": "rủi ro",
+  "style-5": "xử lý",
+  "sys-users-cdn": "tài nguyên",
+  "sys-users-gateway": "HTTPS",
+  "sys-admin-gateway": "vận hành",
+  "sys-gateway-auth": "token",
+  "sys-gateway-api": "định tuyến",
+  "sys-api-order": "lệnh",
+  "sys-api-inventory": "truy vấn",
+  "sys-order-bus": "sự kiện",
+  "sys-bus-worker": "nhận xử lý",
+  "sys-order-postgres": "ghi",
+  "sys-inventory-redis": "cache",
+  "sys-postgres-warehouse": "CDC",
+  "sys-api-observe": "tín hiệu",
+  "sys-worker-payment": "thu tiền",
+  "sys-payment-output": "trạng thái",
+  "sys-observe-output": "SLO",
+  "layer-users-cdn": "tài nguyên",
+  "layer-users-gateway": "HTTPS",
+  "layer-admin-gateway": "vận hành",
+  "layer-gateway-auth": "chính sách",
+  "layer-auth-api": "các claim",
+  "layer-gateway-api": "định tuyến",
+  "layer-api-order": "lệnh",
+  "layer-api-inventory": "truy vấn",
+  "layer-order-bus": "sự kiện",
+  "layer-bus-worker": "nhận xử lý",
+  "layer-order-postgres": "ghi",
+  "layer-inventory-redis": "cache",
+  "layer-bus-warehouse": "tạo mô hình đọc",
+  "layer-api-telemetry": "trace",
+  "layer-postgres-audit": "audit",
+  "layer-worker-payment": "thu tiền",
+  "layer-payment-receipt": "trạng thái",
+  "layer-rollout-receipt": "chốt release",
+  "eda-client-command": "lệnh",
+  "eda-command-outbox": "ghi sự kiện",
+  "eda-outbox-topic": "chuyển tiếp",
+  "eda-topic-worker-a": "nhận xử lý",
+  "eda-topic-worker-b": "nhận xử lý",
+  "eda-topic-dlq": "lỗi",
+  "eda-worker-provider": "retry API",
+  "eda-worker-projection": "cập nhật mô hình đọc",
+  "eda-projection-output": "thông báo",
+  "deploy-cdn-edge": "tĩnh + động",
+  "deploy-edge-api": "định tuyến",
+  "deploy-api-worker": "tác vụ",
+  "deploy-api-cache": "cache",
+  "deploy-api-db": "SQL",
+  "deploy-worker-third-party": "nhà cung cấp",
+  "deploy-db-observe": "tín hiệu",
+  "deploy-observe-output": "chốt release",
+  "lineage-app-ingest": "luồng sự kiện",
+  "lineage-db-ingest": "CDC",
+  "lineage-ingest-raw": "đưa vào vùng thô",
+  "lineage-raw-transform": "làm sạch",
+  "lineage-transform-warehouse": "công bố",
+  "lineage-warehouse-mart": "tạo mô hình",
+  "lineage-warehouse-bi": "phục vụ truy vấn",
+  "lineage-warehouse-audit": "rà soát"
+};
+
+const blueprintNodeCopies: Record<string, LocalizedNodeCopy> = {
+  "dns-zone": {
+    title: "Phân giải DNS",
+    detail: "Máy chủ gốc, TLD, máy chủ tên có thẩm quyền, resolver và bước tìm IP mà máy khách nhìn thấy."
+  },
+  "client-phone": {
+    title: "Di động / Trình duyệt",
+    detail: "Người dùng nhập domain và bắt đầu luồng yêu cầu."
+  },
+  "recursive-resolver": {
+    title: "Resolver đệ quy",
+    detail: "Resolver của nhà mạng hoặc dịch vụ công cộng kiểm tra cache trước khi truy vấn DNS."
+  },
+  "root-ns": {
+    title: "Root NS",
+    detail: "Trả về máy chủ tên TLD cho .com, .org hoặc một hậu tố khác."
+  },
+  "tld-ns": {
+    title: "TLD NS",
+    detail: "Chỉ resolver đến máy chủ tên có thẩm quyền."
+  },
+  "authoritative-ns": {
+    title: "Máy chủ tên có thẩm quyền",
+    detail: "Trả về bản ghi cuối, TTL và đích canonical."
+  },
+  "resolved-ip": {
+    title: "IP đã phân giải",
+    detail: "IP, CNAME, TTL, trạng thái DNSSEC và khả năng cache."
+  },
+  "request-zone": {
+    title: "Yêu cầu từ máy khách và chính sách lớp biên",
+    detail: "Metadata của yêu cầu, kiểm soát bảo mật, CDN, API gateway và thông tin phản hồi."
+  },
+  "request-envelope": {
+    title: "Gói thông tin yêu cầu",
+    detail: "Header, ID yêu cầu, khóa idempotency, token xác thực, ngôn ngữ và cách nén."
+  },
+  "cdn-edge": {
+    title: "CDN / Lớp biên",
+    detail: "TLS, cache tài nguyên tĩnh, WAF, kiểm tra bot và định tuyến theo khu vực."
+  },
+  "api-gateway-blueprint": {
+    title: "API Gateway",
+    detail: "Kiểm tra hợp lệ, bàn giao xác thực, giới hạn tần suất, định tuyến, đo mức sử dụng và loại yêu cầu trùng."
+  },
+  "response-envelope": {
+    title: "Gói thông tin phản hồi",
+    detail: "Mã 4xx/5xx, phân trang, header cache, cookie, độ trễ và mã lỗi."
+  },
+  "security-options": {
+    title: "Các lựa chọn bảo mật",
+    detail: "OAuth, quy tắc WAF, chính sách TLS, CSRF, ký yêu cầu và khoảng thời gian chống phát lại."
+  },
+  "observability-note": {
+    title: "Dải chỉ số",
+    detail: "Thời gian phản hồi, mã trạng thái lỗi, số kết nối đang hoạt động và thông báo lỗi."
+  },
+  "runtime-zone": {
+    title: "Cân bằng tải và vận hành",
+    detail: "Định tuyến đầu vào, lựa chọn cân bằng tải, máy chủ frontend, cụm backend và đường điều phối."
+  },
+  "load-balancer": {
+    title: "Bộ cân bằng tải",
+    detail: "Round robin, gán trọng số, ít kết nối nhất, hashing và kiểm tra sức khỏe."
+  },
+  "frontend-servers": {
+    title: "Các máy chủ frontend",
+    detail: "HTTP, WebSocket, SSE, short polling, API truyền luồng và phiên trực tiếp."
+  },
+  "edge-static": {
+    title: "Các máy chủ CDN / Edge",
+    detail: "Tài nguyên tĩnh toàn cầu, luồng ABR, xử lý cache miss, lấy từ origin và cache theo khu vực."
+  },
+  "backend-cluster": {
+    title: "Cụm backend",
+    detail: "Cụm dịch vụ có ranh giới microservice, tự động mở rộng và áp lực CPU hoặc bộ nhớ."
+  },
+  "message-dispatcher": {
+    title: "Bộ điều phối thông điệp",
+    detail: "Chuyển thông điệp của từng phần dữ liệu đến máy chủ frontend đang giữ kết nối hoạt động."
+  },
+  "balancing-controls": {
+    title: "Danh sách kiểm tra cân bằng tải",
+    detail: "Kiểm tra đầu vào, xác thực, hạn chế tần suất, danh sách cho phép, điều tiết luồng và kết thúc TLS."
+  },
+  "server-state": {
+    title: "Bảng kết nối",
+    detail: "Người dùng, đối tượng kết nối, máy chủ phụ trách, băng thông và topic."
+  },
+  "coordination-zone": {
+    title: "Các cơ chế phối hợp",
+    detail: "Tạo ID, khóa, xử lý đồng thời và metadata định tuyến để giữ thao tác ghi phân tán ổn định."
+  },
+  "distributed-id": {
+    title: "ID phân tán",
+    detail: "UUID, Snowflake, các biến thể tự tăng, Baidu UID và Sonyflake."
+  },
+  "resource-lock": {
+    title: "Khóa tài nguyên",
+    detail: "Redis Redlock, Chubby, Zookeeper, thời hạn lease và tranh chấp khóa."
+  },
+  "concurrency-note": {
+    title: "Các lựa chọn xử lý đồng thời",
+    detail: "Tuần tự, theo lô, optimistic, pessimistic, retry và cập nhật idempotent."
+  },
+  "metadata-table": {
+    title: "Metadata của từng phần dữ liệu truyền",
+    detail: "Khóa, checksum, timestamp, máy chủ, con trỏ đối tượng và trạng thái retry."
+  },
+  "data-zone-blueprint": {
+    title: "Cơ sở dữ liệu và cache",
+    detail: "Kho chính, shard, replica, lưu trữ lạnh, cache trong bộ nhớ và chính sách loại bỏ."
+  },
+  "primary-db-blueprint": {
+    title: "Database",
+    detail: "RDBMS, wide-column, document, key-value, graph, quadtree và time-series."
+  },
+  shards: {
+    title: "Các shard",
+    detail: "Chia theo khoảng, hash, địa lý, thư mục hoặc hash lại nút nóng."
+  },
+  replicas: {
+    title: "Các replica",
+    detail: "Quorum, hinted handoff, Merkle tree, liên vùng và tách luồng đọc ghi."
+  },
+  "cold-storage": {
+    title: "Lưu trữ lạnh",
+    detail: "Bản ghi cũ, consistent hashing, vòng hash và truy cập kho lưu trữ."
+  },
+  "memory-cache": {
+    title: "Cache trong bộ nhớ",
+    detail: "Write-through, read-through, write-around và write-back."
+  },
+  "distributed-cache": {
+    title: "Cache phân tán",
+    detail: "Cache miss hoặc hit, mức dùng đĩa và bộ nhớ, loại bỏ và vô hiệu hóa dữ liệu."
+  },
+  "eviction-policy": {
+    title: "Chính sách loại bỏ cache",
+    detail: "LRU, LFU, FIFO, MRU, ngẫu nhiên, ít dùng nhất và hết hạn theo nhu cầu."
+  },
+  "media-zone": {
+    title: "Luồng tải và xử lý tệp đa phương tiện",
+    detail: "Tải từng phần, kiểm tra checksum, đưa vào queue, xử lý và lưu tệp đã mã hóa."
+  },
+  "object-storage": {
+    title: "Object Storage",
+    detail: "Các phần dữ liệu S3 thô, tải nhiều phần, con trỏ đối tượng và nguồn checksum."
+  },
+  "object-chunk-note": {
+    title: "Với mỗi phần dữ liệu",
+    detail: "Số thông điệp, tốc độ tiêu thụ, số đang truyền, số chờ xác nhận và giới hạn queue."
+  },
+  "upload-queue": {
+    title: "Message Queue",
+    detail: "Broker, pub/sub, kiểm tra checksum, retry và backpressure."
+  },
+  "processing-workers": {
+    title: "Các tiến trình xử lý",
+    detail: "Kiểm tra checksum, chuyển mã, quét, nén, giới hạn tần suất và đẩy tệp kết quả."
+  },
+  "encoded-storage": {
+    title: "Encoded Media Storage",
+    detail: "Media đã encode theo lossless hoặc lossy, kèm object count, compression ratio và failure count."
+  },
+  "media-cost-note": {
+    title: "Chi phí xử lý",
+    detail: "Thời gian tính toán, số lần thất bại, mức dùng CPU và đĩa, dung lượng lưu trữ cùng số đối tượng."
+  },
+  "fanout-zone": {
+    title: "Các dịch vụ fan-out phổ biến",
+    detail: "Fan-out qua pub/sub đến dịch vụ thông báo, tìm kiếm, analytics, gợi ý, tính phí và hệ thống bên thứ ba."
+  },
+  "pubsub-queue": {
+    title: "Queue Pub/Sub",
+    detail: "Các topic đi qua broker, có khóa retry và nhóm consumer."
+  },
+  "notification-service": {
+    title: "Dịch vụ thông báo",
+    detail: "Kiểm soát thư rác, từ cấm, loại trùng và retry bằng khóa idempotent."
+  },
+  "recommendation-service": {
+    title: "Dịch vụ gợi ý",
+    detail: "Lọc theo nội dung và lọc cộng tác."
+  },
+  "log-processing": {
+    title: "Xử lý log",
+    detail: "Chuẩn hóa log và phát các luồng observability."
+  },
+  "search-service": {
+    title: "Dịch vụ tìm kiếm",
+    detail: "Lập chỉ mục tài liệu và phục vụ lưu lượng truy vấn."
+  },
+  "analytics-service": {
+    title: "Dịch vụ analytics",
+    detail: "Sự kiện, dashboard, cohort, chuyển đổi và cảnh báo."
+  },
+  "payment-charge": {
+    title: "Thu tiền",
+    detail: "Khóa idempotent, thẻ hết hạn, số dư không đủ và ngân hàng bên thứ ba."
+  }
+};
+
+const blueprintEdgeCopies: Record<string, string> = {
+  "client-resolver": "tra cứu domain",
+  "resolver-root": "máy chủ gốc?",
+  "root-tld": "TLD NS",
+  "tld-auth": "ANS",
+  "auth-ip": "12.34.56.78",
+  "ip-cdn": "kết nối",
+  "request-cdn": "yêu cầu",
+  "cdn-gateway": "không có trong cache gốc",
+  "gateway-response": "phản hồi",
+  "security-gateway": "chính sách",
+  "gateway-metrics": "telemetry",
+  "gateway-lb": "định tuyến",
+  "lb-frontend": "đích đạt health check",
+  "frontend-edge-static": "tài nguyên tĩnh / luồng",
+  "frontend-backend": "lời gọi API",
+  "backend-dispatcher": "điều phối",
+  "dispatcher-state": "máy chủ giữ kết nối",
+  "backend-id": "ID mới",
+  "backend-lock": "bảo vệ thao tác ghi",
+  "backend-metadata": "bản ghi phần dữ liệu",
+  "backend-primary": "giao dịch",
+  "primary-shards": "phân vùng",
+  "primary-replicas": "tạo bản sao",
+  "primary-cold": "lưu trữ",
+  "backend-cache": "dữ liệu đọc thường xuyên",
+  "cache-distributed": "vô hiệu hóa",
+  "metadata-object": "con trỏ đối tượng",
+  "object-queue": "sự kiện phần dữ liệu",
+  "queue-workers": "nhận xử lý",
+  "workers-storage": "tệp đã xử lý",
+  "workers-cost": "chỉ số chi phí",
+  "encoded-pubsub": "fan-out",
+  "pubsub-notify": "thông báo",
+  "pubsub-reco": "gợi ý",
+  "pubsub-log": "log",
+  "pubsub-search": "lập chỉ mục",
+  "pubsub-analytics": "sự kiện",
+  "pubsub-payment": "thu tiền"
+};
+
+const vietnameseDemoCopies: Record<string, LocalizedDemoCopy> = {
+  "react-flow-architecture-demo": {
+    sections: architectureSectionCopies,
+    views: architectureViewCopies,
+    nodes: architectureNodeCopies,
+    edges: architectureEdgeCopies
+  },
+  "react-flow-system-blueprint": {
+    sections: blueprintSectionCopies,
+    views: blueprintViewCopies,
+    nodes: blueprintNodeCopies,
+    edges: blueprintEdgeCopies
+  }
+};
+
+function localizeNode(node: StudioFlowArchitectureNodeSpec, copy: LocalizedDemoCopy): StudioFlowArchitectureNodeSpec {
+  const localized = copy.nodes[node.id];
+  const translateBadge = ["blocked", "done", "risk", "summary", "valid"].includes(node.badge);
+  return {
+    ...node,
+    title: localized?.title ?? node.title,
+    detail: localized?.detail ?? node.detail,
+    badge: translateBadge ? (vietnameseBadgeCopies[node.badge] ?? node.badge) : node.badge
+  };
+}
+
+function localizeEdge(edge: StudioFlowArchitectureEdgeSpec, copy: LocalizedDemoCopy): StudioFlowArchitectureEdgeSpec {
+  return {
+    ...edge,
+    label: copy.edges[edge.id] ?? edge.label
+  };
+}
+
+function localizeView(view: StudioFlowArchitectureViewSpec, copy: LocalizedDemoCopy): StudioFlowArchitectureViewSpec {
+  const localized = copy.views[view.id];
+  return {
+    ...view,
+    title: localized?.title ?? view.title,
+    description: localized?.description ?? view.description,
+    notes: localized?.notes ?? view.notes,
+    nodes: view.nodes.map((node) => localizeNode(node, copy)),
+    edges: view.edges.map((edge) => localizeEdge(edge, copy))
+  };
+}
+
+function localizeDemo(demo: StudioFlowArchitectureDemo, copy: LocalizedDemoCopy): StudioFlowArchitectureDemo {
+  return {
+    ...demo,
+    sections: demo.sections.map((section, index) => ({
+      ...section,
+      title: copy.sections[index]?.title ?? section.title,
+      items: copy.sections[index]?.items ?? section.items
+    })),
+    nodes: demo.nodes.map((node) => localizeNode(node, copy)),
+    edges: demo.edges.map((edge) => localizeEdge(edge, copy)),
+    views: demo.views.map((view) => localizeView(view, copy))
+  };
+}
+
+export function getLocalizedStudioDemoFlows(flows: StudioFlow[], locale: string): StudioFlow[] {
+  if (locale.toLowerCase().split("-")[0] !== "vi") return flows;
+
+  return flows.map((flow) => {
+    const copy = vietnameseDemoCopies[flow.id];
+    if (!copy || !flow.architectureDemo) return flow;
+
+    return {
+      ...flow,
+      architectureDemo: localizeDemo(flow.architectureDemo, copy)
+    };
+  });
+}

--- a/src/app/[locale]/studio/studio.localized-workspace.ts
+++ b/src/app/[locale]/studio/studio.localized-workspace.ts
@@ -1,0 +1,453 @@
+import { studioFolders, studioNotes } from "./studio.data";
+import type { StudioFolder, StudioNote } from "./studio.data";
+
+type LocalizedStudioNote = Partial<Omit<StudioNote, "id" | "folderId" | "status" | "updatedAt">>;
+
+const vietnameseFolders: Record<string, Pick<StudioFolder, "label" | "subtitle" | "groups">> = {
+  "machine-bootstrap": {
+    label: "Chuẩn bị máy mới",
+    subtitle: "Những việc cần làm trước khi bắt đầu",
+    groups: [
+      {
+        label: "Thiết lập công cụ AI",
+        noteIds: ["ai-operating-system", "ai-driven-engineering-foundation", "antigravity-awesome-skills", "open-design"]
+      },
+      { label: "Thiết lập máy tính", noteIds: ["computer-baseline"] },
+      { label: "Thiết lập dòng lệnh", noteIds: ["terminal-baseline"] }
+    ]
+  },
+  "ai-learning": {
+    label: "Học và làm việc cùng AI",
+    subtitle: "Những chủ đề tôi sẽ tìm hiểu tiếp",
+    groups: [
+      {
+        label: "Cách tổ chức công việc",
+        noteIds: ["ai-operating-system", "ai-driven-engineering-foundation", "ai-system-engineering-roadmap"]
+      },
+      { label: "Multi-agent systems", noteIds: ["multi-agent-ai", "openhands", "crewai"] }
+    ]
+  },
+  "design-tools": {
+    label: "Công cụ thiết kế",
+    subtitle: "Hỗ trợ AI tạo và rà soát giao diện",
+    groups: [{ label: "Open Design", noteIds: ["open-design"] }]
+  }
+};
+
+const vietnameseNotes: Record<string, LocalizedStudioNote> = {
+  "ai-operating-system": {
+    title: "Cách tôi phối hợp các công cụ AI",
+    subtitle: "Phân vai NotebookLM, GPT, Claude, Codex và Antigravity cho việc tìm hiểu, phản biện và triển khai.",
+    tags: ["Cách làm việc với AI", "NotebookLM", "GPT", "Claude", "Codex", "Antigravity", "Học mỗi ngày"],
+    summary:
+      "Ghi chú này nói rõ tôi giao việc gì cho từng công cụ AI, kiểm tra kết quả ở đâu và vì sao quyết định cuối cùng vẫn phải do mình chịu trách nhiệm.",
+    sections: [
+      {
+        heading: "Nguyên tắc chung",
+        body:
+          "Có nhiều công cụ không giúp ích nếu tài liệu và bối cảnh bị rải khắp nơi. Tôi bắt đầu từ dữ kiện, làm rõ bài toán, chọn đúng công cụ, rà kỹ phần có rủi ro rồi lưu lại điều đáng dùng cho lần sau."
+      },
+      {
+        heading: "Vai trò của từng công cụ",
+        body:
+          "Tôi dùng NotebookLM để đọc và đối chiếu tài liệu gốc; GPT để tìm hiểu và lên hướng làm; Claude để phản biện và gọt câu chữ; Codex để thay đổi code; Antigravity để làm prototype, UI flow, browser check và thử nghiệm multi-agent. Đây là cách phân vai thường dùng, không phải luật cứng."
+      },
+      {
+        heading: "Học đều mỗi ngày",
+        body:
+          "Một ngày có ích nên để lại ít nhất một thứ tốt hơn hôm qua: một câu lệnh rõ hơn, danh sách kiểm tra dùng lại được, phần mã đã rà kỹ, quyết định sáng hơn hoặc ghi chú có nguồn. Tôi không cần dùng hết mọi công cụ; tôi cần lặp lại được cách chọn công cụ đúng."
+      },
+      {
+        heading: "Hướng phát triển nghề nghiệp",
+        body:
+          "Tôi muốn đi sâu hơn vào kiến trúc phần mềm, cách dùng AI có trách nhiệm, dẫn dắt kỹ thuật, tư duy sản phẩm và giao tiếp rõ ràng. Những tài liệu hướng dẫn, ví dụ kiến trúc, bài viết công khai và bản thử tự động hoá nhỏ sẽ là bằng chứng thật cho quá trình đó."
+      }
+    ],
+    commands: [
+      {
+        label: "Lên kế hoạch cho buổi sáng",
+        command:
+          "Hôm nay là [ngày]. Năng lượng hiện tại: [x]. Việc bắt buộc: [x]. Việc còn dang dở: [x]. Hãy giúp tôi chọn 3 kết quả quan trọng nhất, 1 cách làm với AI cần luyện, 1 việc nên hoãn, 1 việc cho sức khỏe hoặc nghề nghiệp, và chia thời gian thực tế trong ngày.",
+        note: "Dùng trong dự án PhongOS / Life & Career."
+      },
+      {
+        label: "Rà soát tuần mới",
+        command:
+          "Tình hình hiện tại của tôi: Công việc: [x]. Cuộc sống: [x]. Tài chính: [x]. Sức khỏe: [x]. Quan hệ: [x]. Học tập: [x]. Hãy làm một trang tổng hợp gồm: điều quan trọng lúc này, rủi ro, việc nên bỏ qua, quyết định cần đưa ra và hành động trong 7 ngày tới.",
+        note: "Dùng vào Chủ nhật hoặc trước một tuần có nhiều việc đan xen."
+      },
+      {
+        label: "Chọn công cụ phù hợp",
+        command:
+          "Tôi có việc này: [mô tả]. Hãy đề xuất thứ tự dùng NotebookLM, GPT, Claude, Codex và Antigravity. Nêu lý do, câu lệnh cho từng công cụ, giới hạn an toàn và tài liệu tôi nên lưu lại.",
+        note: "Dùng khi đề bài quá rộng hoặc chưa biết nên bắt đầu bằng công cụ nào."
+      }
+    ],
+    checklist: [
+      {
+        label: "Tạo các dự án riêng trong ChatGPT.",
+        detail: "PhongOS, Engineering Leadership, Finance & Investment, Learning & Research, Writing / Personal Brand."
+      },
+      {
+        label: "Tạo các sổ riêng trong NotebookLM.",
+        detail: "Career Archive, Finance Library, Learning AI/Systems, Life Archive, Work Knowledge Base."
+      },
+      { label: "Lưu mẫu câu lệnh dùng lại cho GPT, Claude, Codex, Antigravity và NotebookLM." },
+      { label: "Dành ít nhất một vòng học cùng AI trong mỗi ngày làm việc." },
+      { label: "Mỗi tuần lưu lại một bài học hoặc tài liệu đáng dùng.", checked: true },
+      {
+        label: "Không đưa bí mật, khóa riêng, dữ liệu khách hàng hoặc dữ liệu nội bộ nhạy cảm vào công cụ AI cá nhân.",
+        checked: true
+      }
+    ]
+  },
+  "ai-driven-engineering-foundation": {
+    title: "Nền tảng kỹ thuật khi làm việc cùng AI",
+    subtitle: "Bản đồ quyết định kỹ thuật từ lúc nhận việc đến khi hệ thống chạy thật.",
+    tags: ["Nền tảng kỹ thuật", "Kiến trúc", "Dữ liệu", "Khả năng phục hồi", "Observability", "AI"],
+    summary:
+      "AI có thể viết mã nhanh, nhưng chất lượng kỹ thuật vẫn phụ thuộc vào câu hỏi đúng, đánh đổi rõ, tình huống hỏng được kiểm thử và người chịu trách nhiệm khi hệ thống vận hành.",
+    sections: [
+      {
+        heading: "Vì sao phần này quan trọng",
+        body:
+          "Bước tiếp theo không phải là xin AI viết thêm code. Tôi cần một decision map chắc hơn: nhờ AI phân tích gì, assumption nào phải phản biện, risk nào phải có test và release thế nào để production không trở thành nơi đoán mò."
+      },
+      {
+        heading: "Bảy lớp từ yêu cầu đến vận hành",
+        body:
+          "Mỗi thay đổi đáng kể nên đi qua bảy lớp: nhu cầu kinh doanh; miền nghiệp vụ hoặc tình huống sử dụng; hợp đồng API hay quy trình; dữ liệu và tính nhất quán; kiến trúc và mẫu thiết kế; triển khai và kiểm thử; cuối cùng là release, observability và vận hành."
+      },
+      {
+        heading: "Những lớp kiến thức cần bồi đắp",
+        body:
+          "Tôi học dần về software design, data modeling, replication và consistency, khả năng phục hồi của distributed system, event-driven architecture với CQRS và Event Sourcing, cache, performance, observability, SRE và production operations. Mục tiêu không phải thuộc hết thuật ngữ mà là biết lúc nào từng ý tưởng có ích."
+      },
+      {
+        heading: "Cách luyện mỗi ngày",
+        body:
+          "Trước khi viết mã, tôi đọc lại một lớp và tự hỏi một câu ở góc nhìn kỹ sư lâu năm. Sau khi làm xong, tôi lưu một thứ có thể dùng lại: câu lệnh tốt hơn, kế hoạch truy vấn, ADR, ca kiểm thử, rủi ro release, dashboard signal hoặc bài học ngắn."
+      },
+      {
+        heading: "Bài tập dài hạn",
+        body:
+          "Tôi dùng một nền tảng thương mại điện tử, thuê bao hoặc đặt lịch làm phòng thí nghiệm lâu dài. Hệ thống bắt đầu bằng modular monolith, PostgreSQL, Redis, Outbox và queue; sau đó mới thêm Saga cho thanh toán, Circuit Breaker, mô hình đọc CQRS, Event Sourcing cho vòng đời đơn hàng, OpenTelemetry, dashboard, feature flag, zero-downtime migration, load test, runbook và ADR."
+      }
+    ],
+    commands: [
+      {
+        label: "Làm rõ yêu cầu",
+        command:
+          "Hãy đóng vai Staff Software Engineer. Với yêu cầu này, hãy hỏi các câu quan trọng nhất trước khi triển khai. Chia câu hỏi theo: kinh doanh, sản phẩm, dữ liệu, API, bảo mật, độ tin cậy, release và observability.",
+        note: "Dùng trước khi giao việc cho Codex hoặc Antigravity."
+      },
+      {
+        label: "Ghi lại quyết định kiến trúc",
+        command:
+          "Hãy viết một Architecture Decision Record cho tính năng này và so sánh ít nhất 3 phương án. Với mỗi phương án, phân tích độ phức tạp, khả năng mở rộng, tính nhất quán, rủi ro vận hành, chi phí, công sức chuyển đổi, rollback strategy và khả năng bảo trì lâu dài.",
+        note: "Dùng khi thay đổi chạm tới kiến trúc, dữ liệu hoặc vận hành."
+      },
+      {
+        label: "Production readiness",
+        command:
+          "Hãy lập production-readiness checklist cho tính năng này, gồm test cases, failure scenarios, observability, alert, rollback, cách kiểm chứng migration, tác động tới người dùng và abort criteria.",
+        note: "Dùng trước khi rollout hoặc trước vòng rà soát cuối."
+      }
+    ],
+    checklist: [
+      { label: "Đọc lại một lớp trong bản đồ trước khi bắt đầu việc kỹ thuật đáng kể." },
+      {
+        label: "Tự hỏi ít nhất một câu ở góc nhìn kỹ sư lâu năm trước khi triển khai.",
+        detail: "Kinh doanh, sản phẩm, nghiệp vụ, API, dữ liệu, tính nhất quán, độ tin cậy, bảo mật, observability hoặc release."
+      },
+      { label: "Dùng AI để phân tích và phản biện trước, không chỉ để sinh mã." },
+      {
+        label: "Lưu một tài liệu có thể dùng lại sau mỗi việc.",
+        detail: "Câu lệnh, danh sách kiểm tra, ADR, kế hoạch truy vấn, ma trận kiểm thử, runbook, ghi chú release hoặc bài học sau sự cố."
+      },
+      { label: "Mỗi tuần đẩy bài tập dài hạn tiến thêm một bước." }
+    ]
+  },
+  "ai-system-engineering-roadmap": {
+    title: "Lộ trình kỹ thuật hệ thống khi làm việc cùng AI",
+    subtitle: "Bản đồ học về vòng đời phần mềm, hệ phân tán, lưu trữ lớn và cách dùng AI để phản biện.",
+    tags: ["Nâng kỹ năng AI", "Kỹ thuật hệ thống", "SDLC", "Hệ phân tán", "Lưu trữ", "Quy trình kỹ thuật"],
+    summary:
+      "AI hỗ trợ viết mã, còn kỹ sư vẫn phải làm chủ quyết định kiến trúc, tình huống hỏng của hệ phân tán, đánh đổi lưu trữ và chất lượng rà soát.",
+    sections: [
+      {
+        heading: "Chuyển trọng tâm",
+        body:
+          "Mục tiêu là đi từ viết cú pháp sang làm chủ cả hệ thống. AI có thể phác mã và kiểm thử, nhưng kỹ sư vẫn quyết định mô hình nghiệp vụ, hợp đồng dữ liệu, cách giữ nhất quán, release path, observability plan và mức rủi ro vận hành có thể chấp nhận."
+      },
+      {
+        heading: "Trụ cột 1: Làm chủ vòng đời phần mềm",
+        body:
+          "Tôi học toàn bộ SDLC như một hệ thống quản trị: strategy và discovery; requirement và specification; architecture và design; implementation; QA; release; observability và incident response; maintenance và technical debt; rồi feedback và iteration. Thói quen quan trọng nhất là không đưa code do AI sinh ra lên production nếu tôi chưa thể giải thích nó và bảo đảm observability."
+      },
+      {
+        heading: "Trụ cột 2: Kiến trúc phân tán và khả năng phục hồi",
+        body:
+          "Tôi đi sâu vào Event Sourcing, CQRS, snapshot, optimistic concurrency, thay đổi schema sự kiện, các tầng lưu trữ nóng/ấm/lạnh, trạng thái Circuit Breaker, cửa sổ đo, cách xử lý thay thế và retry với exponential backoff kèm jitter. Câu hỏi thực tế luôn là: hệ thống ra sao khi phụ thuộc bên ngoài chậm, gửi trùng, đến muộn hoặc chỉ hỏng một phần?"
+      },
+      {
+        heading: "Trụ cột 3: Lưu trữ ở quy mô lớn",
+        body:
+          "Tôi rèn trực giác về lưu trữ qua B-Tree và LSM-Tree; clustered, non-clustered, composite và covering index; quy tắc leftmost prefix; index bị mất hiệu lực; sao chép đồng bộ và bất đồng bộ; quorum với Raft hoặc Multi-Paxos; logical replication; sharding; consistent hashing; virtual node; xử lý điểm nóng; 2PC và Saga."
+      },
+      {
+        heading: "Trụ cột 4: Cách làm kỹ thuật cùng AI",
+        body:
+          "Tôi dùng AI trước hết như người phân tích yêu cầu, người chất vấn kiến trúc, người lên chiến lược kiểm thử và người rà soát mức sẵn sàng khi vận hành. AI cần chỉ ra điểm mơ hồ, race condition, giả định về tính nhất quán, lỗ hổng kiểm thử, thiếu sót về rollback hoặc observability trước khi được giao viết mã."
+      }
+    ],
+    commands: [
+      {
+        label: "Gợi mở yêu cầu trước khi làm",
+        command:
+          "Hãy đóng vai Staff Software Engineer. Với yêu cầu này, hãy hỏi các câu quan trọng nhất trước khi triển khai. Chia câu hỏi theo: kinh doanh, sản phẩm, dữ liệu, API, bảo mật, độ tin cậy, release và observability.",
+        note: "Dùng trước khi tách một ticket mơ hồ thành các việc cụ thể."
+      },
+      {
+        label: "Phản biện kiến trúc",
+        command:
+          "Hãy phản biện thiết kế này. Tìm race condition, data consistency bug, security risk, performance bottleneck, operational assumption chưa nói ra và các failure scenario trên production.",
+        note: "Dùng trước khi giao Codex hoặc Antigravity triển khai."
+      },
+      {
+        label: "Chiến lược kiểm thử và bảo mật",
+        command:
+          "Hãy tạo ma trận kiểm thử cho tính năng này: unit, integration, contract, E2E, load test, bảo mật, migration, rollback và tình huống phụ thuộc bên ngoài bị hỏng. Chỉ rõ kiểm thử nào phải chặn release.",
+        note: "Dùng trước khi lên kế hoạch rollout."
+      }
+    ],
+    checklist: [
+      { label: "Mỗi tuần rà lại một giai đoạn SDLC và một lớp telemetry." },
+      {
+        label: "Học sâu một mẫu thiết kế phân tán.",
+        detail: "Event Sourcing, CQRS, Circuit Breaker, Retry, Saga, Outbox hoặc idempotent consumer."
+      },
+      {
+        label: "Thực hành một chủ đề lưu trữ bằng bằng chứng cụ thể.",
+        detail: "Kế hoạch dùng index, hành vi sao chép, đánh đổi khi sharding, consistent hashing hoặc kế hoạch truy vấn."
+      },
+      { label: "Dùng AI để phản biện trước khi dùng AI để viết mã." },
+      { label: "Mỗi ngày lưu một tài liệu nhỏ để kiến thức tích lũy dần.", checked: true }
+    ]
+  },
+  "antigravity-awesome-skills": {
+    title: "Cài thư viện Antigravity Awesome Skills",
+    subtitle: "Lệnh cài lại bộ hướng dẫn cho AI mà tôi thường dùng.",
+    tags: ["Thiết lập AI", "Antigravity", "Codex", "Claude", "Gemini", "Thư viện hướng dẫn"],
+    summary:
+      "Đây không phải danh sách mọi hướng dẫn đã cài. Nó là tờ ghi nhanh khi đổi máy: chạy lệnh nào, nguồn chính ở đâu và cần nhờ AI khôi phục những gì.",
+    sections: [
+      {
+        heading: "Thư viện này mang lại gì",
+        body:
+          "Antigravity Awesome Skills là thư viện các tệp SKILL.md có thể cài đặt cho trợ lý lập trình AI. Tôi dùng nó như nguồn hướng dẫn thống nhất, thay vì nhớ bằng đầu hoặc viết lại câu lệnh riêng cho từng lần."
+      },
+      {
+        heading: "Tác giả và nguồn chính",
+        body:
+          "Tác giả trên GitHub là sickn33. Kho mã là nguồn cần đối chiếu trước tiên; trang danh mục phù hợp khi chỉ cần tìm nhanh hoặc chia sẻ liên kết."
+      },
+      {
+        heading: "Nhờ AI hỗ trợ khi đổi máy",
+        body:
+          "Khi nhận ghi chú này trên máy mới, AI phải mở kho GitHub, đọc README mới nhất rồi chọn đúng lệnh cài cho công cụ đích. Tuyệt đối không sao chép tệp chứa thông tin đăng nhập từ máy cũ."
+      }
+    ],
+    commands: [
+      { label: "Cài đặt mặc định", command: "npx antigravity-awesome-skills", note: "Lệnh đầu tiên cần nhớ." },
+      {
+        label: "Cài cho Antigravity CLI",
+        command: "npx antigravity-awesome-skills --agy",
+        note: "Dùng khi cần các lệnh kỹ năng của Antigravity CLI trong ~/.gemini/antigravity-cli/skills."
+      },
+      {
+        label: "Ví dụ cài bản gọn",
+        command: "npx antigravity-awesome-skills --path .agents/skills --category development,backend --risk safe,none",
+        note: "Dùng khi bản cài đầy đủ khiến công cụ phải nạp quá nhiều hướng dẫn."
+      },
+      {
+        label: "Cài plugin cho Claude Code",
+        command: "/plugin marketplace add sickn33/antigravity-awesome-skills && /plugin install antigravity-awesome-skills",
+        note: "Cách cài được nêu trong tài liệu bắt đầu của dự án."
+      }
+    ],
+    links: [
+      {
+        label: "Kho mã GitHub",
+        href: "https://github.com/sickn33/antigravity-awesome-skills",
+        note: "Nguồn chính của dự án."
+      },
+      {
+        label: "Hướng dẫn bắt đầu",
+        href: "https://github.com/sickn33/antigravity-awesome-skills/blob/main/docs/users/getting-started.md",
+        note: "Cách cài cho từng công cụ."
+      },
+      {
+        label: "Danh mục trực tuyến",
+        href: "https://sickn33.github.io/antigravity-awesome-skills",
+        note: "Trang tìm và xem nhanh."
+      }
+    ],
+    checklist: [
+      { label: "Mở kho mã và xác nhận lệnh cài mới nhất.", checked: true },
+      {
+        label: "Chạy bộ cài cho đúng công cụ AI.",
+        detail: "Antigravity, Claude Code, Codex, Gemini, Cursor hoặc công cụ được hỗ trợ khác."
+      },
+      { label: "Khởi động lại công cụ hoặc CLI sau khi cài.", detail: "Nhiều công cụ chỉ nhận hướng dẫn mới khi khởi động." },
+      { label: "Không chuyển credential file hoặc OAuth cache.", checked: true }
+    ]
+  },
+  "open-design": {
+    title: "Open Design",
+    subtitle: "Không gian thiết kế và cầu nối MCP cho các bản giao diện do AI hỗ trợ.",
+    tags: ["Thiết kế", "MCP", "Codex", "Claude", "Gemini", "Antigravity"],
+    summary:
+      "Tôi lưu Open Design như một nguồn tham khảo về thiết kế và một lựa chọn kết nối MCP cho việc làm giao diện. Trước khi cài, cần kiểm tra lại lệnh và công cụ được hỗ trợ trong tài liệu mới nhất của dự án.",
+    sections: [
+      {
+        heading: "Đây là công cụ gì",
+        body:
+          "Dự án giới thiệu Open Design như một workspace mã nguồn mở, ưu tiên chạy trên máy cá nhân để tạo design artifact cùng AI. Trong Studio, tôi quan tâm nhất đến UI prototype, design system và tài liệu có thể mang đi review."
+      },
+      {
+        heading: "Vì sao tôi lưu công cụ này",
+        body:
+          "Công cụ có thể hữu ích khi AI cần dựng hoặc chỉnh một mẫu giao diện mà không tách công việc sang một quy trình thiết kế khác. Khả năng kết nối qua MCP cũng khiến nó phù hợp với nhóm ghi chú thiết lập AI."
+      },
+      {
+        heading: "Cách thử trên máy mới",
+        body:
+          "Đầu tiên, kiểm tra tài liệu hiện tại của dự án; sau đó cài ứng dụng và chỉ nối MCP vào công cụ AI thật sự cần dùng. Hãy bắt đầu bằng một kết nối, kiểm chứng nó hoạt động rồi mới thêm kết nối khác."
+      }
+    ],
+    commands: [
+      { label: "Cài MCP cho Codex", command: "od mcp install codex" },
+      { label: "Cài MCP cho Antigravity", command: "od mcp install antigravity" },
+      { label: "Cài MCP cho Claude", command: "od mcp install claude" },
+      { label: "Cài MCP cho Gemini", command: "od mcp install gemini" },
+      { label: "Xem trước lệnh cài MCP", command: "od mcp install codex --print" }
+    ],
+    links: [
+      { label: "Kho mã GitHub", href: "https://github.com/nexu-io/open-design", note: "Trang dự án mã nguồn mở." },
+      { label: "Trang giới thiệu và tải ứng dụng", href: "https://open-design.ai", note: "Trang sản phẩm được liên kết từ kho mã." }
+    ],
+    checklist: [
+      { label: "Cài hoặc mở ứng dụng Open Design trên máy." },
+      { label: "Kết nối MCP với Codex.", detail: "Bắt đầu bằng lệnh od mcp install codex." },
+      { label: "Chỉ kết nối MCP với Antigravity khi thật sự cần hỗ trợ thiết kế ở đó." },
+      { label: "Dùng Open Design như nguồn tham khảo cho giao diện quản trị và không gian làm việc.", checked: true }
+    ]
+  },
+  "computer-baseline": {
+    title: "Thiết lập máy tính",
+    subtitle: "Những việc ở mức hệ điều hành cần xong trước khi bắt đầu dự án.",
+    tags: ["Thiết lập máy", "macOS", "Trình duyệt", "Bảo mật"],
+    summary:
+      "Ghi chú này dành cho phần ngoài dòng lệnh trên một máy kỹ thuật mới: thư mục, trình duyệt, phông chữ, đăng nhập và các nguyên tắc an toàn cơ bản.",
+    sections: [
+      {
+        heading: "Mục tiêu",
+        body:
+          "Một chiếc máy mới nên sớm trở nên quen thuộc: cùng cách xếp thư mục dự án, đủ trình duyệt để kiểm thử, phông chữ dễ đọc và không vô tình đưa bí mật vào ghi chú công khai."
+      }
+    ],
+    checklist: [
+      { label: "Tạo ~/Documents/Projects và tải về các kho mã đang làm." },
+      { label: "Cài đủ trình duyệt dùng cho phát triển và kiểm thử OAuth." },
+      { label: "Khôi phục phông chữ dùng để viết mã và đọc lâu." },
+      { label: "Đăng nhập lại từng công cụ, không sao chép tệp chứa token.", checked: true }
+    ]
+  },
+  "terminal-baseline": {
+    title: "Thiết lập dòng lệnh",
+    subtitle: "Nền tảng dòng lệnh cho công việc kỹ thuật.",
+    tags: ["Dòng lệnh", "Git", "Node", "Bun", "PlantUML"],
+    summary:
+      "Ghi chú này giữ những thứ sát với công việc hằng ngày ở cùng một chỗ: Git, GitHub CLI, Node/Bun, Java/PlantUML, lệnh release và lệnh cài các công cụ AI.",
+    sections: [
+      {
+        heading: "Mục tiêu",
+        body:
+          "Trước khi mở một việc lớn, dòng lệnh phải biết đúng danh tính Git, đăng nhập được, chạy được dự án và kiểm tra được tài liệu hoặc sơ đồ."
+      }
+    ],
+    commands: [
+      { label: "Chạy ứng dụng trên máy", command: "npm run dev" },
+      { label: "Kiểm tra kiểu dữ liệu", command: "npm run typecheck" },
+      { label: "Kiểm tra cú pháp PlantUML", command: "java -jar plantuml.jar --check-syntax docs/diagrams/*.puml" }
+    ],
+    checklist: [
+      { label: "Cấu hình danh tính Git và cách dùng khóa SSH." },
+      { label: "Đăng nhập GitHub CLI." },
+      { label: "Cài Node, npm, Bun, Java và các CLI của dự án." },
+      { label: "Lưu các lệnh cài cần thiết trong Studio này." }
+    ]
+  },
+  "multi-agent-ai": {
+    title: "Multi-agent AI",
+    subtitle: "Tìm hiểu cách phối hợp nhiều agent mà không đánh mất phán đoán của con người.",
+    tags: ["Học về AI", "Nhiều tác nhân", "Quy trình"],
+    summary:
+      "Nội dung dự kiến tìm hiểu: lúc nào multi-agent giúp planning, implementation, review, testing hoặc research tốt hơn; lúc nào nó chỉ làm tăng chi phí phối hợp.",
+    sections: [
+      {
+        heading: "Câu hỏi cần trả lời",
+        body: "Khi nào multi-agent setup giúp engineering judgment tốt hơn, và khi nào chỉ cần một agent tập trung cùng test suite đủ tốt?"
+      }
+    ],
+    checklist: [
+      { label: "So sánh vai trò lập kế hoạch, triển khai, rà soát và kiểm chứng." },
+      { label: "Ghi rõ tình huống hỏng trước khi thêm tự động hoá." }
+    ]
+  },
+  openhands: {
+    title: "OpenHands",
+    subtitle: "Dự kiến tìm hiểu cách cài đặt, cô lập môi trường và xử lý việc dài.",
+    tags: ["Học về AI", "OpenHands"],
+    summary:
+      "Bản đánh giá dự kiến sẽ xem cách cài, mức phù hợp với kho mã, ranh giới sandbox, khả năng xử lý việc dài và phần trùng với Codex hoặc Claude.",
+    sections: [
+      {
+        heading: "Câu hỏi cần trả lời",
+        body: "OpenHands phù hợp hơn với vai trò bạn lập trình chạy trên máy, bộ thực thi trong sandbox hay một quy trình riêng cho thay đổi dài và tự chủ hơn?"
+      }
+    ]
+  },
+  crewai: {
+    title: "CrewAI",
+    subtitle: "Dự kiến tìm hiểu về vai trò rõ ràng, bộ nhớ và cách bàn giao giữa các tác nhân.",
+    tags: ["Học về AI", "CrewAI", "Tác nhân AI"],
+    summary:
+      "Bản đánh giá dự kiến tập trung vào lúc nào vai trò, bộ nhớ và bàn giao có cấu trúc đem lại lợi ích rõ hơn một đoạn script hoặc một tác nhân duy nhất.",
+    sections: [
+      {
+        heading: "Câu hỏi cần trả lời",
+        body: "Việc nào thật sự hưởng lợi từ vai trò, bộ nhớ và bàn giao giữa các tác nhân; việc nào lại chậm hơn chỉ vì thêm cấu trúc?"
+      }
+    ]
+  }
+};
+
+export function getLocalizedStudioFolders(locale: string): StudioFolder[] {
+  if (locale !== "vi") return studioFolders;
+
+  return studioFolders.map((folder) => ({
+    ...folder,
+    ...(vietnameseFolders[folder.id] ?? {})
+  }));
+}
+
+export function getLocalizedStudioNotes(locale: string): StudioNote[] {
+  if (locale !== "vi") return studioNotes;
+
+  return studioNotes.map((note) => ({
+    ...note,
+    ...(vietnameseNotes[note.id] ?? {})
+  }));
+}

--- a/src/app/seo.config.ts
+++ b/src/app/seo.config.ts
@@ -109,9 +109,9 @@ export const PAGE_SEO: Record<
     ogAlt: 'Blog — software architecture and engineering, explained simply',
   },
   studio: {
-    title: 'Studio — Engineering Flows, AI Notes & System Design',
+    title: 'Studio — Engineering Notes, Checklists, and System Flows',
     description:
-      'A public working shelf for system design flows, release readiness, AI-assisted delivery, machine setup, daily learning checklists, and skill libraries.',
+      'A public workspace for the notes, checklists, and visual flows I use to review architecture, prepare releases, set up tools, and work with AI responsibly.',
     path: '/studio',
     keywords: [
       'Nguyen Le Phong studio',

--- a/tests/studio-localization.test.mjs
+++ b/tests/studio-localization.test.mjs
@@ -1,0 +1,144 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { createRequire } from "node:module";
+import test from "node:test";
+
+const require = createRequire(import.meta.url);
+const ts = require("typescript");
+
+require.extensions[".ts"] = (module, filename) => {
+  const source = readFileSync(filename, "utf8");
+  const output = ts.transpileModule(source, {
+    compilerOptions: {
+      jsx: ts.JsxEmit.ReactJSX,
+      module: ts.ModuleKind.CommonJS,
+      target: ts.ScriptTarget.ES2022
+    }
+  }).outputText;
+  module._compile(output, filename);
+};
+
+const data = require("../src/app/[locale]/studio/studio.data.ts");
+const localizedContent = require("../src/app/[locale]/studio/studio.localized-content.ts");
+const localizedDemos = require("../src/app/[locale]/studio/studio.localized-demos.ts");
+const localizedWorkspace = require("../src/app/[locale]/studio/studio.localized-workspace.ts");
+
+function flattenChecklistSteps(checklist) {
+  const flattened = [];
+  const visit = (sectionId, steps) => {
+    for (const step of steps) {
+      flattened.push({
+        key: `${checklist.id}/${sectionId}/${step.id}`,
+        id: step.id,
+        label: step.label
+      });
+      if (step.children) visit(sectionId, step.children);
+    }
+  };
+
+  for (const section of checklist.sections) visit(section.id, section.steps);
+  return flattened;
+}
+
+test("Studio English and Vietnamese content preserve structure and contextual meaning", () => {
+  const englishSkills = localizedContent.getLocalizedStudioAiSkills("en");
+  const vietnameseSkills = localizedContent.getLocalizedStudioAiSkills("vi");
+  assert.equal(englishSkills.length, 26);
+  assert.equal(vietnameseSkills.length, englishSkills.length);
+  assert.deepEqual(vietnameseSkills.map((skill) => skill.id), englishSkills.map((skill) => skill.id));
+
+  for (const skill of englishSkills) {
+    assert.equal(skill.markdown.trim().split("\n")[0], `# ${skill.title}`);
+  }
+  for (const skill of vietnameseSkills) {
+    assert.equal(skill.markdown.trim().split("\n")[0], `# ${skill.title}`);
+  }
+  assert.equal(
+    vietnameseSkills.find((skill) => skill.id === "design-system-ui-craft")?.title,
+    "Design system và chất lượng UI"
+  );
+
+  const englishChecklists = localizedContent.getLocalizedStudioWorkflowChecklists("en");
+  const vietnameseChecklists = localizedContent.getLocalizedStudioWorkflowChecklists("vi");
+  assert.equal(englishChecklists.length, 14);
+  assert.equal(vietnameseChecklists.length, englishChecklists.length);
+  assert.deepEqual(vietnameseChecklists.map((checklist) => checklist.id), englishChecklists.map((checklist) => checklist.id));
+
+  const englishSteps = englishChecklists.flatMap(flattenChecklistSteps);
+  const vietnameseSteps = vietnameseChecklists.flatMap(flattenChecklistSteps);
+  assert.equal(englishSteps.length, 215);
+  assert.equal(new Set(englishSteps.map((step) => step.key)).size, englishSteps.length);
+  assert.deepEqual(vietnameseSteps.map((step) => step.key), englishSteps.map((step) => step.key));
+
+  const contextualLabels = new Map(vietnameseSteps.map((step) => [step.key, step.label]));
+  assert.equal(
+    contextualLabels.get("capstone-production-project/feature-set/scope"),
+    "Bắt đầu bằng Modular Monolith trước khi tách service."
+  );
+  assert.equal(
+    contextualLabels.get("release-readiness/quality/scope"),
+    "Xác nhận phạm vi PR khớp với ticket và không giấu việc dọn dẹp ngoài yêu cầu."
+  );
+  assert.equal(
+    contextualLabels.get("engineering-delivery-checklist/post-rollout/review"),
+    "Nhờ AI review sau rollout, gồm kết quả, metric, vấn đề, tác động tới người dùng, technical debt, việc cần làm và bài học."
+  );
+
+  const vietnameseNotes = localizedWorkspace.getLocalizedStudioNotes("vi");
+  assert.equal(vietnameseNotes.length, data.studioNotes.length);
+  assert.deepEqual(vietnameseNotes.map((note) => note.id), data.studioNotes.map((note) => note.id));
+  assert.equal(vietnameseNotes[0].title, "Cách tôi phối hợp các công cụ AI");
+
+  const vietnameseFolders = localizedWorkspace.getLocalizedStudioFolders("vi");
+  assert.equal(vietnameseFolders.length, data.studioFolders.length);
+  assert.equal(vietnameseFolders[0].label, "Chuẩn bị máy mới");
+});
+
+test("Vietnamese React Flow demos keep technical labels and localize explanations", () => {
+  const englishFlows = localizedContent.getLocalizedStudioFlows("en");
+  const vietnameseFlows = localizedDemos.getLocalizedStudioDemoFlows(
+    localizedContent.getLocalizedStudioFlows("vi"),
+    "vi"
+  );
+
+  for (const flowId of ["react-flow-architecture-demo", "react-flow-system-blueprint"]) {
+    const englishFlow = englishFlows.find((flow) => flow.id === flowId);
+    const vietnameseFlow = vietnameseFlows.find((flow) => flow.id === flowId);
+    assert.ok(englishFlow?.architectureDemo);
+    assert.ok(vietnameseFlow?.architectureDemo);
+
+    const englishDemo = englishFlow.architectureDemo;
+    const vietnameseDemo = vietnameseFlow.architectureDemo;
+    assert.deepEqual(vietnameseDemo.views.map((view) => view.id), englishDemo.views.map((view) => view.id));
+    assert.deepEqual(vietnameseDemo.nodes.map((node) => node.id), englishDemo.nodes.map((node) => node.id));
+    assert.deepEqual(vietnameseDemo.edges.map((edge) => edge.id), englishDemo.edges.map((edge) => edge.id));
+    for (let index = 0; index < englishDemo.views.length; index += 1) {
+      assert.deepEqual(
+        vietnameseDemo.views[index].nodes.map((node) => node.id),
+        englishDemo.views[index].nodes.map((node) => node.id)
+      );
+      assert.deepEqual(
+        vietnameseDemo.views[index].edges.map((edge) => edge.id),
+        englishDemo.views[index].edges.map((edge) => edge.id)
+      );
+    }
+
+    assert.notEqual(vietnameseDemo.views[0].title, englishDemo.views[0].title);
+    assert.notEqual(vietnameseDemo.views[0].description, englishDemo.views[0].description);
+    assert.notEqual(vietnameseDemo.nodes[0].detail, englishDemo.nodes[0].detail);
+  }
+
+  const englishNodes = englishFlows.flatMap((flow) => flow.architectureDemo?.views.flatMap((view) => view.nodes) ?? []);
+  const vietnameseNodes = vietnameseFlows.flatMap((flow) => flow.architectureDemo?.views.flatMap((view) => view.nodes) ?? []);
+  const englishEdges = englishFlows.flatMap((flow) => flow.architectureDemo?.views.flatMap((view) => view.edges) ?? []);
+  const vietnameseEdges = vietnameseFlows.flatMap((flow) => flow.architectureDemo?.views.flatMap((view) => view.edges) ?? []);
+
+  assert.equal(englishNodes.find((node) => node.id === "api-gateway")?.title, "API Gateway");
+  assert.equal(vietnameseNodes.find((node) => node.id === "api-gateway")?.title, "API Gateway");
+  assert.equal(englishNodes.find((node) => node.id === "policy-decision")?.title, "Policy?");
+  assert.equal(vietnameseNodes.find((node) => node.id === "policy-decision")?.title, "Chính sách nào?");
+  assert.equal(englishNodes.find((node) => node.title === "Receipt")?.title, "Receipt");
+  assert.equal(vietnameseNodes.find((node) => node.id === englishNodes.find((item) => item.title === "Receipt")?.id)?.title, "Biên nhận");
+  assert.equal(englishEdges.find((edge) => edge.id === "lb-frontend")?.label, "healthy target");
+  assert.equal(vietnameseEdges.find((edge) => edge.id === "lb-frontend")?.label, "đích đạt health check");
+});

--- a/tests/studio-route.test.mjs
+++ b/tests/studio-route.test.mjs
@@ -64,6 +64,9 @@ test("studio route is wired into routing, seo, navigation, analytics, and invent
   assert.ok(existsSync("src/app/[locale]/studio/studio-admin-shell.tsx"));
   assert.ok(existsSync("src/app/[locale]/studio/studio.shadow-styles.ts"));
   assert.ok(existsSync("src/app/[locale]/studio/studio.data.ts"));
+  assert.ok(existsSync("src/app/[locale]/studio/studio.localized-content.ts"));
+  assert.ok(existsSync("src/app/[locale]/studio/studio.localized-workspace.ts"));
+  assert.ok(existsSync("src/app/[locale]/studio/studio.localized-demos.ts"));
   assert.ok(existsSync("src/app/[locale]/studio/studio.react-flow-architecture-demo.ts"));
   assert.ok(existsSync("src/app/[locale]/studio/studio.react-flow-system-blueprint.ts"));
   assert.ok(existsSync("src/components/studio-kit/index.ts"));
@@ -87,6 +90,8 @@ test("studio route is wired into routing, seo, navigation, analytics, and invent
     adminShell,
     data,
     localizedContent,
+    localizedWorkspace,
+    localizedDemos,
     shadowCss,
     kitIndex,
     shadowIsland,
@@ -109,6 +114,8 @@ test("studio route is wired into routing, seo, navigation, analytics, and invent
     readFile("src/app/[locale]/studio/studio-admin-shell.tsx", "utf8"),
     readFile("src/app/[locale]/studio/studio.data.ts", "utf8"),
     readFile("src/app/[locale]/studio/studio.localized-content.ts", "utf8"),
+    readFile("src/app/[locale]/studio/studio.localized-workspace.ts", "utf8"),
+    readFile("src/app/[locale]/studio/studio.localized-demos.ts", "utf8"),
     readFile("src/app/[locale]/studio/studio.shadow-styles.ts", "utf8"),
     readFile("src/components/studio-kit/index.ts", "utf8"),
     readFile("src/components/studio-kit/shadow-island.tsx", "utf8"),
@@ -149,11 +156,17 @@ test("studio route is wired into routing, seo, navigation, analytics, and invent
 
   assert.match(page, /generateStaticParams/);
   assert.match(page, /generateMetadata/);
+  assert.match(page, /Studio — Engineering Notes, Checklists, and System Flows/);
+  assert.match(page, /Studio — Ghi chú kỹ thuật, Checklists và System Flows/);
   assert.match(page, /PageTracker page="studio" eventName="studio_view"/);
-  assert.match(page, /"@type":\s*"HowTo"/);
-  assert.match(page, /flow-\$\{flow\.id\}/);
+  assert.match(page, /"@type":\s*"CollectionPage"/);
+  assert.doesNotMatch(page, /"@type":\s*"HowTo"/);
+  assert.doesNotMatch(page, /"@type":\s*"TechArticle"/);
+  assert.doesNotMatch(page, /getLocalizedStudioNotes|getLocalizedStudioFlows/);
   assert.match(page, /StudioWorkspace/);
   assert.match(page, /studio-route-shell/);
+  assert.match(page, /<div className="studio-route-shell">/);
+  assert.doesNotMatch(page, /<main className="studio-route-shell">/);
   assert.match(page, /body:has\(\.studio-route-shell\) \.app-nav/);
   assert.match(page, /body:has\(\.studio-route-shell\) \.app-footer/);
   assert.doesNotMatch(page, /studio\.css/);
@@ -222,7 +235,7 @@ test("studio route is wired into routing, seo, navigation, analytics, and invent
   assert.match(adminShell, /studioCopyByLocale/);
   assert.match(adminShell, /getStudioCopy/);
   assert.match(adminShell, /getLocalizedRouteDefinitions/);
-  assert.match(adminShell, /navLabel:\s*"Studio cá nhân"/);
+  assert.match(adminShell, /navLabel:\s*"Studio cá nhân của Nguyễn Lê Phong"/);
   assert.match(adminShell, /navLabel:\s*"个人 Studio"/);
   assert.match(adminShell, /navLabel:\s*"パーソナル Studio"/);
   assert.match(adminShell, /navLabel:\s*"개인 Studio"/);
@@ -231,7 +244,7 @@ test("studio route is wired into routing, seo, navigation, analytics, and invent
   assert.match(adminShell, /studio-topbar/);
   assert.match(adminShell, /metric-grid/);
   assert.match(adminShell, /<span>Studio<\/span>/);
-  assert.match(adminShell, /Find setup note/);
+  assert.match(adminShell, /Search Studio/);
   assert.match(adminShell, /Profile navigation/);
   assert.match(adminShell, /Profile menu/);
   assert.match(adminShell, /label:\s*"Home"/);
@@ -334,11 +347,10 @@ test("studio route is wired into routing, seo, navigation, analytics, and invent
   assert.match(adminShell, /title:\s*"Delivery Checklists"/);
   assert.match(adminShell, /title:\s*"Welcome"/);
   assert.match(adminShell, /title:\s*"System Design Flow"/);
-  assert.match(adminShell, /"flow-react-flow-architecture-demo":\s*"Example"/);
-  assert.match(adminShell, /"flow-react-flow-system-blueprint":\s*"Blueprint"/);
+  assert.match(adminShell, /"flow-react-flow-architecture-demo":\s*"React Flow Examples"/);
+  assert.match(adminShell, /"flow-react-flow-system-blueprint":\s*"System Blueprint"/);
   assert.match(adminShell, /chartLabel:\s*"Flow chart"/);
-  assert.match(adminShell, /Read the path from left to right/);
-  assert.match(adminShell, /chartLabel:\s*"Sơ đồ flow"/);
+  assert.match(adminShell, /Read from left to right/);
   assert.match(adminShell, /Đọc từ trái sang phải/);
   assert.doesNotMatch(adminShell, /Mail preview/);
   assert.doesNotMatch(adminShell, /Chat preview/);
@@ -568,104 +580,52 @@ test("studio route is wired into routing, seo, navigation, analytics, and invent
   assert.match(shadowCss, /\.route-actions,\s*\.calendar-grid\s*\{[^}]*grid-template-columns:\s*1fr/s);
 
   for (const expected of [
-    "AI setup",
+    "Machine bootstrap",
+    "My AI Working System",
+    "Engineering Foundations for AI-Assisted Work",
+    "System Engineering Roadmap for AI-Assisted Work",
+    "Antigravity Awesome Skills",
+    "Open Design",
     "Computer setup",
     "Terminal setup",
-    "Machine bootstrap",
-    "AI Operating System",
-    "Daily direction for using NotebookLM, GPT, Claude, Codex, and Antigravity as one system.",
-    "NotebookLM keeps source-backed truth",
-    "AI-Driven Engineering Foundation",
-    "Daily roadmap for technical decision-making from task intake to production operation.",
-    "Seven layers from task to production",
-    "Production readiness prompt",
-    "Morning planning prompt",
-    "Weekly command center prompt",
-    "Codex",
-    "Claude",
-    "Antigravity",
-    "Gemini",
-    "Open Design",
+    "Multi-agent AI",
+    "OpenHands",
+    "CrewAI",
     "npx antigravity-awesome-skills",
     "https://github.com/sickn33/antigravity-awesome-skills",
     "od mcp install codex",
-    "od mcp install antigravity",
-    "Code Review Skill",
-    "Code Shape Review",
-    "Data structures",
-    "Strategy for replaceable rules",
-    "Clean architecture",
-    "Service boundaries",
-    "Utility extraction",
-    "Frontend Architecture Skill",
-    "Backend Architecture Skill",
-    "Blog Content Writer Skill",
-    "Prompt Writing Skill",
-    "Status Report Skill",
-    "Doc / Spec / Tech Spec Skill",
-    "Proposal / Slide / Pitch Deck Skill",
-    "AI Operating System Skill",
-    "Daily AI Learning Coach Skill",
-    "NotebookLM Source Of Truth Skill",
-    "AI Delivery Factory Skill",
-    "Claude Deep Review Skill",
-    "Career AI Strategy Skill",
-    "Engineering Decision Map Skill",
-    "Staff Engineer AI Review Pack Skill",
-    "Data, Resilience, Observability Review Skill",
-    "Ticket intake to first commit",
-    "AI-driven engineering foundation roadmap",
-    "Engineering delivery checklist",
-    "Senior engineer reflex",
-    "Capstone production project",
-    "AI system engineering roadmap",
-    "SDLC ownership",
-    "Distributed architecture and resilience",
-    "Large-scale storage",
-    "B-Tree and LSM-Tree",
-    "AI-Driven System Engineering Roadmap",
-    "AI-first elicitation prompt",
-    "Circuit Breaker",
-    "Event Sourcing",
-    "OpenTelemetry",
-    "Create a new module",
-    "Release readiness",
-    "Rollout plan",
-    "Roll out by phase.",
-    "Daily AI learning loop",
-    "Weekly AI OS review",
-    "AI tool routing decision tree",
-    "AI-assisted feature workflow",
-    "90-day AI skill plan",
-    "Create five ChatGPT Projects.",
-    "Create five NotebookLM notebooks.",
-    "Architecture & System Design",
-    "React Flow",
-    "React Flow Example for Software Diagrams",
-    "A React Flow showcase for example families",
-    "overview",
-    "interaction",
-    "grouping",
-    "layout",
-    "styling",
-    "whiteboard",
-    "architecture",
-    "Node Shapes",
-    "Edge Types",
-    "System Design Interview Flow",
+    "Code Review",
+    "Frontend Architecture",
+    "Backend Architecture",
+    "Technical Writing",
+    "Prompt Design",
+    "Executive Status Reporting",
+    "Technical Specification & RFC",
+    "AI Workflow Design",
+    "Continuous AI Learning",
+    "Source-Grounded Knowledge Extraction",
+    "AI-Assisted Delivery & CI/CD",
+    "Adversarial Design Review",
+    "Architecture Decision Mapping",
+    "Architecture Risk Audit",
+    "Skill Library Inventory",
+    "From Ticket to First Commit",
+    "Engineering Delivery Checklist",
+    "Production Systems Practice Project",
+    "Create a New Module",
+    "Release Readiness",
+    "Rollout Plan",
+    "Daily AI Practice Loop",
+    "Weekly AI Workflow Review",
+    "AI Tool Routing Guide",
+    "90-Day AI Practice Plan",
+    "React Flow Pattern Library",
     "Architecture Decision Flow",
     "Production Incident Flow",
     "Release Readiness Flow",
     "AI-Assisted Delivery Flow",
     "Portfolio Story Flow",
-    "System Design Blueprint",
-    "A product manager asks for a new partner onboarding flow.",
-    "A team debates whether to add a queue for partner sync.",
-    "checkout latency climbs",
-    "dashboard filter with analytics and SEO changes",
-    "AI agent helps with coding",
-    "CV bullet, STAR answer, blog outline, or case-study draft",
-    "poster-style architecture map"
+    "System Design Blueprint"
   ]) {
     assert.match(data, new RegExp(expected.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")));
   }
@@ -676,33 +636,64 @@ test("studio route is wired into routing, seo, navigation, analytics, and invent
   for (const expected of [
     "getLocalizedStudioAiSkills",
     "getLocalizedStudioWorkflowChecklists",
-    "Review thay đổi theo correctness",
-    "Review data structure",
-    "Review design pattern",
-    "Review clean architecture",
-    "application service giữ orchestration",
-    "generic utility bắt đầu giữ product state",
+    "Rà soát mã nguồn",
+    "tính đúng đắn trước",
     "Kiến trúc frontend",
-    "Viết blog content",
-    "Từ ticket đến commit đầu tiên",
-    "Checklist delivery engineering",
+    "Kiến trúc backend",
+    "Viết nội dung kỹ thuật",
+    "Thiết kế prompt",
+    "Báo cáo tiến độ và vận hành",
+    "Hệ thống làm việc với AI",
+    "Đánh giá sản phẩm AI",
+    "Bảo mật, quyền riêng tư và mô hình đe dọa",
+    "Danh sách kiểm tra khi giao phần mềm",
+    "Lộ trình kỹ thuật hệ thống với AI",
+    "Vòng học AI hằng ngày",
     "getLocalizedStudioFlows",
     "getLocalizedStudioFlowGroups",
-    "Flow System Design",
-    "React Flow",
-    "Example",
-    "System Design Blueprint",
-    "Đổi các dạng example trước khi chọn sơ đồ",
-    "onboarding đối tác",
-    "release readiness",
-    "support noise",
-    "Catalog node shape React Flow",
-    "Canvas software architecture",
-    "Blueprint system design lớn bằng React Flow",
+    "Quy trình thiết kế hệ thống",
+    "Quy trình ra quyết định kiến trúc",
+    "Quy trình xử lý sự cố",
+    "Quy trình AI-assisted Delivery",
+    "Bộ ví dụ React Flow",
+    "Bản thiết kế hệ thống bằng React Flow",
     "isVietnameseLocale"
   ]) {
     assert.match(localizedContent, new RegExp(expected.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")));
   }
+
+  for (const expected of [
+    "Chuẩn bị máy mới",
+    "Cách tôi phối hợp các công cụ AI",
+    "Nền tảng kỹ thuật khi làm việc cùng AI",
+    "Lộ trình kỹ thuật hệ thống khi làm việc cùng AI",
+    "Thiết lập máy tính",
+    "Thiết lập dòng lệnh",
+    "Multi-agent AI",
+    "getLocalizedStudioFolders",
+    "getLocalizedStudioNotes"
+  ]) {
+    assert.match(localizedWorkspace, new RegExp(expected.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")));
+  }
+
+  for (const expected of [
+    "getLocalizedStudioDemoFlows",
+    "locale.toLowerCase().split",
+    "Sơ đồ dày thông tin theo phong cách production",
+    "title: localized?.title ?? node.title",
+    "title: localized?.title ?? view.title",
+    "label: copy.edges[edge.id] ?? edge.label"
+  ]) {
+    assert.match(localizedDemos, new RegExp(expected.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")));
+  }
+
+  assert.match(localizedContent, /title:\s*"Design system và chất lượng UI"/);
+  assert.match(localizedContent, /tags:\s*\["Design system", "UI", "Accessibility", "Responsive"\]/);
+
+  assert.doesNotMatch(adminShell, /Đây là nơi em gom/);
+  assert.doesNotMatch(adminShell, /Tìm AI setup/);
+  assert.doesNotMatch(adminShell, /Studio Admin dashboard/);
+  assert.doesNotMatch(adminShell, /Container đầu tiên cho research/);
 
   for (const expected of [
     "Built-in primitives",


### PR DESCRIPTION
## Summary

- Rewrite the public Studio workspace in English and Vietnamese with sharper, friendlier copy while preserving established software-engineering terms in English.
- Localize notes, skills, checklists, and React Flow explanations without changing their IDs, ordering, analytics contracts, or canvas structure.
- Correct locale-aware metadata, accessibility labels, contextual checklist lookup, and JSON-LD so it only describes content the route actually exposes.

## Scope

- [x] UI / UX
- [x] Content / SEO
- [x] Data / locale behavior
- [ ] Build / deployment
- [x] Tests / tooling
- [ ] Documentation

## Verification

- [x] `npm run typecheck`
- [x] `npm run lint`
- [x] `npm test` — 41/41 passing
- [x] `npm run build:fast` — 2,160 static pages generated
- [ ] Manual browser check
- [x] `npm run verify:offline`
- [x] Inspected the generated EN/VI Studio metadata and JSON-LD in `out/`

## Screenshots

Not captured. This change updates content, metadata, localization, and accessibility wiring without changing the intended layout; the in-app browser backend was unavailable during verification.

## Risk And Rollback

- Risk level: medium
- Rollback plan: revert `feat(studio): revamp bilingual workspace content` to restore the previous copy and localization behavior.

## Notes For Reviewer

- Default assignee: `nguyenlephong`
- Deployment impact: static Studio pages will be regenerated for all locales; no route, analytics event name, or deployment configuration changes.
- Vietnamese copy intentionally keeps familiar terms such as `design system`, `frontend`, `backend`, `release`, `rollout`, `production`, `cache`, `queue`, and `observability` in English.
