### PR TITLE
fix(ci): stop pages from rewriting next config

### DIFF
--- a/.github/workflows/nextjs.yml
+++ b/.github/workflows/nextjs.yml
@@ -43,8 +43,6 @@ jobs:
 
       - name: Configure GitHub Pages
         uses: actions/configure-pages@v6
-        with:
-          static_site_generator: next
 
       - name: Run source quality gates
         run: npm run check

--- a/tests/deployment-workflow.test.mjs
+++ b/tests/deployment-workflow.test.mjs
@@ -38,6 +38,11 @@ test('Pages workflow grants deployment credentials only to the deploy job', () =
   assert.doesNotMatch(deployJob, /contents: write/)
 })
 
+test('Pages workflow configures Pages without rewriting the composed Next config', () => {
+  assert.match(workflow, /uses: actions\/configure-pages@v6/)
+  assert.doesNotMatch(workflow, /static_site_generator:/)
+})
+
 test('Pages workflow verifies the built out tree before uploading it', () => {
   const buildIndex = workflow.indexOf('run: npm run build')
   const verifyIndex = workflow.indexOf('run: npm run verify:artifact')


### PR DESCRIPTION
## Summary

- Keep `actions/configure-pages@v6` for GitHub Pages metadata and artifact setup.
- Stop `configure-pages` from injecting `static_site_generator: next` into the composed Next.js configuration.
- Add a regression test that preserves this deployment contract.

## Scope

- [ ] UI / UX
- [ ] Content / SEO
- [ ] Data / locale behavior
- [x] Build / deployment
- [x] Tests / tooling
- [ ] Documentation

## Verification

- [ ] `npm run typecheck`
- [ ] `npm run lint`
- [ ] `npm test`
- [ ] `npm run build` or `npm run build:fast`
- [ ] Manual browser check
- [x] `npx -y node@22.18.0 --test tests/deployment-workflow.test.mjs` (9/9 passed)
- [x] `git diff --check`

## Screenshots

Not applicable; this change only affects the GitHub Pages workflow and its regression test.

## Risk And Rollback

- Risk level: low
- Rollback plan: revert `fix(ci): stop pages from rewriting next config` to restore the previous `configure-pages` input.

## Notes For Reviewer

- Default assignee: `nguyenlephong`
- Deployment impact: `next.config.mjs` remains the single owner of `output: 'export'`, `images.unoptimized`, and the user-site base path. The Pages action still runs, but no longer rewrites the composed `next-intl` config before the production build.
