### PR TITLE
perf(seo): reduce static artifact and harden runtime signals

### DIFF
--- a/.github/workflows/ci-frontend.yml
+++ b/.github/workflows/ci-frontend.yml
@@ -147,5 +147,8 @@ jobs:
       - name: Install Playwright Chromium
         run: npx playwright install --with-deps chromium
 
+      - name: Verify localized 404 recovery
+        run: npm run verify:not-found
+
       - name: Verify offline browser behavior
         run: npm run verify:offline

--- a/.github/workflows/ci-frontend.yml
+++ b/.github/workflows/ci-frontend.yml
@@ -133,6 +133,9 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      - name: Verify concurrent development first hits
+        run: npm run verify:dev-concurrency
+
       # Skip OG-image generation for speed; this still runs the full
       # `next build` and fails on any compile / type / lint error.
       - name: Build (static export, OG skipped)

--- a/.github/workflows/nextjs.yml
+++ b/.github/workflows/nextjs.yml
@@ -47,6 +47,9 @@ jobs:
       - name: Run source quality gates
         run: npm run check
 
+      - name: Verify concurrent development first hits
+        run: npm run verify:dev-concurrency
+
       - name: Build production static export
         run: npm run build
 

--- a/.github/workflows/nextjs.yml
+++ b/.github/workflows/nextjs.yml
@@ -59,6 +59,9 @@ jobs:
       - name: Install Playwright Chromium
         run: npx playwright install --with-deps chromium
 
+      - name: Verify localized 404 recovery
+        run: npm run verify:not-found
+
       - name: Verify offline browser behavior
         run: npm run verify:offline
 

--- a/.github/workflows/seo-field-monitoring.yml
+++ b/.github/workflows/seo-field-monitoring.yml
@@ -1,0 +1,35 @@
+name: Observe SEO field data
+
+on:
+  schedule:
+    - cron: '17 5 * * 2'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: seo-field-monitoring
+  cancel-in-progress: true
+
+jobs:
+  observe:
+    name: Search Console and CrUX observation
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+        with:
+          persist-credentials: false
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v5
+        with:
+          node-version-file: .nvmrc
+
+      - name: Collect sanitized field data
+        env:
+          GOOGLE_SEARCH_CONSOLE_SERVICE_ACCOUNT_JSON: ${{ secrets.GOOGLE_SEARCH_CONSOLE_SERVICE_ACCOUNT_JSON }}
+          CRUX_API_KEY: ${{ secrets.CRUX_API_KEY }}
+        run: node scripts/monitor-seo-field-data.mjs

--- a/.github/workflows/seo-field-monitoring.yml
+++ b/.github/workflows/seo-field-monitoring.yml
@@ -15,6 +15,7 @@ concurrency:
 jobs:
   observe:
     name: Search Console and CrUX observation
+    if: github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:

--- a/config/seo-field-monitoring.json
+++ b/config/seo-field-monitoring.json
@@ -1,0 +1,57 @@
+{
+  "schemaVersion": 1,
+  "searchConsole": {
+    "property": "https://nguyenlephong.github.io/",
+    "sitemapUrl": "https://nguyenlephong.github.io/sitemap.xml",
+    "windowDays": 28,
+    "finalDataLagDays": 3,
+    "minimumPriorImpressions": 200,
+    "impressionDropThresholdPercent": 30,
+    "inspectionCanaries": [
+      {
+        "label": "home",
+        "url": "https://nguyenlephong.github.io/en"
+      },
+      {
+        "label": "blog-index",
+        "url": "https://nguyenlephong.github.io/en/blog"
+      },
+      {
+        "label": "studio",
+        "url": "https://nguyenlephong.github.io/en/studio"
+      },
+      {
+        "label": "article",
+        "url": "https://nguyenlephong.github.io/en/blog/architecture/ports-and-adapters"
+      }
+    ]
+  },
+  "crux": {
+    "origin": "https://nguyenlephong.github.io",
+    "formFactor": "PHONE",
+    "collectionPeriodCount": 8,
+    "metrics": [
+      "largest_contentful_paint",
+      "interaction_to_next_paint",
+      "cumulative_layout_shift"
+    ],
+    "pages": [
+      {
+        "label": "home",
+        "url": "https://nguyenlephong.github.io/en"
+      },
+      {
+        "label": "blog-index",
+        "url": "https://nguyenlephong.github.io/en/blog"
+      },
+      {
+        "label": "notes-index",
+        "url": "https://nguyenlephong.github.io/en/notes"
+      },
+      {
+        "label": "studio",
+        "url": "https://nguyenlephong.github.io/en/studio"
+      }
+    ]
+  }
+}

--- a/config/static-artifact-budgets.json
+++ b/config/static-artifact-budgets.json
@@ -2,10 +2,10 @@
   "schemaVersion": 1,
   "outputDirectory": "out",
   "siteOrigin": "https://nguyenlephong.github.io",
-  "warnAtPercent": 90,
+  "warnAtPercent": 75,
   "limits": {
-    "totalBytes": 891289600,
-    "fileCount": 27500,
+    "totalBytes": 629145600,
+    "fileCount": 20000,
     "maxHtmlBytes": 440320,
     "maxJavaScriptBytes": 1415578,
     "maxCssBytes": 215040,

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -7,15 +7,22 @@ const { version: appVersion } = JSON.parse(
 )
 
 const withNextIntl = createNextIntlPlugin('./src/i18n/request.ts')
+const isDevelopment = process.env.NODE_ENV === 'development'
 
 /** @type {import('next').NextConfig} */
 const nextConfig = {
-  output: "export",
+  // The production build remains a pure static export. Keeping export mode on
+  // during `next dev` makes concurrent first-route compilation race while
+  // updating prerender-manifest.json in Next 16.
+  output: isDevelopment ? undefined : "export",
   turbopack: {},
   // Tree-shake icon + animation libraries with deep barrel exports so we
   // only ship the few we actually use. Saves tens of KB and reduces TBT.
   experimental: {
-    globalNotFound: true,
+    // The custom document is required by the exported production artifact.
+    // Development uses Next's built-in 404 so a concurrent missing-route
+    // compile cannot contend with valid first-route compilation.
+    globalNotFound: !isDevelopment,
     optimizePackageImports: [
       "react-icons",
       "react-icons/lu",

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -15,6 +15,7 @@ const nextConfig = {
   // Tree-shake icon + animation libraries with deep barrel exports so we
   // only ship the few we actually use. Saves tens of KB and reduces TBT.
   experimental: {
+    globalNotFound: true,
     optimizePackageImports: [
       "react-icons",
       "react-icons/lu",

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "check": "npm run typecheck && npm run lint && npm test",
     "quality": "npm run check && npm run build:fast && npm run verify:pagination && npm run verify:artifact && npm run verify:offline",
     "verify:artifact": "node scripts/verify-static-artifact.mjs",
+    "verify:dev-concurrency": "node scripts/verify-dev-concurrency.mjs",
     "verify:not-found": "node scripts/verify-static-not-found.mjs",
     "verify:pagination": "node scripts/verify-content-pagination.mjs",
     "verify:offline": "node scripts/verify-offline.mjs",

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "check": "npm run typecheck && npm run lint && npm test",
     "quality": "npm run check && npm run build:fast && npm run verify:pagination && npm run verify:artifact && npm run verify:offline",
     "verify:artifact": "node scripts/verify-static-artifact.mjs",
+    "verify:not-found": "node scripts/verify-static-not-found.mjs",
     "verify:pagination": "node scripts/verify-content-pagination.mjs",
     "verify:offline": "node scripts/verify-offline.mjs",
     "og:generate": "node scripts/generate-static-og.mjs",

--- a/scripts/monitor-seo-field-data.mjs
+++ b/scripts/monitor-seo-field-data.mjs
@@ -75,6 +75,40 @@ function safeIsoDateTime(value) {
   return Number.isNaN(date.getTime()) ? null : date.toISOString();
 }
 
+function normalizeCanonicalUrl(value) {
+  if (typeof value !== "string" || !value.trim()) return null;
+  try {
+    const url = new URL(value);
+    url.hash = "";
+    if (url.pathname.length > 1) {
+      url.pathname = url.pathname.replace(/\/+$/, "");
+    }
+    return url.toString();
+  } catch {
+    return null;
+  }
+}
+
+export function compareCanonicalUrls(
+  googleCanonical,
+  userCanonical,
+  expectedCanonical
+) {
+  const google = normalizeCanonicalUrl(googleCanonical);
+  const user = normalizeCanonicalUrl(userCanonical);
+  const expected = normalizeCanonicalUrl(expectedCanonical);
+  const googleMatchesExpected = google && expected ? google === expected : null;
+  const userMatchesExpected = user && expected ? user === expected : null;
+
+  return {
+    canonicalAgreement: google && user ? google === user : null,
+    googleMatchesExpected,
+    userMatchesExpected,
+    canonicalMatches:
+      googleMatchesExpected === true && userMatchesExpected === true
+  };
+}
+
 function requestReason(error) {
   return error instanceof MonitorError ? error.reason : "request_failed";
 }
@@ -295,6 +329,11 @@ function sanitizeInspection(response, canary) {
   }
   const googleCanonical = safeText(result.googleCanonical, 500);
   const userCanonical = safeText(result.userCanonical, 500);
+  const canonicalComparison = compareCanonicalUrls(
+    googleCanonical,
+    userCanonical,
+    canary.expectedCanonical ?? canary.url
+  );
 
   return {
     label: canary.label,
@@ -305,10 +344,7 @@ function sanitizeInspection(response, canary) {
     pageFetchState: safeText(result.pageFetchState, 40),
     robotsTxtState: safeText(result.robotsTxtState, 40),
     lastCrawlTime: safeIsoDateTime(result.lastCrawlTime),
-    canonicalMatches:
-      googleCanonical && userCanonical
-        ? googleCanonical === userCanonical
-        : null
+    ...canonicalComparison
   };
 }
 
@@ -701,7 +737,10 @@ function validateConfig(config) {
     !Array.isArray(search.inspectionCanaries) ||
     search.inspectionCanaries.some(
       (canary) =>
-        typeof canary?.label !== "string" || typeof canary?.url !== "string"
+        typeof canary?.label !== "string" ||
+        typeof canary?.url !== "string" ||
+        (canary.expectedCanonical !== undefined &&
+          typeof canary.expectedCanonical !== "string")
     ) ||
     !Number.isInteger(search.windowDays) ||
     search.windowDays < 1 ||
@@ -729,6 +768,9 @@ function validateConfig(config) {
   const publicUrls = [
     search.sitemapUrl,
     ...search.inspectionCanaries.map((canary) => canary.url),
+    ...search.inspectionCanaries.map(
+      (canary) => canary.expectedCanonical ?? canary.url
+    ),
     ...crux.pages.map((page) => page.url)
   ];
   let origin;
@@ -869,12 +911,12 @@ export function renderMarkdown(report) {
   if (Array.isArray(report.searchConsole.inspections)) {
     lines.push(
       "",
-      "| Canary | Availability | Verdict | Fetch | Canonical match |",
-      "| --- | --- | --- | --- | --- |"
+      "| Canary | Availability | Verdict | Fetch | User expected | Google expected | Agreement |",
+      "| --- | --- | --- | --- | --- | --- | --- |"
     );
     for (const item of report.searchConsole.inspections) {
       lines.push(
-        `| ${markdownCell(item.label)} | ${markdownCell(item.availability)} | ${markdownCell(item.verdict ?? item.reason)} | ${markdownCell(item.pageFetchState)} | ${markdownCell(item.canonicalMatches)} |`
+        `| ${markdownCell(item.label)} | ${markdownCell(item.availability)} | ${markdownCell(item.verdict ?? item.reason)} | ${markdownCell(item.pageFetchState)} | ${markdownCell(item.userMatchesExpected)} | ${markdownCell(item.googleMatchesExpected)} | ${markdownCell(item.canonicalAgreement)} |`
       );
     }
   }

--- a/scripts/monitor-seo-field-data.mjs
+++ b/scripts/monitor-seo-field-data.mjs
@@ -1,0 +1,961 @@
+#!/usr/bin/env node
+
+import { createSign } from "node:crypto";
+import { appendFile, readFile } from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+export const ENDPOINTS = Object.freeze({
+  oauthToken: "https://oauth2.googleapis.com/token",
+  searchConsole: "https://www.googleapis.com/webmasters/v3",
+  urlInspection:
+    "https://searchconsole.googleapis.com/v1/urlInspection/index:inspect",
+  cruxHistory:
+    "https://chromeuxreport.googleapis.com/v1/records:queryHistoryRecord"
+});
+
+const CONFIG_PATH = path.resolve("config/seo-field-monitoring.json");
+const SEARCH_CONSOLE_SCOPE =
+  "https://www.googleapis.com/auth/webmasters.readonly";
+const REQUEST_TIMEOUT_MS = 15_000;
+const CRUX_METRIC_KEYS = Object.freeze({
+  largest_contentful_paint: "lcp",
+  interaction_to_next_paint: "inp",
+  cumulative_layout_shift: "cls"
+});
+
+class MonitorError extends Error {
+  constructor(reason) {
+    super(reason);
+    this.reason = reason;
+  }
+}
+
+function base64Url(value) {
+  return Buffer.from(value).toString("base64url");
+}
+
+function finiteNumber(value, digits = 3) {
+  if (
+    value === null ||
+    value === undefined ||
+    (typeof value === "string" && value.trim() === "") ||
+    (typeof value !== "string" && typeof value !== "number")
+  ) {
+    return null;
+  }
+  const number = Number(value);
+  if (!Number.isFinite(number)) return null;
+  const factor = 10 ** digits;
+  return Math.round(number * factor) / factor;
+}
+
+function nonNegativeInteger(value) {
+  if (
+    value === null ||
+    value === undefined ||
+    (typeof value === "string" && value.trim() === "") ||
+    (typeof value !== "string" && typeof value !== "number")
+  ) {
+    return null;
+  }
+  const number = Number(value);
+  return Number.isFinite(number) && number >= 0 ? Math.trunc(number) : null;
+}
+
+function safeText(value, maxLength = 100) {
+  if (typeof value !== "string") return null;
+  const normalized = value.replace(/[\u0000-\u001f\u007f]/g, " ").trim();
+  return normalized ? normalized.slice(0, maxLength) : null;
+}
+
+function safeIsoDateTime(value) {
+  if (typeof value !== "string") return null;
+  const date = new Date(value);
+  return Number.isNaN(date.getTime()) ? null : date.toISOString();
+}
+
+function requestReason(error) {
+  return error instanceof MonitorError ? error.reason : "request_failed";
+}
+
+function combineAvailability(statuses) {
+  if (statuses.length === 0) return "unknown";
+  if (statuses.every((status) => status === "observed")) return "observed";
+  if (
+    statuses.some((status) => status === "observed" || status === "partial")
+  ) {
+    return "partial";
+  }
+  if (statuses.every((status) => status === "skipped")) return "skipped";
+  return "unknown";
+}
+
+function isoDate(date) {
+  return date.toISOString().slice(0, 10);
+}
+
+export function searchDateRange(now, windowDays, finalDataLagDays) {
+  const end = new Date(
+    Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate())
+  );
+  end.setUTCDate(end.getUTCDate() - finalDataLagDays);
+  const start = new Date(end);
+  start.setUTCDate(start.getUTCDate() - windowDays + 1);
+  return { startDate: isoDate(start), endDate: isoDate(end) };
+}
+
+function priorDateRange(currentRange, windowDays) {
+  const end = new Date(`${currentRange.startDate}T00:00:00Z`);
+  end.setUTCDate(end.getUTCDate() - 1);
+  const start = new Date(end);
+  start.setUTCDate(start.getUTCDate() - windowDays + 1);
+  return { startDate: isoDate(start), endDate: isoDate(end) };
+}
+
+async function requestJson(fetchImpl, url, init = {}) {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), REQUEST_TIMEOUT_MS);
+  timer.unref?.();
+
+  try {
+    const response = await fetchImpl(url, {
+      ...init,
+      signal: controller.signal
+    });
+    if (!response.ok) throw new MonitorError(`http_${response.status}`);
+    try {
+      return await response.json();
+    } catch {
+      throw new MonitorError("invalid_json");
+    }
+  } catch (error) {
+    if (error instanceof MonitorError) throw error;
+    if (error?.name === "AbortError") throw new MonitorError("timeout");
+    throw new MonitorError("request_failed");
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+function parseServiceAccount(raw) {
+  if (!raw) throw new MonitorError("credentials_missing");
+  let value;
+  try {
+    value = JSON.parse(raw);
+  } catch {
+    throw new MonitorError("credentials_invalid");
+  }
+
+  if (
+    typeof value?.client_email !== "string" ||
+    typeof value?.private_key !== "string"
+  ) {
+    throw new MonitorError("credentials_invalid");
+  }
+  return value;
+}
+
+export async function exchangeServiceAccountToken(
+  serviceAccountJson,
+  { fetchImpl = fetch, now = new Date() } = {}
+) {
+  const serviceAccount = parseServiceAccount(serviceAccountJson);
+  const issuedAt = Math.floor(now.getTime() / 1000);
+  const header = base64Url(JSON.stringify({ alg: "RS256", typ: "JWT" }));
+  const payload = base64Url(
+    JSON.stringify({
+      iss: serviceAccount.client_email,
+      scope: SEARCH_CONSOLE_SCOPE,
+      aud: ENDPOINTS.oauthToken,
+      iat: issuedAt,
+      exp: issuedAt + 3600
+    })
+  );
+  const unsigned = `${header}.${payload}`;
+  let signature;
+  try {
+    signature = createSign("RSA-SHA256")
+      .update(unsigned)
+      .end()
+      .sign(serviceAccount.private_key, "base64url");
+  } catch {
+    throw new MonitorError("credentials_invalid");
+  }
+
+  const body = new URLSearchParams({
+    grant_type: "urn:ietf:params:oauth:grant-type:jwt-bearer",
+    assertion: `${unsigned}.${signature}`
+  });
+  const response = await requestJson(fetchImpl, ENDPOINTS.oauthToken, {
+    method: "POST",
+    headers: { "content-type": "application/x-www-form-urlencoded" },
+    body
+  });
+  if (typeof response?.access_token !== "string" || !response.access_token) {
+    throw new MonitorError("token_missing");
+  }
+  return response.access_token;
+}
+
+function sanitizeSearchAnalytics(response, dateRange) {
+  const row = Array.isArray(response?.rows) ? response.rows[0] : null;
+  if (!row) {
+    return {
+      availability: "observed",
+      ...dateRange,
+      clicks: 0,
+      impressions: 0,
+      ctr: null,
+      position: null,
+      aggregation: safeText(response?.responseAggregationType, 30),
+      empty: true
+    };
+  }
+
+  return {
+    availability: "observed",
+    ...dateRange,
+    clicks: finiteNumber(row.clicks),
+    impressions: finiteNumber(row.impressions),
+    ctr: finiteNumber(row.ctr, 5),
+    position: finiteNumber(row.position),
+    aggregation: safeText(response.responseAggregationType, 30)
+  };
+}
+
+export function compareSearchAnalytics(current, prior, config) {
+  const comparison = {
+    status: "unknown",
+    minimumPriorImpressions: config.minimumPriorImpressions,
+    dropThresholdPercent: config.impressionDropThresholdPercent,
+    impressionChangePercent: null,
+    impressionDropPercent: null
+  };
+
+  if (
+    current.availability !== "observed" ||
+    prior.availability !== "observed" ||
+    current.impressions === null ||
+    prior.impressions === null
+  ) {
+    return { ...comparison, reason: "window_unavailable" };
+  }
+  if (prior.impressions < config.minimumPriorImpressions) {
+    return { ...comparison, status: "insufficient_baseline" };
+  }
+
+  const changePercent = finiteNumber(
+    ((current.impressions - prior.impressions) / prior.impressions) * 100,
+    1
+  );
+  const dropPercent = finiteNumber(Math.max(0, -changePercent), 1);
+  return {
+    ...comparison,
+    status:
+      dropPercent >= config.impressionDropThresholdPercent
+        ? "drop_detected"
+        : "within_threshold",
+    impressionChangePercent: changePercent,
+    impressionDropPercent: dropPercent
+  };
+}
+
+function sanitizeSitemap(response, sitemapUrl) {
+  const sitemap = Array.isArray(response?.sitemap)
+    ? response.sitemap.find((entry) => entry?.path === sitemapUrl)
+    : null;
+  if (!sitemap) return { availability: "unknown", reason: "not_reported" };
+
+  return {
+    availability: "observed",
+    pending: sitemap.isPending === true,
+    errors: nonNegativeInteger(sitemap.errors),
+    warnings: nonNegativeInteger(sitemap.warnings),
+    lastSubmitted: safeIsoDateTime(sitemap.lastSubmitted),
+    lastDownloaded: safeIsoDateTime(sitemap.lastDownloaded),
+    contents: Array.isArray(sitemap.contents)
+      ? sitemap.contents.map((content) => ({
+          type: safeText(content?.type, 30),
+          submitted: nonNegativeInteger(content?.submitted),
+          indexed: nonNegativeInteger(content?.indexed)
+        }))
+      : []
+  };
+}
+
+function sanitizeInspection(response, canary) {
+  const result = response?.inspectionResult?.indexStatusResult;
+  if (!result) {
+    return {
+      label: canary.label,
+      availability: "unknown",
+      reason: "no_data"
+    };
+  }
+  const googleCanonical = safeText(result.googleCanonical, 500);
+  const userCanonical = safeText(result.userCanonical, 500);
+
+  return {
+    label: canary.label,
+    availability: "observed",
+    verdict: safeText(result.verdict, 40),
+    coverageState: safeText(result.coverageState, 100),
+    indexingState: safeText(result.indexingState, 40),
+    pageFetchState: safeText(result.pageFetchState, 40),
+    robotsTxtState: safeText(result.robotsTxtState, 40),
+    lastCrawlTime: safeIsoDateTime(result.lastCrawlTime),
+    canonicalMatches:
+      googleCanonical && userCanonical
+        ? googleCanonical === userCanonical
+        : null
+  };
+}
+
+async function observedOrUnknown(task) {
+  try {
+    return await task();
+  } catch (error) {
+    return { availability: "unknown", reason: requestReason(error) };
+  }
+}
+
+function collectSearchAnalyticsWindow(
+  fetchImpl,
+  url,
+  authorization,
+  dateRange
+) {
+  return observedOrUnknown(async () => {
+    const response = await requestJson(fetchImpl, url, {
+      method: "POST",
+      headers: { ...authorization, "content-type": "application/json" },
+      body: JSON.stringify({
+        ...dateRange,
+        type: "web",
+        dataState: "final",
+        aggregationType: "byProperty",
+        rowLimit: 1
+      })
+    });
+    return sanitizeSearchAnalytics(response, dateRange);
+  });
+}
+
+export async function collectSearchConsole(
+  config,
+  { fetchImpl = fetch, now = new Date(), serviceAccountJson, accessToken } = {}
+) {
+  let token = accessToken;
+  if (!token) {
+    if (!serviceAccountJson) {
+      return { availability: "skipped", reason: "credentials_missing" };
+    }
+    try {
+      token = await exchangeServiceAccountToken(serviceAccountJson, {
+        fetchImpl,
+        now
+      });
+    } catch (error) {
+      return { availability: "unknown", reason: requestReason(error) };
+    }
+  }
+
+  const authorization = { authorization: `Bearer ${token}` };
+  const propertyPath = encodeURIComponent(config.property);
+  const currentRange = searchDateRange(
+    now,
+    config.windowDays,
+    config.finalDataLagDays
+  );
+  const priorRange = priorDateRange(currentRange, config.windowDays);
+  const analyticsUrl = `${ENDPOINTS.searchConsole}/sites/${propertyPath}/searchAnalytics/query`;
+  const [current, prior] = await Promise.all([
+    collectSearchAnalyticsWindow(
+      fetchImpl,
+      analyticsUrl,
+      authorization,
+      currentRange
+    ),
+    collectSearchAnalyticsWindow(
+      fetchImpl,
+      analyticsUrl,
+      authorization,
+      priorRange
+    )
+  ]);
+  const analytics = {
+    availability: combineAvailability([
+      current.availability,
+      prior.availability
+    ]),
+    current,
+    prior,
+    comparison: compareSearchAnalytics(current, prior, config)
+  };
+
+  const sitemap = await observedOrUnknown(async () => {
+    const response = await requestJson(
+      fetchImpl,
+      `${ENDPOINTS.searchConsole}/sites/${propertyPath}/sitemaps`,
+      { headers: authorization }
+    );
+    return sanitizeSitemap(response, config.sitemapUrl);
+  });
+
+  const inspections = [];
+  for (const canary of config.inspectionCanaries) {
+    const inspection = await observedOrUnknown(async () => {
+      const response = await requestJson(fetchImpl, ENDPOINTS.urlInspection, {
+        method: "POST",
+        headers: { ...authorization, "content-type": "application/json" },
+        body: JSON.stringify({
+          inspectionUrl: canary.url,
+          siteUrl: config.property,
+          languageCode: "en-US"
+        })
+      });
+      return sanitizeInspection(response, canary);
+    });
+    inspections.push(
+      inspection.label ? inspection : { ...inspection, label: canary.label }
+    );
+  }
+
+  const availability = combineAvailability([
+    analytics.availability,
+    sitemap.availability,
+    ...inspections.map((inspection) => inspection.availability)
+  ]);
+  return { availability, analytics, sitemap, inspections };
+}
+
+function dateObject(value) {
+  const year = nonNegativeInteger(value?.year);
+  const month = nonNegativeInteger(value?.month);
+  const day = nonNegativeInteger(value?.day);
+  if (!year || !month || !day) return null;
+  return `${String(year).padStart(4, "0")}-${String(month).padStart(2, "0")}-${String(day).padStart(2, "0")}`;
+}
+
+function metricRating(key, value) {
+  if (value === null) return "unknown";
+  const thresholds = {
+    lcp: [2500, 4000],
+    inp: [200, 500],
+    cls: [0.1, 0.25]
+  }[key];
+  if (!thresholds) return "unknown";
+  if (value <= thresholds[0]) return "good";
+  if (value <= thresholds[1]) return "needs_improvement";
+  return "poor";
+}
+
+function sanitizeCruxRecord(response, target, metricNames) {
+  const record = response?.record;
+  if (!record?.metrics) {
+    return {
+      label: target.label,
+      kind: target.kind,
+      availability: "unknown",
+      reason: "no_data"
+    };
+  }
+
+  const metrics = {};
+  for (const metricName of metricNames) {
+    const key = CRUX_METRIC_KEYS[metricName];
+    if (!key) continue;
+    const p75s = record.metrics[metricName]?.percentilesTimeseries?.p75s;
+    const value = Array.isArray(p75s)
+      ? finiteNumber(p75s.at(-1), key === "cls" ? 4 : 0)
+      : null;
+    metrics[key] = { p75: value, rating: metricRating(key, value) };
+  }
+
+  const metricStatuses = Object.values(metrics).map((metric) =>
+    metric.p75 === null ? "unknown" : "observed"
+  );
+  const latestPeriod = Array.isArray(record.collectionPeriods)
+    ? record.collectionPeriods.at(-1)
+    : null;
+
+  return {
+    label: target.label,
+    kind: target.kind,
+    availability: combineAvailability(metricStatuses),
+    period: latestPeriod
+      ? {
+          firstDate: dateObject(latestPeriod.firstDate),
+          lastDate: dateObject(latestPeriod.lastDate)
+        }
+      : null,
+    metrics
+  };
+}
+
+export async function collectCrux(config, { fetchImpl = fetch, apiKey } = {}) {
+  if (!apiKey) {
+    return { availability: "skipped", reason: "api_key_missing" };
+  }
+
+  const targets = [
+    { label: "origin", kind: "origin", value: config.origin },
+    ...config.pages.map((page) => ({
+      label: page.label,
+      kind: "url",
+      value: page.url
+    }))
+  ];
+  const results = [];
+  const endpoint = new URL(ENDPOINTS.cruxHistory);
+  endpoint.searchParams.set("key", apiKey);
+
+  for (const target of targets) {
+    const result = await observedOrUnknown(async () => {
+      const body = {
+        formFactor: config.formFactor,
+        metrics: config.metrics,
+        collectionPeriodCount: config.collectionPeriodCount,
+        [target.kind]: target.value
+      };
+      const response = await requestJson(fetchImpl, endpoint, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify(body)
+      });
+      return sanitizeCruxRecord(response, target, config.metrics);
+    });
+    const normalized =
+      result.reason === "http_404" ? { ...result, reason: "no_data" } : result;
+    results.push(
+      normalized.label
+        ? normalized
+        : { ...normalized, label: target.label, kind: target.kind }
+    );
+  }
+
+  return {
+    availability: combineAvailability(
+      results.map((result) => result.availability)
+    ),
+    formFactor: config.formFactor,
+    targets: results
+  };
+}
+
+function healthCode(...parts) {
+  return parts
+    .filter(Boolean)
+    .map((part) =>
+      String(part)
+        .toLowerCase()
+        .replace(/[^a-z0-9]+/g, "_")
+        .replace(/^_+|_+$/g, "")
+    )
+    .filter(Boolean)
+    .join("_")
+    .slice(0, 120);
+}
+
+function unique(values) {
+  return [...new Set(values)];
+}
+
+export function evaluateSeoHealth(searchConsole, crux) {
+  const issues = [];
+  const unknowns = [];
+  const attention = [];
+
+  if (!searchConsole.analytics) {
+    issues.push(
+      healthCode("search_console", searchConsole.reason ?? "unavailable")
+    );
+  } else {
+    for (const windowName of ["current", "prior"]) {
+      const window = searchConsole.analytics[windowName];
+      if (window?.availability !== "observed") {
+        issues.push(
+          healthCode(
+            "search_analytics",
+            windowName,
+            window?.reason ?? "unavailable"
+          )
+        );
+      }
+    }
+
+    const comparison = searchConsole.analytics.comparison;
+    if (comparison?.status === "drop_detected") {
+      issues.push("search_analytics_impressions_drop");
+    } else if (comparison?.status === "insufficient_baseline") {
+      unknowns.push("search_analytics_insufficient_baseline");
+    } else if (comparison?.status !== "within_threshold") {
+      unknowns.push("search_analytics_comparison_unknown");
+    }
+  }
+
+  const sitemap = searchConsole.sitemap;
+  if (!sitemap || sitemap.availability !== "observed") {
+    issues.push(
+      healthCode(
+        "sitemap",
+        sitemap?.reason ?? searchConsole.reason ?? "unavailable"
+      )
+    );
+  } else {
+    if (sitemap.errors === null) unknowns.push("sitemap_errors_unknown");
+    else if (sitemap.errors > 0) issues.push("sitemap_errors_present");
+    if (sitemap.warnings === null) unknowns.push("sitemap_warnings_unknown");
+    else if (sitemap.warnings > 0) issues.push("sitemap_warnings_present");
+    if (sitemap.pending) attention.push("sitemap_pending");
+  }
+
+  if (!Array.isArray(searchConsole.inspections)) {
+    issues.push(
+      healthCode("url_inspection", searchConsole.reason ?? "unavailable")
+    );
+  } else {
+    for (const inspection of searchConsole.inspections) {
+      const prefix = healthCode("url_inspection", inspection.label);
+      if (inspection.availability !== "observed") {
+        issues.push(healthCode(prefix, inspection.reason ?? "unavailable"));
+        continue;
+      }
+      if (inspection.verdict !== "PASS") {
+        issues.push(healthCode(prefix, "index_verdict"));
+      }
+      if (inspection.pageFetchState !== "SUCCESSFUL") {
+        issues.push(healthCode(prefix, "fetch"));
+      }
+      if (inspection.indexingState !== "INDEXING_ALLOWED") {
+        issues.push(healthCode(prefix, "indexing"));
+      }
+      if (inspection.robotsTxtState !== "ALLOWED") {
+        issues.push(healthCode(prefix, "robots"));
+      }
+      if (inspection.canonicalMatches !== true) {
+        issues.push(healthCode(prefix, "canonical_mismatch"));
+      }
+    }
+  }
+
+  if (!Array.isArray(crux.targets)) {
+    issues.push(healthCode("crux", crux.reason ?? "unavailable"));
+  } else {
+    for (const target of crux.targets) {
+      const prefix = healthCode(
+        "crux",
+        target.kind,
+        target.label === target.kind ? null : target.label
+      );
+      if (target.availability === "unknown" && target.reason === "no_data") {
+        unknowns.push(healthCode(prefix, "no_data"));
+        continue;
+      }
+      if (target.availability === "unknown") {
+        issues.push(healthCode(prefix, target.reason ?? "unavailable"));
+        continue;
+      }
+      for (const [metric, result] of Object.entries(target.metrics ?? {})) {
+        if (result.rating === "poor") {
+          issues.push(healthCode(prefix, metric, "poor"));
+        } else if (result.rating === "needs_improvement") {
+          attention.push(healthCode(prefix, metric, "needs_improvement"));
+        } else if (result.rating !== "good") {
+          unknowns.push(healthCode(prefix, metric, "unknown"));
+        }
+      }
+    }
+  }
+
+  const sanitizedIssues = unique(issues);
+  const sanitizedUnknowns = unique(unknowns);
+  const sanitizedAttention = unique(attention);
+  const status = sanitizedIssues.length
+    ? "action_required"
+    : sanitizedAttention.length
+      ? "needs_attention"
+      : sanitizedUnknowns.length
+        ? "unknown"
+        : "healthy";
+
+  return {
+    status,
+    actionRequired: sanitizedIssues.length > 0,
+    issues: sanitizedIssues,
+    attention: sanitizedAttention,
+    unknowns: sanitizedUnknowns
+  };
+}
+
+function validateConfig(config) {
+  if (config?.schemaVersion !== 1) throw new MonitorError("config_invalid");
+  const search = config.searchConsole;
+  const crux = config.crux;
+  if (
+    !search ||
+    !crux ||
+    typeof search.property !== "string" ||
+    typeof search.sitemapUrl !== "string" ||
+    !Array.isArray(search.inspectionCanaries) ||
+    search.inspectionCanaries.some(
+      (canary) =>
+        typeof canary?.label !== "string" || typeof canary?.url !== "string"
+    ) ||
+    !Number.isInteger(search.windowDays) ||
+    search.windowDays < 1 ||
+    !Number.isInteger(search.finalDataLagDays) ||
+    search.finalDataLagDays < 0 ||
+    !Number.isInteger(search.minimumPriorImpressions) ||
+    search.minimumPriorImpressions < 1 ||
+    !Number.isFinite(search.impressionDropThresholdPercent) ||
+    search.impressionDropThresholdPercent <= 0 ||
+    search.impressionDropThresholdPercent > 100 ||
+    typeof crux.origin !== "string" ||
+    !Array.isArray(crux.pages) ||
+    crux.pages.some(
+      (page) => typeof page?.label !== "string" || typeof page?.url !== "string"
+    ) ||
+    !Array.isArray(crux.metrics) ||
+    !["PHONE", "DESKTOP", "TABLET"].includes(crux.formFactor) ||
+    !Number.isInteger(crux.collectionPeriodCount) ||
+    crux.collectionPeriodCount < 1 ||
+    crux.collectionPeriodCount > 40
+  ) {
+    throw new MonitorError("config_invalid");
+  }
+
+  const publicUrls = [
+    search.sitemapUrl,
+    ...search.inspectionCanaries.map((canary) => canary.url),
+    ...crux.pages.map((page) => page.url)
+  ];
+  let origin;
+  try {
+    origin = new URL(crux.origin).origin;
+    if (
+      new URL(search.property).origin !== origin ||
+      publicUrls.some((value) => new URL(value).origin !== origin)
+    ) {
+      throw new MonitorError("config_invalid");
+    }
+  } catch {
+    throw new MonitorError("config_invalid");
+  }
+  if (
+    !search.property.startsWith("https://") ||
+    search.inspectionCanaries.length < 1 ||
+    search.inspectionCanaries.length > 10 ||
+    crux.pages.length < 1 ||
+    crux.pages.length > 10 ||
+    crux.metrics.length < 1 ||
+    crux.metrics.some((metric) => !Object.hasOwn(CRUX_METRIC_KEYS, metric))
+  ) {
+    throw new MonitorError("config_invalid");
+  }
+  return config;
+}
+
+export async function collectSeoFieldData(
+  config,
+  { fetchImpl = fetch, now = new Date(), env = process.env } = {}
+) {
+  const validConfig = validateConfig(config);
+  const [searchConsole, crux] = await Promise.all([
+    collectSearchConsole(validConfig.searchConsole, {
+      fetchImpl,
+      now,
+      serviceAccountJson: env.GOOGLE_SEARCH_CONSOLE_SERVICE_ACCOUNT_JSON
+    }),
+    collectCrux(validConfig.crux, {
+      fetchImpl,
+      apiKey: env.CRUX_API_KEY
+    })
+  ]);
+
+  const sourceAvailability = combineAvailability([
+    searchConsole.availability,
+    crux.availability
+  ]);
+  const availability =
+    sourceAvailability === "skipped" ? "unknown" : sourceAvailability;
+  const health = evaluateSeoHealth(searchConsole, crux);
+  return {
+    schemaVersion: 1,
+    generatedAt: now.toISOString(),
+    availability,
+    health,
+    note: "Availability reports whether field data was observed; health reports whether action is required.",
+    searchConsole,
+    crux
+  };
+}
+
+function markdownCell(value) {
+  if (value === null || value === undefined || value === "") return "unknown";
+  return String(value)
+    .replace(/[|\r\n]/g, " ")
+    .slice(0, 120);
+}
+
+function metricCell(metric) {
+  if (!metric || metric.p75 === null) return "unknown";
+  return `${metric.p75} (${metric.rating})`;
+}
+
+export function renderMarkdown(report) {
+  const lines = [
+    "# SEO field-data monitor",
+    "",
+    `Availability: **${markdownCell(report.availability)}**`,
+    "",
+    `SEO health: **${markdownCell(report.health.status)}**`,
+    "",
+    `Action required: **${report.health.actionRequired ? "yes" : "no"}**`,
+    "",
+    "> Availability and health are separate. Unknown data is never reported as healthy."
+  ];
+
+  if (report.health.issues.length) {
+    lines.push("", "## Action required", "");
+    for (const issue of report.health.issues) {
+      lines.push(`- ${markdownCell(issue)}`);
+    }
+  }
+  if (report.health.attention.length) {
+    lines.push("", "## Needs attention", "");
+    for (const item of report.health.attention) {
+      lines.push(`- ${markdownCell(item)}`);
+    }
+  }
+  if (report.health.unknowns.length) {
+    lines.push("", "## Unknown observations", "");
+    for (const item of report.health.unknowns) {
+      lines.push(`- ${markdownCell(item)}`);
+    }
+  }
+
+  lines.push(
+    "",
+    "## Search Console",
+    "",
+    `Availability: **${markdownCell(report.searchConsole.availability)}**`
+  );
+
+  const analytics = report.searchConsole.analytics;
+  if (analytics) {
+    lines.push(
+      "",
+      "| Window | Clicks | Impressions | CTR | Position |",
+      "| --- | ---: | ---: | ---: | ---: |",
+      `| Current: ${markdownCell(analytics.current.startDate)} to ${markdownCell(analytics.current.endDate)} | ${markdownCell(analytics.current.clicks)} | ${markdownCell(analytics.current.impressions)} | ${markdownCell(analytics.current.ctr)} | ${markdownCell(analytics.current.position)} |`,
+      `| Prior: ${markdownCell(analytics.prior.startDate)} to ${markdownCell(analytics.prior.endDate)} | ${markdownCell(analytics.prior.clicks)} | ${markdownCell(analytics.prior.impressions)} | ${markdownCell(analytics.prior.ctr)} | ${markdownCell(analytics.prior.position)} |`,
+      "",
+      `Impression trend: **${markdownCell(analytics.comparison.status)}**; change=${markdownCell(analytics.comparison.impressionChangePercent)}%; alert at drop >=${markdownCell(analytics.comparison.dropThresholdPercent)}% when prior impressions >=${markdownCell(analytics.comparison.minimumPriorImpressions)}`
+    );
+  } else if (report.searchConsole.reason) {
+    lines.push("", `Reason: ${markdownCell(report.searchConsole.reason)}`);
+  }
+
+  if (report.searchConsole.sitemap) {
+    const sitemap = report.searchConsole.sitemap;
+    lines.push(
+      "",
+      `Sitemap availability: **${markdownCell(sitemap.availability)}**; errors=${markdownCell(sitemap.errors)}, warnings=${markdownCell(sitemap.warnings)}, pending=${markdownCell(sitemap.pending)}`
+    );
+  }
+
+  if (Array.isArray(report.searchConsole.inspections)) {
+    lines.push(
+      "",
+      "| Canary | Availability | Verdict | Fetch | Canonical match |",
+      "| --- | --- | --- | --- | --- |"
+    );
+    for (const item of report.searchConsole.inspections) {
+      lines.push(
+        `| ${markdownCell(item.label)} | ${markdownCell(item.availability)} | ${markdownCell(item.verdict ?? item.reason)} | ${markdownCell(item.pageFetchState)} | ${markdownCell(item.canonicalMatches)} |`
+      );
+    }
+  }
+
+  lines.push(
+    "",
+    "## CrUX History",
+    "",
+    `Availability: **${markdownCell(report.crux.availability)}**`
+  );
+  if (report.crux.reason) {
+    lines.push("", `Reason: ${markdownCell(report.crux.reason)}`);
+  }
+  if (Array.isArray(report.crux.targets)) {
+    lines.push(
+      "",
+      "| Target | Availability | LCP p75 | INP p75 | CLS p75 | Period end |",
+      "| --- | --- | ---: | ---: | ---: | --- |"
+    );
+    for (const target of report.crux.targets) {
+      lines.push(
+        `| ${markdownCell(target.label)} | ${markdownCell(target.availability)} | ${metricCell(target.metrics?.lcp)} | ${metricCell(target.metrics?.inp)} | ${metricCell(target.metrics?.cls)} | ${markdownCell(target.period?.lastDate)} |`
+      );
+    }
+  }
+
+  return `${lines.join("\n")}\n`;
+}
+
+async function emitReport(report, env) {
+  process.stdout.write(`${JSON.stringify(report, null, 2)}\n`);
+  if (env.GITHUB_STEP_SUMMARY) {
+    await appendFile(env.GITHUB_STEP_SUMMARY, renderMarkdown(report), "utf8");
+  }
+}
+
+async function main() {
+  const now = new Date();
+  try {
+    const config = JSON.parse(await readFile(CONFIG_PATH, "utf8"));
+    const report = await collectSeoFieldData(config, { now });
+    await emitReport(report, process.env);
+    process.exitCode = report.health.actionRequired ? 1 : 0;
+  } catch (error) {
+    const reason =
+      error instanceof MonitorError
+        ? error.reason
+        : error instanceof SyntaxError
+          ? "config_invalid"
+          : "monitor_internal_error";
+    await emitReport(
+      {
+        schemaVersion: 1,
+        generatedAt: now.toISOString(),
+        availability: "unknown",
+        health: {
+          status: "action_required",
+          actionRequired: true,
+          issues: [reason],
+          attention: [],
+          unknowns: []
+        },
+        note: "Monitoring could not produce a sanitized report.",
+        searchConsole: {
+          availability: "unknown",
+          reason
+        },
+        crux: {
+          availability: "unknown",
+          reason
+        }
+      },
+      process.env
+    );
+    process.exitCode = 1;
+  }
+}
+
+if (
+  process.argv[1] &&
+  path.resolve(process.argv[1]) === fileURLToPath(import.meta.url)
+) {
+  await main();
+}

--- a/scripts/postbuild-offline.mjs
+++ b/scripts/postbuild-offline.mjs
@@ -12,6 +12,7 @@ const DEFAULT_LOCALE = 'en'
 const PAGE_VERSION_PARAM = '__offlineVersion'
 const OFFLINE_MANIFEST_VERSION_META = 'offline-manifest-version'
 const CDN_BACKED_EXPORT_PATHS = ['og', 'assets/blog', 'assets/notes', 'assets/photos']
+const BUILD_ONLY_EXPORT_PATHS = ['og-cache']
 const DEFAULT_HTML_FILE_CONCURRENCY = 16
 
 async function walk(dir) {
@@ -32,6 +33,14 @@ async function removeCdnBackedExportAssets() {
   await Promise.all(
     CDN_BACKED_EXPORT_PATHS.map((relativePath) =>
       fs.rm(path.join(OUT_DIR, relativePath), { recursive: true, force: true }),
+    ),
+  )
+}
+
+export async function pruneBuildOnlyExportAssets(outDir = OUT_DIR) {
+  await Promise.all(
+    BUILD_ONLY_EXPORT_PATHS.map((relativePath) =>
+      fs.rm(path.join(outDir, relativePath), { recursive: true, force: true }),
     ),
   )
 }
@@ -98,7 +107,7 @@ function isReadingAsset(relativePath) {
 }
 
 function isExtendedAsset(relativePath) {
-  return relativePath.startsWith('assets/photos/') || relativePath === 'assets/full-bg.svg'
+  return relativePath.startsWith('assets/photos/')
 }
 
 function isCoreSharedFile(relativePath) {
@@ -808,7 +817,10 @@ async function main() {
     return
   }
 
-  await removeCdnBackedExportAssets()
+  await Promise.all([
+    removeCdnBackedExportAssets(),
+    pruneBuildOnlyExportAssets(),
+  ])
   const files = await walk(OUT_DIR)
   const relativeFiles = files.map((file) => path.relative(OUT_DIR, file))
   const [appVersion, remoteAssets, pageVersions] = await Promise.all([

--- a/scripts/verify-dev-concurrency.mjs
+++ b/scripts/verify-dev-concurrency.mjs
@@ -1,0 +1,184 @@
+#!/usr/bin/env node
+
+import assert from "node:assert/strict";
+import { spawn } from "node:child_process";
+import { once } from "node:events";
+import { promises as fs } from "node:fs";
+import { createServer } from "node:net";
+import path from "node:path";
+import { setTimeout as delay } from "node:timers/promises";
+
+const ROOT = process.cwd();
+const HOST = "127.0.0.1";
+const READY_TIMEOUT_MS = 60_000;
+const REQUEST_TIMEOUT_MS = 120_000;
+const NEXT_DIR = path.join(ROOT, ".next");
+const DEV_CACHE = path.join(NEXT_DIR, "dev");
+const DEV_CACHE_BACKUP = path.join(NEXT_DIR, `.dev-backup-${process.pid}`);
+const MANIFEST_PATH = path.join(DEV_CACHE, "prerender-manifest.json");
+const NEXT_BIN = path.join(
+  ROOT,
+  "node_modules",
+  "next",
+  "dist",
+  "bin",
+  "next"
+);
+const CASES = [
+  ["/en", 200],
+  ["/en/about", 200],
+  ["/en/apps", 200],
+  ["/en/apps/english", 200],
+  ["/en/blog", 200],
+  ["/en/blog/architecture", 200],
+  ["/en/blog/architecture/ports-and-adapters", 200],
+  ["/en/blog/page/2", 200],
+  ["/en/gallery", 200],
+  ["/en/heartbeats", 200],
+  ["/en/notes", 200],
+  ["/en/notes/tri-tue-can-duc-hanh", 200],
+  ["/en/notes/page/2", 200],
+  ["/en/offline", 200],
+  ["/en/search/blog.json", 200],
+  ["/en/search/notes.json", 200],
+  ["/vi/studio", 200],
+  ["/zh/notes", 200],
+  ["/__dev-concurrency-missing__", 404]
+];
+
+async function reservePort() {
+  const server = createServer();
+  server.unref();
+  await new Promise((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(0, HOST, resolve);
+  });
+  const address = server.address();
+  assert.ok(address && typeof address === "object");
+  const { port } = address;
+  await new Promise((resolve, reject) =>
+    server.close((error) => (error ? reject(error) : resolve()))
+  );
+  return port;
+}
+
+function stripAnsi(value) {
+  return value.replace(/\u001b\[[0-9;]*m/g, "");
+}
+
+async function waitUntilReady(child, readLogs, readSpawnError) {
+  const deadline = Date.now() + READY_TIMEOUT_MS;
+  while (Date.now() < deadline) {
+    if (/Ready in/.test(readLogs())) return;
+    if (readSpawnError()) throw readSpawnError();
+    if (child.exitCode !== null) {
+      throw new Error(`development server exited with ${child.exitCode}`);
+    }
+    await delay(100);
+  }
+  throw new Error("development server readiness timeout");
+}
+
+async function stopChild(child) {
+  if (!child?.pid || child.exitCode !== null || child.signalCode !== null) return;
+  child.kill("SIGTERM");
+  await Promise.race([once(child, "exit"), delay(5_000)]);
+  if (child.exitCode === null) {
+    child.kill("SIGKILL");
+    await once(child, "exit");
+  }
+}
+
+async function readValidManifest() {
+  let lastError;
+  for (let attempt = 0; attempt < 50; attempt += 1) {
+    try {
+      const raw = await fs.readFile(MANIFEST_PATH, "utf8");
+      JSON.parse(raw);
+      return;
+    } catch (error) {
+      lastError = error;
+      await delay(100);
+    }
+  }
+  throw lastError;
+}
+
+async function main() {
+  await fs.mkdir(NEXT_DIR, { recursive: true });
+  await fs.rm(DEV_CACHE_BACKUP, { recursive: true, force: true });
+  let restorePreviousCache = false;
+  try {
+    await fs.rename(DEV_CACHE, DEV_CACHE_BACKUP);
+    restorePreviousCache = true;
+  } catch (error) {
+    if (error?.code !== "ENOENT") throw error;
+  }
+
+  let logs = "";
+  let child;
+  let spawnError;
+  const capture = (chunk) => {
+    logs = `${logs}${chunk}`.slice(-16_000);
+  };
+
+  try {
+    const port = await reservePort();
+    child = spawn(process.execPath, [NEXT_BIN, "dev", "-p", String(port)], {
+      cwd: ROOT,
+      env: {
+        ...process.env
+      },
+      stdio: ["ignore", "pipe", "pipe"]
+    });
+    child.once("error", (error) => {
+      spawnError = error;
+    });
+    child.stdout.on("data", capture);
+    child.stderr.on("data", capture);
+
+    await waitUntilReady(
+      child,
+      () => stripAnsi(logs),
+      () => spawnError
+    );
+    const results = await Promise.all(
+      CASES.map(async ([route, expectedStatus]) => {
+        const response = await fetch(`http://${HOST}:${port}${route}`, {
+          signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS)
+        });
+        await response.arrayBuffer();
+        return { route, expectedStatus, status: response.status };
+      })
+    );
+
+    for (const result of results) {
+      assert.equal(
+        result.status,
+        result.expectedStatus,
+        `${result.route} returned ${result.status}`
+      );
+    }
+    await readValidManifest();
+    process.stdout.write(
+      `[verify-dev-concurrency] ${results.length} concurrent first hits passed; prerender manifest is valid\n`
+    );
+  } catch (error) {
+    const diagnostic = stripAnsi(logs).trim();
+    if (diagnostic) process.stderr.write(`${diagnostic}\n`);
+    throw error;
+  } finally {
+    await stopChild(child);
+    await fs.rm(DEV_CACHE, { recursive: true, force: true });
+    if (restorePreviousCache) {
+      await fs.rename(DEV_CACHE_BACKUP, DEV_CACHE);
+    }
+  }
+}
+
+main().catch((error) => {
+  process.stderr.write(
+    `[verify-dev-concurrency] failed: ${error instanceof Error ? error.message : String(error)}\n`
+  );
+  process.exitCode = 1;
+});

--- a/scripts/verify-static-not-found.mjs
+++ b/scripts/verify-static-not-found.mjs
@@ -1,0 +1,346 @@
+#!/usr/bin/env node
+import assert from "node:assert/strict";
+import { promises as fs } from "node:fs";
+import { createServer } from "node:http";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { resolveFile } from "./verify-offline.mjs";
+
+const ROOT = process.cwd();
+const OUT_DIR = path.join(ROOT, "out");
+const HOST = "127.0.0.1";
+const REQUESTED_PORT = Number(process.env.NOT_FOUND_VERIFY_PORT ?? "0");
+const SENSITIVE_PATH_SENTINEL = "nf-private-token-7d8c3a";
+const SENSITIVE_EMAIL_SENTINEL = "nf-private-owner@example.test";
+
+const CONTENT_TYPES = {
+  ".css": "text/css; charset=utf-8",
+  ".gif": "image/gif",
+  ".html": "text/html; charset=utf-8",
+  ".ico": "image/x-icon",
+  ".js": "text/javascript; charset=utf-8",
+  ".json": "application/json; charset=utf-8",
+  ".mjs": "text/javascript; charset=utf-8",
+  ".png": "image/png",
+  ".svg": "image/svg+xml",
+  ".txt": "text/plain; charset=utf-8",
+  ".webmanifest": "application/manifest+json; charset=utf-8",
+  ".webp": "image/webp",
+  ".woff": "font/woff",
+  ".woff2": "font/woff2",
+  ".xml": "application/xml; charset=utf-8"
+};
+
+function contentTypeFor(filePath) {
+  return CONTENT_TYPES[path.extname(filePath)] ?? "application/octet-stream";
+}
+
+async function startStaticServer() {
+  const notFoundBody = await fs.readFile(path.join(OUT_DIR, "404.html"));
+  const server = createServer(async (request, response) => {
+    const method = request.method ?? "GET";
+    if (method !== "GET" && method !== "HEAD") {
+      response.writeHead(405);
+      response.end();
+      return;
+    }
+
+    const filePath = await resolveFile(request.url ?? "/", OUT_DIR);
+    const status = filePath ? 200 : 404;
+    const body = filePath ? await fs.readFile(filePath) : notFoundBody;
+    const contentType = filePath
+      ? contentTypeFor(filePath)
+      : "text/html; charset=utf-8";
+
+    response.writeHead(status, {
+      "Cache-Control": "no-store",
+      "Content-Length": String(body.byteLength),
+      "Content-Type": contentType
+    });
+    response.end(method === "HEAD" ? undefined : body);
+  });
+
+  await new Promise((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(REQUESTED_PORT, HOST, resolve);
+  });
+
+  const address = server.address();
+  assert.ok(address && typeof address === "object");
+  return { server, origin: `http://${HOST}:${address.port}` };
+}
+
+async function assertRawArtifact() {
+  const entries = await fs.readdir(OUT_DIR, { recursive: true });
+  const notFoundArtifacts = entries.filter(
+    (entry) => entry === "404.html" || entry.endsWith(`${path.sep}404.html`)
+  );
+  assert.deepEqual(
+    notFoundArtifacts,
+    ["404.html"],
+    "static export should contain exactly one shared 404.html"
+  );
+
+  const [html, localeHtml] = await Promise.all([
+    fs.readFile(path.join(OUT_DIR, "404.html"), "utf8"),
+    fs.readFile(path.join(OUT_DIR, "en.html"), "utf8")
+  ]);
+  assert.equal((html.match(/<h1\b/g) ?? []).length, 1);
+  assert.match(html, /This page is no longer here/);
+  assert.match(html, /data-not-found-locale="en"/);
+  assert.match(html, /href="\/en"/);
+  assert.match(html, /href="\/en\/blog"/);
+  assert.match(html, /href="\/en\/notes"/);
+  for (const locale of ["en", "vi", "zh", "ja", "ko", "fr"]) {
+    assert.match(html, new RegExp(`href="/${locale}"`));
+  }
+  assert.match(html, /<meta[^>]+name="robots"[^>]+content="[^"]*noindex/i);
+  assert.doesNotMatch(html, /<link[^>]+rel="canonical"/i);
+  assert.doesNotMatch(html, /<link[^>]+hreflang=/i);
+  assert.match(html, /capture_pageview: false/);
+  assert.match(html, /capture_pageleave: false/);
+  assert.match(localeHtml, /capture_pageview: true/);
+  assert.match(localeHtml, /capture_pageleave: true/);
+}
+
+async function verifyHydratedCase(page, origin, testCase) {
+  const errors = [];
+  const onPageError = (error) => errors.push(String(error));
+  const onConsole = (message) => {
+    if (message.type() === "error") errors.push(message.text());
+  };
+  page.on("pageerror", onPageError);
+  page.on("console", onConsole);
+
+  const response = await page.goto(`${origin}${testCase.path}`, {
+    waitUntil: "domcontentloaded"
+  });
+  assert.equal(response?.status(), 404);
+  await page.locator('[data-not-found-ready="true"]').waitFor();
+  await page.waitForFunction(() =>
+    window.__notFoundEvents?.some((entry) => entry.event === "not_found_view")
+  );
+  await page.waitForFunction(() => window.__posthogAudit?.inits.length > 0);
+
+  assert.equal(
+    await page.locator("main").getAttribute("data-not-found-locale"),
+    testCase.locale
+  );
+  assert.equal(
+    await page.locator("main").getAttribute("data-not-found-surface"),
+    testCase.surface
+  );
+  assert.equal(
+    await page.locator("html").getAttribute("lang"),
+    testCase.locale
+  );
+  assert.equal(await page.locator("h1").count(), 1);
+  assert.equal(await page.locator("h1").innerText(), testCase.heading);
+  assert.equal(
+    await page.locator("[data-not-found-target]").first().getAttribute("href"),
+    testCase.primaryHref
+  );
+  assert.ok(
+    (await page.locator("nav").getAttribute("aria-label"))?.trim().length > 0
+  );
+  assert.equal(await page.locator('link[rel="canonical"]').count(), 0);
+  const robots = await page.locator('meta[name="robots"]').allTextContents();
+  const robotContents = await page
+    .locator('meta[name="robots"]')
+    .evaluateAll((nodes) => nodes.map((node) => node.getAttribute("content")));
+  assert.ok(robotContents.some((content) => content?.includes("noindex")));
+  assert.equal(robots.length, robotContents.length);
+
+  const viewEvent = await page.evaluate(() =>
+    window.__notFoundEvents.find((entry) => entry.event === "not_found_view")
+  );
+  assert.equal(viewEvent.props.page_type, "not_found");
+  assert.equal(viewEvent.props.detected_locale, testCase.locale);
+  assert.equal(viewEvent.props.requested_surface, testCase.surface);
+  assert.equal("path" in viewEvent.props, false);
+  assert.equal("pathname" in viewEvent.props, false);
+  assert.equal("referrer" in viewEvent.props, false);
+
+  await page
+    .locator("[data-not-found-target]")
+    .first()
+    .evaluate((element) => {
+      element.addEventListener("click", (event) => event.preventDefault(), {
+        once: true
+      });
+    });
+  await page.locator("[data-not-found-target]").first().click();
+  await page.waitForFunction(() =>
+    window.__notFoundEvents?.some(
+      (entry) => entry.event === "not_found_recovery_click"
+    )
+  );
+  const clickEvent = await page.evaluate(() =>
+    window.__notFoundEvents.find(
+      (entry) => entry.event === "not_found_recovery_click"
+    )
+  );
+  assert.equal(
+    clickEvent.props.target,
+    testCase.surface === "other" ? "home" : testCase.surface
+  );
+  assert.equal(clickEvent.props.detected_locale, testCase.locale);
+  assert.equal("path" in clickEvent.props, false);
+  assert.equal("pathname" in clickEvent.props, false);
+  assert.equal("referrer" in clickEvent.props, false);
+
+  const posthogAudit = await page.evaluate(() => window.__posthogAudit);
+  assert.ok(posthogAudit.inits.length > 0);
+  for (const init of posthogAudit.inits) {
+    assert.equal(init.options.capture_pageview, false);
+    assert.equal(init.options.capture_pageleave, false);
+  }
+  assert.equal(
+    posthogAudit.events.some(
+      (entry) => entry.event === "$pageview" || entry.event === "$pageleave"
+    ),
+    false
+  );
+  for (const event of posthogAudit.events) {
+    assert.equal("path" in event.props, false);
+    assert.equal("pathname" in event.props, false);
+    assert.equal("referrer" in event.props, false);
+  }
+  const serializedAudit = JSON.stringify(posthogAudit);
+  for (const sensitiveValue of testCase.sensitiveValues ?? []) {
+    assert.ok(page.url().includes(sensitiveValue.urlFragment));
+    assert.equal(serializedAudit.includes(sensitiveValue.secret), false);
+  }
+
+  const hydrationErrors = errors.filter((message) =>
+    /hydration|hydrated|uncaught|not valid|failed to execute/i.test(message)
+  );
+  assert.deepEqual(hydrationErrors, []);
+  page.off("pageerror", onPageError);
+  page.off("console", onConsole);
+}
+
+async function verifyBrowserBehavior(origin) {
+  const { chromium } = await import("playwright");
+  const browser = await chromium.launch({ headless: true });
+  const context = await browser.newContext();
+  await context.addInitScript(() => {
+    window.__posthogAudit = {
+      inits: [],
+      events: [],
+      registrations: []
+    };
+    window.__notFoundEvents = window.__posthogAudit.events;
+    window.posthog = {
+      __SV: 1,
+      init(projectKey, options) {
+        window.__posthogAudit.inits.push({ projectKey, options });
+      },
+      capture(event, props = {}) {
+        window.__posthogAudit.events.push({ event, props });
+      },
+      register(props) {
+        window.__posthogAudit.registrations.push(props);
+      }
+    };
+  });
+  const page = await context.newPage();
+
+  try {
+    for (const testCase of [
+      {
+        path: `/zh/blog/${SENSITIVE_PATH_SENTINEL}?email=${encodeURIComponent(SENSITIVE_EMAIL_SENTINEL)}&token=${SENSITIVE_PATH_SENTINEL}`,
+        locale: "zh",
+        surface: "blog",
+        heading: "这个页面目前不在这里",
+        primaryHref: "/zh/blog",
+        sensitiveValues: [
+          {
+            secret: SENSITIVE_PATH_SENTINEL,
+            urlFragment: SENSITIVE_PATH_SENTINEL
+          },
+          {
+            secret: SENSITIVE_EMAIL_SENTINEL,
+            urlFragment: encodeURIComponent(SENSITIVE_EMAIL_SENTINEL)
+          }
+        ]
+      },
+      {
+        path: "/fr/notes/ancienne-note",
+        locale: "fr",
+        surface: "notes",
+        heading: "Cette page n’est plus disponible ici",
+        primaryHref: "/fr/notes"
+      },
+      {
+        path: "/missing-without-locale",
+        locale: "en",
+        surface: "other",
+        heading: "This page is no longer here",
+        primaryHref: "/en"
+      }
+    ]) {
+      await verifyHydratedCase(page, origin, testCase);
+      await page.evaluate(() => {
+        window.__notFoundEvents.length = 0;
+      });
+    }
+
+    const noScriptContext = await browser.newContext({
+      javaScriptEnabled: false
+    });
+    const noScriptPage = await noScriptContext.newPage();
+    try {
+      const response = await noScriptPage.goto(`${origin}/ja/old-link`, {
+        waitUntil: "domcontentloaded"
+      });
+      assert.equal(response?.status(), 404);
+      assert.equal(await noScriptPage.locator("h1").count(), 1);
+      assert.equal(
+        await noScriptPage.locator("h1").innerText(),
+        "This page is no longer here"
+      );
+      assert.equal(
+        await noScriptPage.locator("html").getAttribute("lang"),
+        "en"
+      );
+      for (const href of [
+        "/en",
+        "/en/blog",
+        "/en/notes",
+        "/vi",
+        "/zh",
+        "/ja",
+        "/ko",
+        "/fr"
+      ]) {
+        assert.ok(await noScriptPage.locator(`a[href="${href}"]`).count());
+      }
+    } finally {
+      await noScriptContext.close();
+    }
+  } finally {
+    await context.close();
+    await browser.close();
+  }
+}
+
+async function main() {
+  await assertRawArtifact();
+  const { server, origin } = await startStaticServer();
+  try {
+    await verifyBrowserBehavior(origin);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve(undefined)));
+    });
+  }
+  console.log("Static not-found verification passed.");
+}
+
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+  main().catch((error) => {
+    console.error(error);
+    process.exitCode = 1;
+  });
+}

--- a/scripts/verify-static-not-found.mjs
+++ b/scripts/verify-static-not-found.mjs
@@ -99,8 +99,10 @@ async function assertRawArtifact() {
   assert.doesNotMatch(html, /<link[^>]+hreflang=/i);
   assert.match(html, /capture_pageview: false/);
   assert.match(html, /capture_pageleave: false/);
+  assert.match(html, /before_send:/);
   assert.match(localeHtml, /capture_pageview: true/);
   assert.match(localeHtml, /capture_pageleave: true/);
+  assert.doesNotMatch(localeHtml, /before_send:/);
 }
 
 async function verifyHydratedCase(page, origin, testCase) {
@@ -205,6 +207,17 @@ async function verifyHydratedCase(page, origin, testCase) {
     assert.equal("path" in event.props, false);
     assert.equal("pathname" in event.props, false);
     assert.equal("referrer" in event.props, false);
+    const serializedProperties = JSON.stringify(event.props);
+    for (const sdkLocationKey of [
+      "$current_url",
+      "$pathname",
+      "$session_entry_url",
+      "$session_entry_pathname",
+      "$initial_current_url",
+      "$referrer"
+    ]) {
+      assert.equal(serializedProperties.includes(sdkLocationKey), false);
+    }
   }
   const serializedAudit = JSON.stringify(posthogAudit);
   for (const sensitiveValue of testCase.sensitiveValues ?? []) {
@@ -228,16 +241,59 @@ async function verifyBrowserBehavior(origin) {
     window.__posthogAudit = {
       inits: [],
       events: [],
-      registrations: []
+      registrations: [],
+      pending: []
     };
     window.__notFoundEvents = window.__posthogAudit.events;
+
+    const emit = (event, props = {}) => {
+      const options = window.__posthogAudit.inits.at(-1)?.options;
+      if (!options) {
+        window.__posthogAudit.pending.push({ event, props });
+        return;
+      }
+
+      let captureResult = {
+        event,
+        properties: {
+          ...props,
+          $current_url: window.location.href,
+          $pathname: window.location.pathname,
+          $session_entry_url: window.location.href,
+          $session_entry_pathname: window.location.pathname,
+          $referrer: document.referrer,
+          $initial_current_url: window.location.href,
+          $set: {
+            $initial_current_url: window.location.href,
+            $initial_referrer: document.referrer
+          },
+          $set_once: {
+            $session_entry_url: window.location.href,
+            $session_entry_pathname: window.location.pathname
+          }
+        }
+      };
+      if (typeof options.before_send === "function") {
+        captureResult = options.before_send(captureResult);
+      }
+      if (captureResult) {
+        window.__posthogAudit.events.push({
+          event: captureResult.event,
+          props: captureResult.properties
+        });
+      }
+    };
+
     window.posthog = {
       __SV: 1,
       init(projectKey, options) {
         window.__posthogAudit.inits.push({ projectKey, options });
+        for (const pending of window.__posthogAudit.pending.splice(0)) {
+          emit(pending.event, pending.props);
+        }
       },
       capture(event, props = {}) {
-        window.__posthogAudit.events.push({ event, props });
+        emit(event, props);
       },
       register(props) {
         window.__posthogAudit.registrations.push(props);

--- a/specs/authored-content-static-export.md
+++ b/specs/authored-content-static-export.md
@@ -1,0 +1,46 @@
+# Authored content static export
+
+## What
+
+Generate blog and note article routes only for locales that contain authored
+content. A locale switch from an article keeps the article path when that
+translation exists; otherwise it opens the translated collection page instead
+of constructing a non-canonical article URL.
+
+The postbuild step also removes `out/og-cache`, which is an input cache for OG
+generation rather than a deployable asset. The unused `public/assets/full-bg.svg`
+asset is removed from the source and offline manifest policy.
+
+## Why
+
+The previous route generator emitted every article for every configured locale.
+That produced 1,272 fallback pages without authored translations, adding 14,728
+files and about 313.6 MiB to the static artifact. These pages were intentionally
+absent from the sitemap, so keeping them as successful public URLs increased
+deployment cost without adding indexable content.
+
+The source `blog-data`, `notes-data`, and `thoughts-data` directories remain in
+the deployed artifact for now. They are not needed by the current reader or
+search runtime, but there is not enough evidence to rule out external consumers
+of those historically public URLs.
+
+## Acceptance criteria
+
+1. Blog and note static params equal their declared authored locale sets.
+2. No untranslated article URL is generated or included in the sitemap.
+3. Canonical and `hreflang` metadata continue to include authored variants only.
+4. Selecting an authored locale keeps the current article URL.
+5. Selecting an unavailable locale opens that locale's blog or notes collection.
+6. The existing `locale_change` analytics event remains wired.
+7. `out/og-cache` is removed before the offline manifest and deployment artifact
+   are finalized.
+8. The artifact verifier and pagination/offline checks pass on a production
+   export.
+9. CI warns at 75% of the rebased 20,000-file/600 MiB budget and fails before
+   the artifact can return to its previous size.
+
+## Non-goals
+
+- Removing the public content-data directories without a compatibility audit.
+- Enabling experimental Next.js prefetch or segment-output behavior.
+- Changing sitemap coverage for authored content.

--- a/specs/content-list-loading-performance.md
+++ b/specs/content-list-loading-performance.md
@@ -1,0 +1,34 @@
+# Content List Loading Performance
+
+## What
+
+Blog and notes cards use intent-driven App Router prefetching. Links remain
+normal localized Next links, but viewport visibility alone does not fetch every
+article payload. Keyboard focus or pointer hover restores Next's native
+prefetch policy for only the intended link.
+
+The public header displays the existing 72 px favicon asset at 36 CSS pixels.
+That small asset is loaded eagerly with high fetch priority; the 512 px app
+icon remains unchanged for Next metadata and install/icon consumers.
+
+## Why
+
+Content archives can render dozens of links at once. Automatic viewport
+prefetching turns those lists into dozens of speculative RSC requests. The
+header also transferred a 512 px image for a 36 px slot, increasing critical
+image bytes without improving visual quality.
+
+## Acceptance criteria
+
+1. Blog and notes article-card links render with `prefetch={false}` before
+   interaction.
+2. Pointer hover or keyboard focus changes only that link to Next's default
+   App Router prefetch mode (`null`).
+3. Touch, click, modifier-click, locale routing, existing link props, and card
+   analytics continue through the existing Next/next-intl link contract.
+4. The header requests the 72 px favicon, displayed at 36 x 36, with eager
+   loading and high fetch priority.
+5. `src/app/icon.png` remains the metadata app icon and is not repurposed or
+   removed.
+6. Tests lock the intent-prefetch state mapping, card wiring, analytics wiring,
+   and header image contract.

--- a/specs/seo-field-data-monitoring.md
+++ b/specs/seo-field-data-monitoring.md
@@ -3,7 +3,7 @@
 ## What
 
 A standalone, read-only GitHub Actions workflow observes SEO field data every
-Tuesday and can also be started manually. It writes a sanitized job summary and
+Tuesday and can also be started manually from `main`. It writes a sanitized job summary and
 log entry; it does not commit reports, upload public artifacts, submit URLs, or
 modify the Search Console property. The workflow has no `push` or pull-request
 trigger, so a failed observation cannot gate a deployment or merge.
@@ -82,6 +82,8 @@ References:
   them.
 - URL Inspection referring URLs, discovered sitemaps, raw canonicals, rich
   results, and mobile-usability details are not retained.
+- Each canary compares both the user and Google canonical with its configured
+  expected canonical. Agreement on the same wrong URL is still a failure.
 - CrUX API keys remain request-only and never appear in the sanitized report.
 - A CrUX `404` for a configured target is treated as unavailable field data,
   not as a healthy value. Page-level absence stays `unknown`, which is expected
@@ -91,8 +93,8 @@ References:
 
 ## Acceptance criteria
 
-1. The standalone workflow supports weekly and manual execution with read-only
-   repository permission and no deploy or pull-request trigger.
+1. The standalone workflow supports weekly and `main`-only manual execution
+   with read-only repository permission and no deploy or pull-request trigger.
 2. Missing secrets, invalid permissions, and API failures produce a sanitized
    action-required summary and fail this observation workflow.
 3. Current and prior Search Analytics requests contain no dimensions or

--- a/specs/seo-field-data-monitoring.md
+++ b/specs/seo-field-data-monitoring.md
@@ -1,0 +1,106 @@
+# SEO field-data monitoring
+
+## What
+
+A standalone, read-only GitHub Actions workflow observes SEO field data every
+Tuesday and can also be started manually. It writes a sanitized job summary and
+log entry; it does not commit reports, upload public artifacts, submit URLs, or
+modify the Search Console property. The workflow has no `push` or pull-request
+trigger, so a failed observation cannot gate a deployment or merge.
+
+The monitor reads:
+
+- two aggregate Search Analytics rows for adjacent final 28-day windows,
+  without `query`, `page`, or any other grouping dimension;
+- the configured sitemap's reported status;
+- a small fixed set of URL Inspection canaries;
+- CrUX History for the origin and representative public pages on phone traffic.
+
+Availability and health are separate outputs. `observed` only means that an API
+returned usable field data. Health is `action_required`, `needs_attention`,
+`unknown`, or `healthy`. Missing credentials, insufficient permission, API
+errors, sitemap errors or warnings, URL Inspection failures, material Search
+Analytics regressions, and poor observed Core Web Vitals are action-required
+and make the standalone workflow exit non-zero. A genuinely absent page-level
+CrUX sample remains `unknown` and does not become either healthy or actionable.
+
+## Configuration and access
+
+The public targets live in `config/seo-field-monitoring.json`. Two repository
+secrets are required for live observations:
+
+1. `GOOGLE_SEARCH_CONSOLE_SERVICE_ACCOUNT_JSON`: a Google service-account JSON
+   key. Enable the Search Console API and add the service account email as a
+   user of the exact `https://nguyenlephong.github.io/` URL-prefix property. The
+   script requests only the
+   `https://www.googleapis.com/auth/webmasters.readonly` OAuth scope.
+2. `CRUX_API_KEY`: a Google Cloud API key with the Chrome UX Report API enabled.
+   Restrict the key to that API and rotate it if it is exposed.
+
+Never put either value in the config, source, workflow arguments, screenshots,
+or issue comments. GitHub's step summary is public for a public repository, so
+the script emits only aggregate metrics, fixed canary labels, sanitized status
+fields, and Core Web Vitals percentiles.
+
+Search Analytics compares the current final 28-day window with the immediately
+preceding 28-day window. An impression drop is action-required at **30% or
+more**, but only when the prior window has at least **200 impressions**. For this
+small public site, 200 impressions is a deliberate noise floor: it requires an
+absolute decline of at least 60 impressions before the percentage can alert.
+Below that floor the trend is `insufficient_baseline`, health remains `unknown`,
+and no drop alert is raised.
+
+## API contracts
+
+The implementation uses the current official endpoints:
+
+- Search Analytics:
+  `POST https://www.googleapis.com/webmasters/v3/sites/{siteUrl}/searchAnalytics/query`
+- Sitemap list:
+  `GET https://www.googleapis.com/webmasters/v3/sites/{siteUrl}/sitemaps`
+- URL Inspection:
+  `POST https://searchconsole.googleapis.com/v1/urlInspection/index:inspect`
+- CrUX History:
+  `POST https://chromeuxreport.googleapis.com/v1/records:queryHistoryRecord`
+
+References:
+
+- https://developers.google.com/webmaster-tools/v1/searchanalytics/query
+- https://developers.google.com/webmaster-tools/v1/sitemaps/list
+- https://developers.google.com/webmaster-tools/v1/urlInspection.index/inspect
+- https://developer.chrome.com/docs/crux/history-api/
+- https://web.dev/articles/defining-core-web-vitals-thresholds
+
+## Failure and privacy behavior
+
+- Missing secrets, invalid config, authentication failures, and API failures
+  produce `action_required` and a non-zero exit. Because this is a separate
+  scheduled/manual workflow, that failure does not gate deploys.
+- API response bodies and OAuth errors are never echoed on failure; only a
+  bounded reason such as `http_403`, `timeout`, or `no_data` is reported.
+- Search Analytics row keys are discarded even if an upstream response includes
+  them.
+- URL Inspection referring URLs, discovered sitemaps, raw canonicals, rich
+  results, and mobile-usability details are not retained.
+- CrUX API keys remain request-only and never appear in the sanitized report.
+- A CrUX `404` for a configured target is treated as unavailable field data,
+  not as a healthy value. Page-level absence stays `unknown`, which is expected
+  before enough eligible real-user traffic exists.
+- Observed Core Web Vitals use the official p75 poor thresholds: LCP over
+  4,000 ms, INP over 500 ms, or CLS over 0.25 is action-required.
+
+## Acceptance criteria
+
+1. The standalone workflow supports weekly and manual execution with read-only
+   repository permission and no deploy or pull-request trigger.
+2. Missing secrets, invalid permissions, and API failures produce a sanitized
+   action-required summary and fail this observation workflow.
+3. Current and prior Search Analytics requests contain no dimensions or
+   query/page filters; a drop of at least 30% alerts only above the 200-impression
+   prior-window baseline.
+4. Sitemap errors or warnings and URL Inspection fetch, indexing, robots, or
+   canonical failures are action-required.
+5. Poor observed p75 Core Web Vitals are action-required. Missing page-level
+   CrUX data stays unknown and cannot make overall health healthy.
+6. Mocked-fetch tests pin request methods, endpoints, bodies, sanitization,
+   availability/health separation, exit behavior, and workflow privacy.

--- a/specs/static-not-found-recovery.md
+++ b/specs/static-not-found-recovery.md
@@ -1,0 +1,67 @@
+# Static not-found recovery
+
+## Why
+
+Old links and untranslated article URLs should end in a useful place without
+turning every possible missing URL into another generated route. The site is a
+static export, so the hosting layer must keep returning the shared `404.html`
+artifact with an HTTP 404 status.
+
+The application has a top-level dynamic locale layout. Next.js 16.2.10's
+experimental `globalNotFound` convention is therefore the narrowest way to
+render one custom fallback outside that layout. It is enabled only after the
+installed Next.js config schema, build entry, production export, and browser
+behavior are verified by this change.
+
+## Behavior
+
+- The build emits one custom `out/404.html`; it does not generate fallback
+  pages for the 1,272 localized content routes.
+- The raw HTML is a complete, useful English recovery page. It has one `h1`,
+  stable links to the English home, blog, and notes pages, and home links for
+  every supported language.
+- After hydration, the first supported locale segment in the requested path
+  selects the copy and updates the document language and title. A missing blog
+  or notes URL keeps that surface as the primary recovery link.
+- Unsupported or absent locale segments fall back to English. The page never
+  redirects and never reconstructs an unknown content URL.
+- Recovery links point only to generated `/{locale}`, `/{locale}/blog`, and
+  `/{locale}/notes` routes. They use ordinary anchors and do not prefetch.
+- The static 404 stays in the offline shell so an already cached site has the
+  same recovery document.
+
+## SEO and accessibility
+
+- The response remains a real HTTP 404 when served by the host.
+- Next.js emits its automatic `noindex` for the 404 response. The page does not
+  add a second robots directive, `nofollow`, a canonical, or locale alternate
+  links. Missing URLs must not compete with valid pages in search results.
+- The document has exactly one visible `h1`, keyboard-visible focus states,
+  labelled navigation, and a useful no-JavaScript experience.
+
+## Analytics
+
+- `not_found_view` is the surface-specific page event. It includes
+  `page_type=not_found`, the detected locale, and the requested surface.
+- `not_found_recovery_click` records the selected safe target and language.
+- The 404 bootstrap disables PostHog's automatic page-view and page-leave
+  capture. Explicit 404 events omit pathname, search, and referrer because a
+  broken URL may contain an email address, reset token, or other secret.
+- Existing event names and PostHog privacy settings remain unchanged. The main
+  locale layout and the global 404 use the same bootstrap component, so the
+  SDK host, DNT support, disabled autocapture, disabled session recording, and
+  persistence configuration cannot drift. Only one root document is rendered
+  for a request, so the bootstrap is not duplicated at runtime.
+
+## Acceptance criteria
+
+- **AC-404-001:** A production static export contains one custom `404.html`
+  with an HTTP-hostable, useful no-JavaScript fallback.
+- **AC-404-002:** `/zh/blog/...` and `/fr/notes/...` hydrate with the matching
+  language, surface-first safe links, one `h1`, and no hydration errors.
+- **AC-404-003:** Unsupported paths recover in English without a redirect.
+- **AC-404-004:** The artifact is `noindex`, has no canonical, and is served
+  with status 404 for missing URLs.
+- **AC-404-005:** View and recovery events use the dedicated not-found
+  taxonomy without renaming existing events.
+- **AC-404-006:** `404.html` remains part of the offline shared shell.

--- a/specs/static-not-found-recovery.md
+++ b/specs/static-not-found-recovery.md
@@ -52,6 +52,25 @@ behavior are verified by this change.
   SDK host, DNT support, disabled autocapture, disabled session recording, and
   persistence configuration cannot drift. Only one root document is rendered
   for a request, so the bootstrap is not duplicated at runtime.
+- A not-found `before_send` hook recursively removes SDK-added URL, path, and
+  referrer properties, including session/initial and `$set`/`$set_once` data.
+  Explicit analytics calls queue locally until the lazy SDK bootstrap is ready.
+
+## Development boundary
+
+- Production keeps `output: "export"` and emits the same static artifact.
+- Production enables the custom global not-found document; development uses
+  Next.js's built-in 404 so a missing-route compile cannot race valid first hits.
+- `next dev` intentionally omits export mode. Next.js 16 can otherwise race
+  concurrent first-route compilation while updating
+  `.next/dev/prerender-manifest.json`, corrupting the manifest and poisoning the
+  development server with 500 responses.
+- Every route-level `generateStaticParams` returns an empty list in development,
+  so routes render on demand instead of concurrently rewriting Next.js's shared
+  prerender manifest. Production still enumerates the complete static route set.
+- CI starts an isolated, clean-cache development server, requests representative
+  public, Studio, and missing routes concurrently, and requires expected
+  responses plus a parseable prerender manifest before the production build runs.
 
 ## Acceptance criteria
 
@@ -65,3 +84,6 @@ behavior are verified by this change.
 - **AC-404-005:** View and recovery events use the dedicated not-found
   taxonomy without renaming existing events.
 - **AC-404-006:** `404.html` remains part of the offline shared shell.
+- **AC-404-007:** Production remains a static export while clean-cache concurrent
+  first hits in development return valid responses without corrupting the
+  prerender manifest.

--- a/specs/static-runtime-boundaries.md
+++ b/specs/static-runtime-boundaries.md
@@ -14,13 +14,13 @@ route group to give public pages and Studio different runtime boundaries.
 
 - `src/app/[locale]/layout.tsx` remains the locale document boundary. It owns
   locale validation, static locale parameters, shared metadata, the
-  internationalization provider, and global analytics scripts.
+  internationalization provider, global analytics scripts, and one shared Web
+  Vitals reporter for both public pages and Studio.
 - All localized routes except Studio live under
   `src/app/[locale]/(site)`. Route groups are omitted from generated URLs.
 - `src/app/[locale]/(site)/layout.tsx` owns public-only chrome and runtime:
   theme and reading-preference scripts, motion, route progress, offline
-  navigation and status, Web Vitals reporting, header, footer, and reader
-  tools.
+  navigation and status, header, footer, and reader tools.
 - Studio remains at `src/app/[locale]/studio`, outside the public route group.
   It must not render, hydrate, or hide public-only chrome.
 - Canonicals, `hreflang`, static parameters, metadata routes, analytics event
@@ -58,15 +58,17 @@ existing IDs must not be renamed or renumbered.
   duplicate URL paths after route-group segments are removed.
 - **AC-SRB-003:** The locale root layout retains locale validation, static
   locale parameters, metadata, internationalization, and global analytics.
-- **AC-SRB-004:** Header, footer, motion, route progress, offline runtime, Web
-  Vitals reporting, and reader tools are mounted only by the public-site
-  layout.
+- **AC-SRB-004:** Header, footer, motion, route progress, offline runtime, and
+  reader tools are mounted only by the public-site layout.
 - **AC-SRB-005:** Studio is outside `(site)` and neither renders nor hides
   public-site chrome through CSS selectors.
 - **AC-SRB-006:** Public pages preserve their canonical paths, metadata,
   static parameters, localization, and analytics wiring.
 - **AC-SRB-007:** Source-contract tests follow the new route-group paths and
   enforce the public/Studio runtime boundary.
+- **AC-SRB-008:** The locale root mounts exactly one Web Vitals reporter with
+  locale and route context. Public routes and Studio share this reporter
+  without pulling public-only chrome into Studio.
 
 ## Verification
 

--- a/specs/studio-static-runtime.md
+++ b/specs/studio-static-runtime.md
@@ -10,11 +10,13 @@ even when a visitor opened the lightweight welcome route.
 
 ## Decision
 
-- Export a concise, localized Studio overview as ordinary HTML inside the
+- Export a concise, localized Studio overview as ordinary light DOM inside the
   shadow host. It remains visible without JavaScript and is replaced only after
   the ShadowRoot is ready.
-- Keep exactly one visible page heading: the static overview owns the H1 before
-  hydration; the active Studio module owns it after the fallback is removed.
+- Keep exactly one localized, visible page H1 in light DOM for the complete
+  route lifetime. Hydration projects that same node through a named slot in the
+  Studio top bar; active Studio module titles are H2 and the ShadowRoot owns no
+  H1.
 - Publish crawlable module links in the overview and mirror those exact URLs in
   the `CollectionPage.hasPart` graph.
 - Keep the existing query/hash Studio navigation contract and analytics event
@@ -40,7 +42,7 @@ even when a visitor opened the lightweight welcome route.
 ## Acceptance criteria
 
 - **AC-STUDIO-STATIC-001:** Every supported locale exports a meaningful Studio
-  overview containing one visible H1, a concise introduction, module
+  overview with one visible page H1, a concise introduction, module
   descriptions, and ordinary anchor links.
 - **AC-STUDIO-STATIC-002:** The overview is the initial ShadowIsland fallback,
   is identical for server render and first hydration render, and is removed
@@ -71,6 +73,10 @@ even when a visitor opened the lightweight welcome route.
   rejected dynamic module.
 - **AC-STUDIO-STATIC-012:** All Studio locales emit explicit `og:image` and
   `twitter:image` metadata; artifact verification rejects either omission.
+- **AC-STUDIO-STATIC-013:** Server HTML, first hydration, and the interactive
+  workspace retain the same localized H1 node in light DOM. A named slot makes
+  it visible inside the hydrated shell, no Shadow DOM subtree contains an H1,
+  and internal view titles use H2 or lower.
 
 ## Verification
 

--- a/specs/web-vitals-rum.md
+++ b/specs/web-vitals-rum.md
@@ -1,0 +1,28 @@
+# Shared Web Vitals RUM
+
+## What
+
+The locale root mounts one Web Vitals reporter for both public-site routes and
+Studio. It sends the existing `web_vital` event through the privacy-aware
+analytics wrapper with the raw metric value, delta, rating, navigation type,
+current path, surface, and locale.
+
+## Why
+
+Mounting the reporter only in the public route group left Studio without field
+performance data. Rounding every metric also converted fractional CLS values
+such as `0.12` to `0`, making layout-shift monitoring unusable.
+
+## Acceptance criteria
+
+1. Exactly one reporter is mounted under the locale provider; nested layouts
+   do not mount another reporter.
+2. The reporter callback has a stable reference so route-context updates do
+   not register duplicate Web Vitals observers.
+3. `value` and `delta` retain their original numeric precision. The payload
+   also includes `rating`, `navigation_type`, `path`, `surface`, and `locale`.
+4. `/[locale]/studio` is reported as the `studio` surface; other localized
+   routes are reported as `site`.
+5. Reporting continues through `track`, preserving Do Not Track handling,
+   failure isolation, the existing event name, and current PostHog privacy
+   configuration.

--- a/src/app/[locale]/(site)/about/opengraph-image.tsx
+++ b/src/app/[locale]/(site)/about/opengraph-image.tsx
@@ -9,6 +9,7 @@ export const size = OG_SIZE
 export const contentType = OG_CONTENT_TYPE
 
 export function generateStaticParams() {
+  if (process.env.NODE_ENV === 'development') return []
   return routing.locales.map((locale) => ({ locale }))
 }
 export const dynamic = 'force-static'

--- a/src/app/[locale]/(site)/about/page.tsx
+++ b/src/app/[locale]/(site)/about/page.tsx
@@ -19,6 +19,7 @@ import PageTracker from '@/components/analytics/PageTracker'
 const seo = PAGE_SEO.about
 
 export function generateStaticParams() {
+  if (process.env.NODE_ENV === 'development') return []
   return routing.locales.map((locale) => ({ locale }))
 }
 

--- a/src/app/[locale]/(site)/apps/english/page.tsx
+++ b/src/app/[locale]/(site)/apps/english/page.tsx
@@ -11,6 +11,7 @@ import EnglishPracticeApp from '@/components/apps/english/EnglishPracticeApp'
 type Props = { params: Promise<{ locale: string }> }
 
 export function generateStaticParams() {
+  if (process.env.NODE_ENV === 'development') return []
   return routing.locales.map((locale) => ({ locale }))
 }
 

--- a/src/app/[locale]/(site)/apps/opengraph-image.tsx
+++ b/src/app/[locale]/(site)/apps/opengraph-image.tsx
@@ -10,6 +10,7 @@ export const size = OG_SIZE
 export const contentType = OG_CONTENT_TYPE
 
 export function generateStaticParams() {
+  if (process.env.NODE_ENV === 'development') return []
   return routing.locales.map((locale) => ({ locale }))
 }
 export const dynamic = 'force-static'

--- a/src/app/[locale]/(site)/apps/page.tsx
+++ b/src/app/[locale]/(site)/apps/page.tsx
@@ -12,6 +12,7 @@ import AppsLinkTracker from '@/components/analytics/AppsLinkTracker'
 const seo = PAGE_SEO.apps
 
 export function generateStaticParams() {
+  if (process.env.NODE_ENV === 'development') return []
   return routing.locales.map((locale) => ({ locale }))
 }
 

--- a/src/app/[locale]/(site)/blog/[category]/[slug]/page.tsx
+++ b/src/app/[locale]/(site)/blog/[category]/[slug]/page.tsx
@@ -38,9 +38,8 @@ type Props = {
   params: Promise<{ locale: string; category: string; slug: string }>
 }
 
-export const dynamicParams = false
-
 export function generateStaticParams() {
+  if (process.env.NODE_ENV === 'development') return []
   return listBlogPostParams()
 }
 

--- a/src/app/[locale]/(site)/blog/[category]/[slug]/page.tsx
+++ b/src/app/[locale]/(site)/blog/[category]/[slug]/page.tsx
@@ -17,7 +17,7 @@ import {
   getCategory,
   getPostContentLocales,
   getSeriesContext,
-  listCategoryPostPairs,
+  listBlogPostParams,
   listPosts,
   loadPost,
 } from '@/lib/blog/data'
@@ -38,11 +38,10 @@ type Props = {
   params: Promise<{ locale: string; category: string; slug: string }>
 }
 
+export const dynamicParams = false
+
 export function generateStaticParams() {
-  const pairs = listCategoryPostPairs()
-  return routing.locales.flatMap((locale) =>
-    pairs.map(({ category, slug }) => ({ locale, category, slug })),
-  )
+  return listBlogPostParams()
 }
 
 function formatDate(iso: string, locale: string): string {
@@ -262,7 +261,11 @@ export default async function BlogPostPage({ params }: Props) {
       : null
 
   return (
-    <main className={`blog-article blog-article--${cat?.accent ?? 'ocean'}`}>
+    <main
+      className={`blog-article blog-article--${cat?.accent ?? 'ocean'}`}
+      data-content-locales={contentLocales.join(' ')}
+      data-content-locale-fallback="/blog"
+    >
       <script
         type="application/ld+json"
         dangerouslySetInnerHTML={{ __html: JSON.stringify(articleLd) }}

--- a/src/app/[locale]/(site)/blog/[category]/opengraph-image.tsx
+++ b/src/app/[locale]/(site)/blog/[category]/opengraph-image.tsx
@@ -10,6 +10,7 @@ export const contentType = OG_CONTENT_TYPE
 export const alt = 'Blog category — Nguyen Le Phong'
 
 export function generateStaticParams() {
+  if (process.env.NODE_ENV === 'development') return []
   const slugs = listCategorySlugs()
   const params = routing.locales.flatMap((locale) =>
     slugs.map((category) => ({ locale, category })),

--- a/src/app/[locale]/(site)/blog/[category]/page.tsx
+++ b/src/app/[locale]/(site)/blog/[category]/page.tsx
@@ -19,6 +19,7 @@ import '../blog.css'
 type Props = { params: Promise<{ locale: string; category: string }> }
 
 export function generateStaticParams() {
+  if (process.env.NODE_ENV === 'development') return []
   const slugs = listCategorySlugs()
   return routing.locales.flatMap((locale) =>
     slugs.map((category) => ({ locale, category })),

--- a/src/app/[locale]/(site)/blog/opengraph-image.tsx
+++ b/src/app/[locale]/(site)/blog/opengraph-image.tsx
@@ -9,6 +9,7 @@ export const size = OG_SIZE
 export const contentType = OG_CONTENT_TYPE
 
 export function generateStaticParams() {
+  if (process.env.NODE_ENV === 'development') return []
   return routing.locales.map((locale) => ({ locale }))
 }
 export const dynamic = 'force-static'

--- a/src/app/[locale]/(site)/blog/page.tsx
+++ b/src/app/[locale]/(site)/blog/page.tsx
@@ -8,6 +8,7 @@ import './blog.css'
 type Props = { params: Promise<{ locale: string }> }
 
 export function generateStaticParams() {
+  if (process.env.NODE_ENV === 'development') return []
   return routing.locales.map((locale) => ({ locale }))
 }
 

--- a/src/app/[locale]/(site)/blog/page/[page]/page.tsx
+++ b/src/app/[locale]/(site)/blog/page/[page]/page.tsx
@@ -10,9 +10,8 @@ import '../../blog.css'
 
 type Props = { params: Promise<{ locale: string; page: string }> }
 
-export const dynamicParams = false
-
 export function generateStaticParams() {
+  if (process.env.NODE_ENV === 'development') return []
   return listBlogArchiveLocales(1).flatMap((locale) =>
     Array.from({ length: Math.max(0, blogPageCount(locale) - 1) }, (_, index) => ({
       locale,

--- a/src/app/[locale]/(site)/gallery/opengraph-image.tsx
+++ b/src/app/[locale]/(site)/gallery/opengraph-image.tsx
@@ -10,6 +10,7 @@ export const size = OG_SIZE
 export const contentType = OG_CONTENT_TYPE
 
 export function generateStaticParams() {
+  if (process.env.NODE_ENV === 'development') return []
   return routing.locales.map((locale) => ({ locale }))
 }
 export const dynamic = 'force-static'

--- a/src/app/[locale]/(site)/gallery/page.tsx
+++ b/src/app/[locale]/(site)/gallery/page.tsx
@@ -12,6 +12,7 @@ import PageTracker from '@/components/analytics/PageTracker'
 const seo = PAGE_SEO.gallery
 
 export function generateStaticParams() {
+  if (process.env.NODE_ENV === 'development') return []
   return routing.locales.map((locale) => ({ locale }))
 }
 

--- a/src/app/[locale]/(site)/heartbeats/page.tsx
+++ b/src/app/[locale]/(site)/heartbeats/page.tsx
@@ -8,6 +8,7 @@ import { familyMembers } from './family.data'
 import './heartbeats.css'
 
 export function generateStaticParams() {
+  if (process.env.NODE_ENV === 'development') return []
   return routing.locales.map((locale) => ({ locale }))
 }
 

--- a/src/app/[locale]/(site)/layout.tsx
+++ b/src/app/[locale]/(site)/layout.tsx
@@ -4,7 +4,6 @@ import { hasLocale } from 'next-intl'
 import { getTranslations, setRequestLocale } from 'next-intl/server'
 import AppFooter from '@/components/AppFooter'
 import AppHeader from '@/components/AppHeader'
-import WebVitalsReporter from '@/components/analytics/WebVitalsReporter'
 import BlogReaderTools from '@/components/blog/BlogReaderTools'
 import FontScript from '@/components/font/FontScript'
 import MotionProvider from '@/components/motion/MotionProvider'
@@ -47,7 +46,6 @@ export default async function SiteLayout({ children, params }: SiteLayoutProps) 
         <RouteProgressBar />
         <OfflineNavigationCapture />
         <OfflineStatusBanner />
-        <WebVitalsReporter />
         <AppHeader />
         {children}
         <AppFooter />

--- a/src/app/[locale]/(site)/notes/[slug]/page.tsx
+++ b/src/app/[locale]/(site)/notes/[slug]/page.tsx
@@ -37,9 +37,8 @@ type Props = { params: Promise<{ locale: string; slug: string }> };
 
 const FALLBACK_TOPIC_COLOR = "#b45309";
 
-export const dynamicParams = false;
-
 export function generateStaticParams() {
+  if (process.env.NODE_ENV === "development") return [];
   return listNoteParams();
 }
 

--- a/src/app/[locale]/(site)/notes/[slug]/page.tsx
+++ b/src/app/[locale]/(site)/notes/[slug]/page.tsx
@@ -37,6 +37,8 @@ type Props = { params: Promise<{ locale: string; slug: string }> };
 
 const FALLBACK_TOPIC_COLOR = "#b45309";
 
+export const dynamicParams = false;
+
 export function generateStaticParams() {
   return listNoteParams();
 }
@@ -285,6 +287,8 @@ export default async function NotePage({ params }: Props) {
   return (
     <main
       className="blog-article blog-article--ocean notes-accent notes-reading"
+      data-content-locales={contentLocales.join(" ")}
+      data-content-locale-fallback="/notes"
       style={{ "--topic-color": topicColor } as React.CSSProperties}
     >
       <script

--- a/src/app/[locale]/(site)/notes/page.tsx
+++ b/src/app/[locale]/(site)/notes/page.tsx
@@ -9,6 +9,7 @@ import '../blog/blog.css'
 type Props = { params: Promise<{ locale: string }> }
 
 export function generateStaticParams() {
+  if (process.env.NODE_ENV === 'development') return []
   return routing.locales.map((locale) => ({ locale }))
 }
 

--- a/src/app/[locale]/(site)/notes/page/[page]/page.tsx
+++ b/src/app/[locale]/(site)/notes/page/[page]/page.tsx
@@ -11,9 +11,8 @@ import '../../../blog/blog.css'
 
 type Props = { params: Promise<{ locale: string; page: string }> }
 
-export const dynamicParams = false
-
 export function generateStaticParams() {
+  if (process.env.NODE_ENV === 'development') return []
   return NOTE_CONTENT_LOCALES.flatMap((locale) =>
     Array.from({ length: Math.max(0, notesPageCount(locale) - 1) }, (_, index) => ({
       locale,

--- a/src/app/[locale]/(site)/offline/page.tsx
+++ b/src/app/[locale]/(site)/offline/page.tsx
@@ -12,6 +12,7 @@ type Props = {
 }
 
 export function generateStaticParams() {
+  if (process.env.NODE_ENV === 'development') return []
   return routing.locales.map((locale) => ({ locale }))
 }
 

--- a/src/app/[locale]/(site)/opengraph-image.tsx
+++ b/src/app/[locale]/(site)/opengraph-image.tsx
@@ -10,6 +10,7 @@ export const contentType = OG_CONTENT_TYPE
 export const dynamic = 'force-static'
 
 export function generateStaticParams() {
+  if (process.env.NODE_ENV === 'development') return []
   return routing.locales.map((locale) => ({ locale }))
 }
 

--- a/src/app/[locale]/(site)/page.tsx
+++ b/src/app/[locale]/(site)/page.tsx
@@ -23,6 +23,7 @@ type Props = {
 }
 
 export function generateStaticParams() {
+  if (process.env.NODE_ENV === 'development') return []
   return routing.locales.map((locale) => ({ locale }))
 }
 

--- a/src/app/[locale]/(site)/search/blog.json/route.ts
+++ b/src/app/[locale]/(site)/search/blog.json/route.ts
@@ -10,9 +10,8 @@ import { createSearchIndex } from '@/lib/content/search-index.server'
 
 type Context = { params: Promise<{ locale: string }> }
 
-export const dynamicParams = false
-
 export function generateStaticParams() {
+  if (process.env.NODE_ENV === 'development') return []
   return routing.locales.map((locale) => ({ locale }))
 }
 

--- a/src/app/[locale]/(site)/search/notes.json/route.ts
+++ b/src/app/[locale]/(site)/search/notes.json/route.ts
@@ -10,9 +10,8 @@ import { createSearchIndex } from '@/lib/content/search-index.server'
 
 type Context = { params: Promise<{ locale: string }> }
 
-export const dynamicParams = false
-
 export function generateStaticParams() {
+  if (process.env.NODE_ENV === 'development') return []
   return routing.locales.map((locale) => ({ locale }))
 }
 

--- a/src/app/[locale]/layout.tsx
+++ b/src/app/[locale]/layout.tsx
@@ -4,6 +4,8 @@ import { hasLocale, NextIntlClientProvider } from 'next-intl'
 import { getTranslations, setRequestLocale } from 'next-intl/server'
 import Script from 'next/script'
 import { SITE_URL } from '@/app/seo.config'
+import PostHogBootstrap from '@/components/analytics/PostHogBootstrap'
+import WebVitalsReporter from '@/components/analytics/WebVitalsReporter'
 import { routing, type Locale } from '@/i18n/routing'
 import React from 'react'
 import '../globals.css'
@@ -174,29 +176,13 @@ export default async function LocaleLayout({ children, params }: LayoutProps) {
           `,
         }}
       />
-      <Script
-        id="POSTHOG"
-        strategy="lazyOnload"
-        dangerouslySetInnerHTML={{
-          __html: `
-            !function(t,e){var o,n,p,r;e.__SV||(window.posthog=e,e._i=[],e.init=function(i,s,a){function g(t,e){var o=e.split(".");2==o.length&&(t=t[o[0]],e=o[1]),t[e]=function(){t.push([e].concat(Array.prototype.slice.call(arguments,0)))}}(p=t.createElement("script")).type="text/javascript",p.crossOrigin="anonymous",p.async=!0,p.src=s.api_host.replace(".i.posthog.com","-assets.i.posthog.com")+"/static/array.js",(r=t.getElementsByTagName("script")[0]).parentNode.insertBefore(p,r);var u=e;for(void 0!==a?u=e[a]=[]:a="posthog",u.people=u.people||[],u.toString=function(t){var e="posthog";return"posthog"!==a&&(e+="."+a),t||(e+=" (stub)"),e},u.people.toString=function(){return u.toString(1)+".people (stub)"},o="capture identify alias people.set people.set_once set_config register register_once unregister opt_out_capturing has_opted_out_capturing opt_in_capturing reset isFeatureEnabled onFeatureFlags".split(" "),n=0;n<o.length;n++)g(u,o[n]);e._i.push([i,s,a])},e.__SV=1)}(document,window.posthog||[]);
-            posthog.init('phc_Ti11bWc5cshVoQe8AI7SuY56FMFP7Fhc9WyymdOGVSw',{
-              api_host:'https://us.i.posthog.com',
-              defaults:'2026-01-30',
-              capture_pageview: true,
-              capture_pageleave: true,
-              autocapture: false,
-              disable_session_recording: true,
-              respect_dnt: true,
-              persistence: 'localStorage+cookie'
-            });
-            posthog.register({ site: 'nguyenlephong.github.io', surface: 'cv', locale: ${JSON.stringify(locale)} });
-          `,
-        }}
-      />
+      <PostHogBootstrap locale={locale} />
 
       <body suppressHydrationWarning>
-        <NextIntlClientProvider>{children}</NextIntlClientProvider>
+        <NextIntlClientProvider>
+          <WebVitalsReporter locale={locale} />
+          {children}
+        </NextIntlClientProvider>
       </body>
     </html>
   )

--- a/src/app/[locale]/layout.tsx
+++ b/src/app/[locale]/layout.tsx
@@ -20,6 +20,7 @@ const LOCALE_OG_MAP: Record<Locale, string> = {
 }
 
 export function generateStaticParams() {
+  if (process.env.NODE_ENV === 'development') return []
   return routing.locales.map((locale) => ({ locale }))
 }
 

--- a/src/app/[locale]/studio/StudioStaticOverview.tsx
+++ b/src/app/[locale]/studio/StudioStaticOverview.tsx
@@ -11,36 +11,18 @@ export default function StudioStaticOverview({ locale }: Readonly<{ locale: stri
       <style>{`
         .studio-static-overview {
           box-sizing: border-box;
-          min-height: 100vh;
-          max-height: 100vh;
-          overflow: auto;
-          padding: clamp(2rem, 6vw, 5.5rem) clamp(1.25rem, 5vw, 4rem);
-          color: #171717;
-          background:
-            radial-gradient(circle at top right, rgba(23, 23, 23, 0.06), transparent 34rem),
-            #fafafa;
-          font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+          min-height: calc(100vh - 9rem);
+          padding: 1.35rem clamp(1.25rem, 5vw, 4rem) clamp(2rem, 6vw, 5.5rem);
+          color: inherit;
+          background: transparent;
+          font: inherit;
         }
         .studio-static-overview * { box-sizing: border-box; }
         .studio-static-overview > header,
         .studio-static-overview > section { width: min(72rem, 100%); margin-inline: auto; }
-        .studio-static-overview .studio-static-eyebrow {
-          margin: 0 0 0.9rem;
-          color: #525252;
-          font-size: 0.78rem;
-          font-weight: 700;
-          letter-spacing: 0.12em;
-          text-transform: uppercase;
-        }
-        .studio-static-overview h1 {
-          margin: 0;
-          font-size: clamp(2.25rem, 7vw, 5.25rem);
-          letter-spacing: -0.055em;
-          line-height: 0.98;
-        }
         .studio-static-overview .studio-static-intro {
           max-width: 48rem;
-          margin: 1.35rem 0 0;
+          margin: 0;
           color: #525252;
           font-size: clamp(1rem, 2vw, 1.2rem);
           line-height: 1.7;
@@ -68,8 +50,6 @@ export default function StudioStaticOverview({ locale }: Readonly<{ locale: stri
         .studio-static-overview li p { margin: 0.9rem 0 1.2rem; color: #525252; line-height: 1.65; }
         .studio-static-overview li > a { color: #171717; font-size: 0.82rem; font-weight: 700; }
         @media (prefers-color-scheme: dark) {
-          .studio-static-overview { color: #f5f5f5; background: #0a0a0a; }
-          .studio-static-overview .studio-static-eyebrow,
           .studio-static-overview .studio-static-intro,
           .studio-static-overview li p { color: #a3a3a3; }
           .studio-static-overview li { border-color: #262626; background: #171717; }
@@ -78,8 +58,6 @@ export default function StudioStaticOverview({ locale }: Readonly<{ locale: stri
         }
       `}</style>
       <header>
-        <p className="studio-static-eyebrow">{content.eyebrow}</p>
-        <h1>{content.title}</h1>
         <p className="studio-static-intro">{content.intro}</p>
       </header>
       <section aria-labelledby="studio-static-modules-heading">

--- a/src/app/[locale]/studio/StudioWorkspace.tsx
+++ b/src/app/[locale]/studio/StudioWorkspace.tsx
@@ -8,10 +8,11 @@ import { studioShadowStyles } from "./studio.shadow-styles";
 
 type StudioWorkspaceProps = {
   fallback: ReactNode;
+  heading: ReactNode;
   locale: string;
 };
 
-export default function StudioWorkspace({ fallback, locale }: StudioWorkspaceProps) {
+export default function StudioWorkspace({ fallback, heading, locale }: StudioWorkspaceProps) {
   useEffect(() => {
     document.body.classList.add("studio-app-shell-active");
     return () => document.body.classList.remove("studio-app-shell-active");
@@ -26,6 +27,7 @@ export default function StudioWorkspace({ fallback, locale }: StudioWorkspacePro
       styles={studioShadowStyles}
       label={workspaceLabel}
       fallback={fallback}
+      heading={heading}
     >
       <StudioAdminShell locale={locale} />
     </ShadowIsland>

--- a/src/app/[locale]/studio/page.tsx
+++ b/src/app/[locale]/studio/page.tsx
@@ -135,11 +135,79 @@ export default async function StudioPage({ params }: Props) {
               padding-bottom: 0 !important;
             }
 
-            body:has(.studio-route-shell) [data-studio-shadow-host],
-            body.studio-app-shell-active [data-studio-shadow-host] {
+            body:has(.studio-route-shell) [data-studio-shadow-host][data-shadow-ready="true"],
+            body.studio-app-shell-active [data-studio-shadow-host][data-shadow-ready="true"] {
               height: 100vh !important;
               min-height: 100vh !important;
               overflow: hidden !important;
+            }
+
+            [data-studio-shadow-host][data-shadow-ready="false"] {
+              height: 100vh;
+              overflow: auto !important;
+              color: #171717;
+              background:
+                radial-gradient(circle at top right, rgba(23, 23, 23, 0.06), transparent 34rem),
+                #fafafa;
+              font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+            }
+
+            [data-studio-shadow-host] > .studio-page-heading {
+              box-sizing: border-box;
+              color: inherit;
+            }
+
+            [data-studio-shadow-host][data-shadow-ready="false"] > .studio-page-heading {
+              width: min(72rem, 100%);
+              margin-inline: auto;
+              padding: clamp(2rem, 6vw, 5.5rem) clamp(1.25rem, 5vw, 4rem) 0;
+            }
+
+            .studio-page-heading__eyebrow {
+              margin: 0 0 0.9rem;
+              color: #525252;
+              font-size: 0.78rem;
+              font-weight: 700;
+              letter-spacing: 0.12em;
+              text-transform: uppercase;
+            }
+
+            .studio-page-heading h1 {
+              margin: 0;
+              font-size: clamp(2.25rem, 7vw, 5.25rem);
+              letter-spacing: -0.055em;
+              line-height: 0.98;
+            }
+
+            [data-studio-shadow-host][data-shadow-ready="true"] > .studio-page-heading {
+              display: block;
+              max-width: min(28vw, 18rem);
+              overflow: hidden;
+            }
+
+            [data-studio-shadow-host][data-shadow-ready="true"] .studio-page-heading__eyebrow {
+              display: none;
+            }
+
+            [data-studio-shadow-host][data-shadow-ready="true"] .studio-page-heading__title {
+              overflow: hidden;
+              font-size: 0.875rem;
+              font-weight: 650;
+              letter-spacing: 0;
+              line-height: 1.2;
+              text-overflow: ellipsis;
+              white-space: nowrap;
+            }
+
+            @media (prefers-color-scheme: dark) {
+              [data-studio-shadow-host][data-shadow-ready="false"] {
+                color: #f5f5f5;
+                background: #0a0a0a;
+              }
+
+              [data-studio-shadow-host][data-shadow-ready="false"] .studio-page-heading__eyebrow {
+                color: #a3a3a3;
+              }
             }
 
           `
@@ -150,7 +218,20 @@ export default async function StudioPage({ params }: Props) {
         dangerouslySetInnerHTML={{ __html: JSON.stringify(collectionLd) }}
       />
       <PageTracker page="studio" eventName="studio_view" section="notes_admin" />
-      <StudioWorkspace locale={locale} fallback={<StudioStaticOverview locale={locale} />} />
+      <StudioWorkspace
+        locale={locale}
+        heading={(
+          <div
+            slot="studio-page-heading"
+            className="studio-page-heading"
+            data-studio-page-heading="true"
+          >
+            <p className="studio-page-heading__eyebrow">{staticContent.eyebrow}</p>
+            <h1 className="studio-page-heading__title">{staticContent.title}</h1>
+          </div>
+        )}
+        fallback={<StudioStaticOverview locale={locale} />}
+      />
     </div>
   );
 }

--- a/src/app/[locale]/studio/page.tsx
+++ b/src/app/[locale]/studio/page.tsx
@@ -40,6 +40,7 @@ function getStudioSeo(locale: string) {
 type Props = { params: Promise<{ locale: string }> };
 
 export function generateStaticParams() {
+  if (process.env.NODE_ENV === "development") return [];
   return routing.locales.map((locale) => ({ locale }));
 }
 

--- a/src/app/[locale]/studio/studio-admin-shell.tsx
+++ b/src/app/[locale]/studio/studio-admin-shell.tsx
@@ -2762,7 +2762,7 @@ function RouteHeading({ route, copy = englishStudioCopy, children }: { route: St
           <Icon aria-hidden="true" />
           <span>{route.kind === "legacy" ? copy.routeKicker.legacy : copy.routeKicker.studio}</span>
         </div>
-        <h1>{route.title}</h1>
+        <h2>{route.title}</h2>
         <p>{route.description}</p>
       </div>
       {children}
@@ -4014,7 +4014,7 @@ function WelcomePage({
       <div className="welcome-shell">
         <div className="welcome-intro">
           <span className="welcome-eyebrow"><LuSparkles aria-hidden="true" /> {copy.welcome.eyebrow}</span>
-          <h1>{route.title}</h1>
+          <h2>{route.title}</h2>
           <p>{copy.welcome.lead}</p>
           <div className="welcome-note-strip">
             <LuSmile aria-hidden="true" />
@@ -5576,7 +5576,7 @@ function StudioFlowMenuPage({
 
   return (
     <section className="route-page studio-flow-route">
-      {selectedFlow.architectureDemo && <h1 className="sr-only">{selectedFlow.title}</h1>}
+      {selectedFlow.architectureDemo && <h2 className="sr-only">{selectedFlow.title}</h2>}
       {!selectedFlow.architectureDemo && (
         <>
           <RouteHeading route={route} copy={copy}>
@@ -5878,7 +5878,7 @@ function AuthPage({ route }: { route: StudioRoute }) {
           <LuCommand aria-hidden="true" />
           <span>Studio</span>
         </div>
-        <h1>{route.title}</h1>
+        <h3>{route.title}</h3>
         <p>{route.description}</p>
         <label className="form-row">
           <span>Email</span>
@@ -6728,6 +6728,8 @@ export function StudioAdminShell({ locale }: StudioAdminShellProps) {
             <button type="button" className="icon-button" aria-label={copy.toggleNavigation} onClick={toggleSidebar}>
               {mobileSidebarOpen ? <LuX aria-hidden="true" /> : <LuPanelLeft aria-hidden="true" />}
             </button>
+            <span className="topbar-separator" aria-hidden="true" />
+            <slot name="studio-page-heading" />
             <span className="topbar-separator" aria-hidden="true" />
             <button
               type="button"

--- a/src/app/[locale]/studio/studio.shadow-styles.ts
+++ b/src/app/[locale]/studio/studio.shadow-styles.ts
@@ -681,6 +681,13 @@ a {
   gap: 0.75rem;
 }
 
+slot[name="studio-page-heading"] {
+  display: block;
+  flex: 0 1 auto;
+  max-width: clamp(8rem, 24vw, 18rem);
+  overflow: hidden;
+}
+
 .topbar-actions {
   gap: 0.5rem;
 }
@@ -975,7 +982,7 @@ a {
   gap: 1rem;
 }
 
-.route-heading h1 {
+.route-heading h2 {
   margin: 0.25rem 0 0;
   color: var(--foreground);
   font-size: 1.875rem;
@@ -1031,7 +1038,7 @@ a {
 }
 
 .route-panel h2,
-.auth-card h1,
+.auth-card h3,
 .invoice-paper strong,
 .kanban-column h2 {
   margin: 0;
@@ -1141,7 +1148,7 @@ a {
   font-weight: 600;
 }
 
-.welcome-intro h1 {
+.welcome-intro h2 {
   margin: 0.9rem 0 0;
   color: var(--foreground);
   font-size: clamp(2.35rem, 5vw, 4.5rem);
@@ -5445,7 +5452,7 @@ tbody tr:hover {
     min-width: 0;
   }
 
-  .route-heading h1 {
+  .route-heading h2 {
     font-size: 1.375rem;
     line-height: 1.15;
   }

--- a/src/app/global-not-found.tsx
+++ b/src/app/global-not-found.tsx
@@ -1,0 +1,162 @@
+import type { Metadata } from "next";
+import { SITE_URL } from "@/app/seo.config";
+import PostHogBootstrap from "@/components/analytics/PostHogBootstrap";
+import NotFoundRecovery from "@/components/not-found/NotFoundRecovery";
+
+export const metadata: Metadata = {
+  metadataBase: new URL(SITE_URL),
+  title: "Page not found | Nguyen Le Phong",
+  description:
+    "The requested page is not available. Continue to Nguyen Le Phong's localized writing, notes, or profile."
+};
+
+export default function GlobalNotFound() {
+  return (
+    <html lang="en" suppressHydrationWarning>
+      <head>
+        <meta charSet="utf-8" />
+        <meta name="viewport" content="width=device-width, initial-scale=1" />
+        <meta name="color-scheme" content="light dark" />
+        <link rel="preconnect" href="https://us.i.posthog.com" crossOrigin="" />
+        <link
+          rel="preconnect"
+          href="https://us-assets.i.posthog.com"
+          crossOrigin=""
+        />
+        <style>{`
+          :root { color-scheme: light dark; }
+          * { box-sizing: border-box; }
+          body {
+            min-height: 100vh;
+            margin: 0;
+            color: #20201d;
+            background:
+              radial-gradient(circle at 85% 12%, rgba(37, 99, 235, 0.09), transparent 28rem),
+              #f7f7f4;
+            font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+          }
+          a { color: inherit; }
+          .not-found {
+            width: min(70rem, 100%);
+            min-height: 100vh;
+            margin-inline: auto;
+            padding: clamp(2rem, 8vw, 7rem) clamp(1rem, 5vw, 3rem);
+          }
+          .not-found__card,
+          .not-found__languages {
+            border: 1px solid #deded8;
+            border-radius: 1.25rem;
+            background: rgba(255, 255, 255, 0.82);
+            box-shadow: 0 1.25rem 4rem rgba(42, 42, 36, 0.07);
+          }
+          .not-found__card { padding: clamp(1.5rem, 5vw, 4rem); }
+          .not-found__eyebrow {
+            margin: 0 0 1rem;
+            color: #5f5f58;
+            font-size: 0.78rem;
+            font-weight: 700;
+            letter-spacing: 0.12em;
+            text-transform: uppercase;
+          }
+          .not-found h1 {
+            max-width: 18ch;
+            margin: 0;
+            font-size: clamp(2.3rem, 7vw, 5.25rem);
+            font-weight: 650;
+            letter-spacing: -0.055em;
+            line-height: 0.98;
+          }
+          .not-found__description {
+            max-width: 46rem;
+            margin: 1.5rem 0 0;
+            color: #55554f;
+            font-size: clamp(1rem, 2vw, 1.15rem);
+            line-height: 1.7;
+          }
+          .not-found__actions {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.75rem;
+            margin-top: 2rem;
+          }
+          .not-found__actions a,
+          .not-found__languages a {
+            border: 1px solid #d5d5cf;
+            border-radius: 999px;
+            padding: 0.7rem 1rem;
+            font-weight: 650;
+            text-decoration: none;
+          }
+          .not-found__actions a:hover,
+          .not-found__languages a:hover { border-color: #2563eb; }
+          .not-found__actions a:focus-visible,
+          .not-found__languages a:focus-visible {
+            outline: 3px solid rgba(37, 99, 235, 0.38);
+            outline-offset: 3px;
+          }
+          .not-found__actions .not-found__primary {
+            border-color: #1d4ed8;
+            background: #1d4ed8;
+            color: #ffffff;
+          }
+          .not-found__languages {
+            display: grid;
+            grid-template-columns: minmax(0, 0.8fr) minmax(0, 1.2fr);
+            gap: 2rem;
+            margin-top: 1rem;
+            padding: clamp(1.25rem, 4vw, 2rem);
+          }
+          .not-found__languages h2 { margin: 0; font-size: 1.15rem; }
+          .not-found__languages p {
+            max-width: 34rem;
+            margin: 0.65rem 0 0;
+            color: #66665f;
+            line-height: 1.6;
+          }
+          .not-found__languages ul {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.6rem;
+            align-content: start;
+            margin: 0;
+            padding: 0;
+            list-style: none;
+          }
+          .not-found__languages a {
+            display: inline-flex;
+            align-items: center;
+            gap: 0.45rem;
+            padding: 0.55rem 0.8rem;
+            font-size: 0.9rem;
+          }
+          @media (max-width: 44rem) {
+            .not-found__languages { grid-template-columns: 1fr; gap: 1.25rem; }
+          }
+          @media (prefers-color-scheme: dark) {
+            body {
+              color: #f3f3ef;
+              background:
+                radial-gradient(circle at 85% 12%, rgba(96, 165, 250, 0.11), transparent 28rem),
+                #11110f;
+            }
+            .not-found__card,
+            .not-found__languages {
+              border-color: #383833;
+              background: rgba(27, 27, 24, 0.88);
+              box-shadow: none;
+            }
+            .not-found__eyebrow,
+            .not-found__description,
+            .not-found__languages p { color: #b6b6ae; }
+            .not-found__actions a,
+            .not-found__languages a { border-color: #4a4a43; }
+          }
+        `}</style>
+      </head>
+      <body>
+        <PostHogBootstrap locale="en" surface="not_found" />
+        <NotFoundRecovery />
+      </body>
+    </html>
+  );
+}

--- a/src/components/AppHeader.tsx
+++ b/src/components/AppHeader.tsx
@@ -46,10 +46,13 @@ export default function AppHeader() {
             onClick={() => track("cv_nav_click", { target: "home" })}
           >
             <Image
-              src="/icon.png"
+              src="/favicon/android-icon-72x72.png"
               alt="Nguyen Le Phong"
               width={36}
               height={36}
+              sizes="36px"
+              loading="eager"
+              fetchPriority="high"
               className="brand-avatar"
             />
             <span className="brand-text">Nguyen Le Phong</span>

--- a/src/components/LocaleSwitcher.tsx
+++ b/src/components/LocaleSwitcher.tsx
@@ -5,10 +5,28 @@ import { useRouter, usePathname } from '@/i18n/navigation'
 import { routing, LOCALE_LABELS, type Locale } from '@/i18n/routing'
 import { LuCheck, LuChevronDown } from 'react-icons/lu'
 import { track } from '@/lib/analytics'
+import {
+  localeSwitchPath,
+  type ContentLocaleRoute,
+} from '@/lib/content/locale-navigation'
 
 interface LocaleSwitcherProps {
   placement?: 'up' | 'down'
   compact?: boolean
+}
+
+function readContentLocaleRoute(): ContentLocaleRoute | null {
+  const element = document.querySelector<HTMLElement>('[data-content-locales]')
+  const fallbackPath = element?.dataset['contentLocaleFallback']
+  if (!element || !fallbackPath) return null
+
+  const availableLocales = (element.dataset['contentLocales'] ?? '')
+    .split(/\s+/)
+    .filter((locale): locale is Locale =>
+      routing.locales.includes(locale as Locale),
+    )
+
+  return { availableLocales, fallbackPath }
 }
 
 export default function LocaleSwitcher({
@@ -52,7 +70,10 @@ export default function LocaleSwitcher({
     track('locale_change', { from: currentLocale, to: nextLocale })
     setOpen(false)
     startTransition(() => {
-      router.replace(pathname, { locale: nextLocale })
+      router.replace(
+        localeSwitchPath(pathname, nextLocale, readContentLocaleRoute()),
+        { locale: nextLocale },
+      )
     })
   }
 

--- a/src/components/analytics/PageTracker.tsx
+++ b/src/components/analytics/PageTracker.tsx
@@ -13,12 +13,17 @@ export type PageType =
   | 'blog_category'
   | 'notes'
   | 'offline'
+  | 'not_found'
   | 'home_alt'
 
 interface PageTrackerProps {
   page: PageType
   /** Optional section grouping that rides along every event on this page. */
   section?: string
+  /** Stable, surface-specific context included with the initial page event. */
+  context?: Readonly<Record<string, unknown>>
+  /** Prevent potentially sensitive fallback URLs and referrers from being captured. */
+  omitLocation?: boolean
   /** Override the page_view event name (default: `page_view`). */
   eventName?:
     | 'page_view'
@@ -31,11 +36,18 @@ interface PageTrackerProps {
     | 'blog_category_view'
     | 'notes_view'
     | 'offline_view'
+    | 'not_found_view'
 }
 
 const SCROLL_BUCKETS = [25, 50, 75, 100] as const
 
-export default function PageTracker({ page, section, eventName = 'page_view' }: PageTrackerProps) {
+export default function PageTracker({
+  page,
+  section,
+  context,
+  omitLocation = false,
+  eventName = 'page_view',
+}: PageTrackerProps) {
   const startedAtRef = useRef<number>(0)
   const visibleMsRef = useRef<number>(0)
   const lastVisibleAtRef = useRef<number>(0)
@@ -49,18 +61,29 @@ export default function PageTracker({ page, section, eventName = 'page_view' }: 
     visibleMsRef.current = 0
     reportedRef.current = new Set()
     finalReportedRef.current = false
+    const trackOptions = omitLocation ? { omitLocation: true } : undefined
 
     registerPageContext({
+      ...context,
       page_type: page,
       page_section: section ?? null,
     })
 
-    track(eventName, {
-      page_type: page,
-      referrer: typeof document !== 'undefined' ? document.referrer || null : null,
-      screen_w: typeof window !== 'undefined' ? window.innerWidth : null,
-      screen_h: typeof window !== 'undefined' ? window.innerHeight : null,
-    })
+    track(
+      eventName,
+      {
+        ...context,
+        page_type: page,
+        ...(omitLocation
+          ? {}
+          : {
+              referrer: typeof document !== 'undefined' ? document.referrer || null : null,
+              screen_w: typeof window !== 'undefined' ? window.innerWidth : null,
+              screen_h: typeof window !== 'undefined' ? window.innerHeight : null,
+            }),
+      },
+      trackOptions,
+    )
 
     const onScroll = (): void => {
       const doc = document.documentElement
@@ -70,7 +93,7 @@ export default function PageTracker({ page, section, eventName = 'page_view' }: 
       for (const bucket of SCROLL_BUCKETS) {
         if (pct >= bucket && !reportedRef.current.has(bucket)) {
           reportedRef.current.add(bucket)
-          track('page_scroll_depth', { page_type: page, depth: bucket })
+          track('page_scroll_depth', { page_type: page, depth: bucket }, trackOptions)
         }
       }
     }
@@ -79,14 +102,18 @@ export default function PageTracker({ page, section, eventName = 'page_view' }: 
       const now = Date.now()
       if (document.visibilityState === 'hidden') {
         visibleMsRef.current += now - lastVisibleAtRef.current
-        track('page_visibility_change', {
-          page_type: page,
-          to: 'hidden',
-          visible_ms: visibleMsRef.current,
-        })
+        track(
+          'page_visibility_change',
+          {
+            page_type: page,
+            to: 'hidden',
+            visible_ms: visibleMsRef.current,
+          },
+          trackOptions,
+        )
       } else {
         lastVisibleAtRef.current = now
-        track('page_visibility_change', { page_type: page, to: 'visible' })
+        track('page_visibility_change', { page_type: page, to: 'visible' }, trackOptions)
       }
     }
 
@@ -100,11 +127,15 @@ export default function PageTracker({ page, section, eventName = 'page_view' }: 
         visibleMsRef.current += now - lastVisibleAtRef.current
         lastVisibleAtRef.current = now
       }
-      track('page_time_on_page', {
-        page_type: page,
-        total_ms: now - startedAtRef.current,
-        visible_ms: visibleMsRef.current,
-      })
+      track(
+        'page_time_on_page',
+        {
+          page_type: page,
+          total_ms: now - startedAtRef.current,
+          visible_ms: visibleMsRef.current,
+        },
+        trackOptions,
+      )
     }
 
     window.addEventListener('scroll', onScroll, { passive: true })
@@ -118,7 +149,7 @@ export default function PageTracker({ page, section, eventName = 'page_view' }: 
       window.removeEventListener('pagehide', reportTime)
       window.removeEventListener('beforeunload', reportTime)
     }
-  }, [page, section, eventName])
+  }, [page, section, context, omitLocation, eventName])
 
   return null
 }

--- a/src/components/analytics/PostHogBootstrap.tsx
+++ b/src/components/analytics/PostHogBootstrap.tsx
@@ -1,0 +1,36 @@
+import Script from "next/script";
+
+type PostHogBootstrapProps = {
+  locale: string;
+  surface?: "cv" | "not_found";
+};
+
+export default function PostHogBootstrap({
+  locale,
+  surface = "cv"
+}: PostHogBootstrapProps) {
+  const captureAutomaticPageLifecycle = surface !== "not_found";
+
+  return (
+    <Script
+      id="POSTHOG"
+      strategy="lazyOnload"
+      dangerouslySetInnerHTML={{
+        __html: `
+          !function(t,e){var o,n,p,r;e.__SV||(window.posthog=e,e._i=[],e.init=function(i,s,a){function g(t,e){var o=e.split(".");2==o.length&&(t=t[o[0]],e=o[1]),t[e]=function(){t.push([e].concat(Array.prototype.slice.call(arguments,0)))}}(p=t.createElement("script")).type="text/javascript",p.crossOrigin="anonymous",p.async=!0,p.src=s.api_host.replace(".i.posthog.com","-assets.i.posthog.com")+"/static/array.js",(r=t.getElementsByTagName("script")[0]).parentNode.insertBefore(p,r);var u=e;for(void 0!==a?u=e[a]=[]:a="posthog",u.people=u.people||[],u.toString=function(t){var e="posthog";return"posthog"!==a&&(e+="."+a),t||(e+=" (stub)"),e},u.people.toString=function(){return u.toString(1)+".people (stub)"},o="capture identify alias people.set people.set_once set_config register register_once unregister opt_out_capturing has_opted_out_capturing opt_in_capturing reset isFeatureEnabled onFeatureFlags".split(" "),n=0;n<o.length;n++)g(u,o[n]);e._i.push([i,s,a])},e.__SV=1)}(document,window.posthog||[]);
+          posthog.init('phc_Ti11bWc5cshVoQe8AI7SuY56FMFP7Fhc9WyymdOGVSw',{
+            api_host:'https://us.i.posthog.com',
+            defaults:'2026-01-30',
+            capture_pageview: ${JSON.stringify(captureAutomaticPageLifecycle)},
+            capture_pageleave: ${JSON.stringify(captureAutomaticPageLifecycle)},
+            autocapture: false,
+            disable_session_recording: true,
+            respect_dnt: true,
+            persistence: 'localStorage+cookie'
+          });
+          posthog.register({ site: 'nguyenlephong.github.io', surface: ${JSON.stringify(surface)}, locale: ${JSON.stringify(locale)} });
+        `
+      }}
+    />
+  );
+}

--- a/src/components/analytics/PostHogBootstrap.tsx
+++ b/src/components/analytics/PostHogBootstrap.tsx
@@ -5,11 +5,47 @@ type PostHogBootstrapProps = {
   surface?: "cv" | "not_found";
 };
 
+const NOT_FOUND_BEFORE_SEND = `function(captureResult) {
+  if (!captureResult || typeof captureResult !== 'object') return captureResult;
+
+  var isLocationKey = function(key) {
+    var normalized = String(key).replace(/^\\$/, '').toLowerCase();
+    return normalized === 'url' ||
+      normalized === 'path' ||
+      normalized === 'pathname' ||
+      normalized === 'referrer' ||
+      normalized === 'referring_domain' ||
+      normalized.endsWith('_url') ||
+      normalized.endsWith('_path') ||
+      normalized.endsWith('_pathname') ||
+      normalized.endsWith('_referrer') ||
+      normalized.endsWith('_referring_domain');
+  };
+
+  var scrub = function(value) {
+    if (Array.isArray(value)) return value.map(scrub);
+    if (!value || typeof value !== 'object') return value;
+
+    return Object.keys(value).reduce(function(safe, key) {
+      if (!isLocationKey(key)) safe[key] = scrub(value[key]);
+      return safe;
+    }, {});
+  };
+
+  return Object.assign({}, captureResult, {
+    properties: scrub(captureResult.properties)
+  });
+}`;
+
 export default function PostHogBootstrap({
   locale,
   surface = "cv"
 }: PostHogBootstrapProps) {
   const captureAutomaticPageLifecycle = surface !== "not_found";
+  const beforeSendConfig =
+    surface === "not_found"
+      ? `,\n            before_send: ${NOT_FOUND_BEFORE_SEND}`
+      : "";
 
   return (
     <Script
@@ -26,7 +62,7 @@ export default function PostHogBootstrap({
             autocapture: false,
             disable_session_recording: true,
             respect_dnt: true,
-            persistence: 'localStorage+cookie'
+            persistence: 'localStorage+cookie'${beforeSendConfig}
           });
           posthog.register({ site: 'nguyenlephong.github.io', surface: ${JSON.stringify(surface)}, locale: ${JSON.stringify(locale)} });
         `

--- a/src/components/analytics/WebVitalsReporter.tsx
+++ b/src/components/analytics/WebVitalsReporter.tsx
@@ -1,17 +1,45 @@
-'use client'
+"use client";
 
-import { useReportWebVitals } from 'next/web-vitals'
-import { track } from '@/lib/analytics'
+import { useCallback, useEffect, useRef } from "react";
+import { usePathname } from "next/navigation";
+import { useReportWebVitals } from "next/web-vitals";
+import { track } from "@/lib/analytics";
+import type { WebVitalAnalyticsPayload } from "@/lib/analytics";
+import { resolveWebVitalSurface } from "./web-vitals-context";
 
-export default function WebVitalsReporter() {
-  useReportWebVitals((metric) => {
-    track('web_vital', {
+type ReportWebVitalsCallback = Parameters<typeof useReportWebVitals>[0];
+
+type WebVitalsReporterProps = {
+  locale: string;
+};
+
+export default function WebVitalsReporter({ locale }: WebVitalsReporterProps) {
+  const pathname = usePathname();
+  const contextRef = useRef({ locale, pathname });
+
+  useEffect(() => {
+    contextRef.current = { locale, pathname };
+  }, [locale, pathname]);
+
+  const reportWebVitals = useCallback<ReportWebVitalsCallback>((metric) => {
+    const context = contextRef.current;
+    const path = window.location.pathname + window.location.search;
+
+    const payload = {
       name: metric.name,
-      value: Math.round(metric.value),
-      rating: (metric as { rating?: string }).rating,
+      value: metric.value,
+      delta: metric.delta,
+      rating: metric.rating,
       id: metric.id,
-      navigation_type: (metric as { navigationType?: string }).navigationType,
-    })
-  })
-  return null
+      navigation_type: metric.navigationType,
+      path,
+      surface: resolveWebVitalSurface(context.pathname),
+      locale: context.locale
+    } satisfies WebVitalAnalyticsPayload;
+
+    track("web_vital", payload);
+  }, []);
+
+  useReportWebVitals(reportWebVitals);
+  return null;
 }

--- a/src/components/analytics/web-vitals-context.ts
+++ b/src/components/analytics/web-vitals-context.ts
@@ -1,0 +1,7 @@
+export type WebVitalSurface = "site" | "studio";
+
+export function resolveWebVitalSurface(pathname: string): WebVitalSurface {
+  const [pathOnly] = pathname.split(/[?#]/, 1);
+  const segments = pathOnly.split("/").filter(Boolean);
+  return segments[1] === "studio" ? "studio" : "site";
+}

--- a/src/components/blog/BlogPostCard.tsx
+++ b/src/components/blog/BlogPostCard.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import { LuEye } from 'react-icons/lu'
-import { Link } from '@/i18n/navigation'
+import IntentPrefetchLink from '@/components/navigation/IntentPrefetchLink'
 import { track } from '@/lib/analytics'
 import type { BlogAccent } from '@/lib/blog/types'
 import type { BlogSearchItem } from '@/lib/content/search-index'
@@ -50,7 +50,7 @@ export default function BlogPostCard({
 }: BlogPostCardProps) {
   return (
     <article className={`blog-card blog-card--${accent}`}>
-      <Link
+      <IntentPrefetchLink
         href={`/blog/${post.category}/${post.slug}`}
         locale={contentLocale}
         className="blog-card__link"
@@ -82,7 +82,7 @@ export default function BlogPostCard({
             )}
           </div>
         </div>
-      </Link>
+      </IntentPrefetchLink>
     </article>
   )
 }

--- a/src/components/navigation/IntentPrefetchLink.tsx
+++ b/src/components/navigation/IntentPrefetchLink.tsx
@@ -1,0 +1,37 @@
+"use client";
+
+import { useState, type ComponentProps } from "react";
+import { Link } from "@/i18n/navigation";
+import { resolveIntentPrefetch } from "./intent-prefetch";
+
+export type IntentPrefetchLinkProps = Omit<
+  ComponentProps<typeof Link>,
+  "prefetch"
+>;
+
+/**
+ * Keeps large link collections quiet until keyboard or pointer intent is clear.
+ * `null` restores Next's native App Router prefetch policy for the active link.
+ */
+export default function IntentPrefetchLink({
+  onFocus,
+  onMouseEnter,
+  ...linkProps
+}: IntentPrefetchLinkProps) {
+  const [hasIntent, setHasIntent] = useState(false);
+
+  return (
+    <Link
+      {...linkProps}
+      prefetch={resolveIntentPrefetch(hasIntent)}
+      onFocus={(event) => {
+        onFocus?.(event);
+        if (!event.defaultPrevented) setHasIntent(true);
+      }}
+      onMouseEnter={(event) => {
+        onMouseEnter?.(event);
+        if (!event.defaultPrevented) setHasIntent(true);
+      }}
+    />
+  );
+}

--- a/src/components/navigation/intent-prefetch.ts
+++ b/src/components/navigation/intent-prefetch.ts
@@ -1,0 +1,5 @@
+export type IntentPrefetchMode = false | null;
+
+export function resolveIntentPrefetch(hasIntent: boolean): IntentPrefetchMode {
+  return hasIntent ? null : false;
+}

--- a/src/components/not-found/NotFoundRecovery.tsx
+++ b/src/components/not-found/NotFoundRecovery.tsx
@@ -1,0 +1,137 @@
+"use client";
+
+import { useEffect, useMemo, useSyncExternalStore } from "react";
+import PageTracker from "@/components/analytics/PageTracker";
+import { routing, LOCALE_LABELS, type Locale } from "@/i18n/routing";
+import { track } from "@/lib/analytics";
+import { getNotFoundCopy } from "./not-found-content";
+import {
+  DEFAULT_NOT_FOUND_CONTEXT,
+  orderedRecoveryTargets,
+  recoveryHref,
+  resolveNotFoundContext,
+  type RecoveryTarget
+} from "./not-found-routing";
+
+const SERVER_PATHNAME = "";
+
+function subscribeToPathname(onStoreChange: () => void) {
+  window.addEventListener("popstate", onStoreChange);
+  return () => window.removeEventListener("popstate", onStoreChange);
+}
+
+function getBrowserPathname() {
+  return window.location.pathname;
+}
+
+function getServerPathname() {
+  return SERVER_PATHNAME;
+}
+
+export default function NotFoundRecovery() {
+  const pathname = useSyncExternalStore(
+    subscribeToPathname,
+    getBrowserPathname,
+    getServerPathname
+  );
+  const ready = pathname !== SERVER_PATHNAME;
+  const context = ready
+    ? resolveNotFoundContext(pathname)
+    : DEFAULT_NOT_FOUND_CONTEXT;
+  const copy = getNotFoundCopy(context.locale);
+  const analyticsContext = useMemo(
+    () => ({
+      detected_locale: context.locale,
+      requested_surface: context.surface
+    }),
+    [context.locale, context.surface]
+  );
+
+  useEffect(() => {
+    if (!ready) return;
+    document.documentElement.lang = context.locale;
+    document.title = copy.metaTitle;
+  }, [context.locale, copy.metaTitle, ready]);
+
+  const trackRecovery = (
+    target: RecoveryTarget | "language_home",
+    selectedLocale?: Locale
+  ) => {
+    track(
+      "not_found_recovery_click",
+      {
+        target,
+        detected_locale: context.locale,
+        requested_surface: context.surface,
+        selected_locale: selectedLocale ?? null
+      },
+      { omitLocation: true }
+    );
+  };
+
+  return (
+    <main
+      className="not-found"
+      data-not-found-locale={context.locale}
+      data-not-found-surface={context.surface}
+      data-not-found-ready={ready ? "true" : "false"}
+    >
+      {ready && (
+        <PageTracker
+          page="not_found"
+          eventName="not_found_view"
+          section={context.surface}
+          context={analyticsContext}
+          omitLocation
+        />
+      )}
+
+      <section className="not-found__card" aria-labelledby="not-found-title">
+        <p className="not-found__eyebrow">404 · {copy.eyebrow}</p>
+        <h1 id="not-found-title">{copy.title}</h1>
+        <p className="not-found__description">
+          {copy.descriptions[context.surface]}
+        </p>
+
+        <nav className="not-found__actions" aria-label={copy.recoveryLabel}>
+          {orderedRecoveryTargets(context.surface).map((target, index) => (
+            <a
+              key={target}
+              className={index === 0 ? "not-found__primary" : undefined}
+              href={recoveryHref(context.locale, target)}
+              data-not-found-target={target}
+              onClick={() => trackRecovery(target)}
+            >
+              {copy.actions[target]}
+            </a>
+          ))}
+        </nav>
+      </section>
+
+      <section
+        className="not-found__languages"
+        aria-labelledby="not-found-language-title"
+      >
+        <div>
+          <h2 id="not-found-language-title">{copy.languageTitle}</h2>
+          <p>{copy.languageDescription}</p>
+        </div>
+        <ul>
+          {routing.locales.map((locale) => (
+            <li key={locale}>
+              <a
+                href={`/${locale}`}
+                hrefLang={locale}
+                lang={locale}
+                onClick={() => trackRecovery("language_home", locale)}
+              >
+                <span aria-hidden="true">{LOCALE_LABELS[locale].flag}</span>
+                {LOCALE_LABELS[locale].name}
+              </a>
+            </li>
+          ))}
+        </ul>
+      </section>
+    </main>
+  );
+}

--- a/src/components/not-found/not-found-content.ts
+++ b/src/components/not-found/not-found-content.ts
@@ -1,0 +1,146 @@
+import type { Locale } from "@/i18n/routing";
+import type { NotFoundSurface, RecoveryTarget } from "./not-found-routing";
+
+export type NotFoundCopy = {
+  metaTitle: string;
+  eyebrow: string;
+  title: string;
+  descriptions: Record<NotFoundSurface, string>;
+  recoveryLabel: string;
+  actions: Record<RecoveryTarget, string>;
+  languageTitle: string;
+  languageDescription: string;
+};
+
+const contentByLocale: Record<Locale, NotFoundCopy> = {
+  en: {
+    metaTitle: "Page not found | Nguyen Le Phong",
+    eyebrow: "Page not found",
+    title: "This page is no longer here",
+    descriptions: {
+      blog: "This article may not be available in the language you chose. The blog archive is a quiet place to continue browsing.",
+      notes:
+        "This note may not be available in the language you chose. You can return to the notes archive and continue from there.",
+      other:
+        "The address may be old, incomplete, or no longer part of this site. The links below will take you somewhere useful."
+    },
+    recoveryLabel: "Ways to continue",
+    actions: {
+      home: "Go to the home page",
+      blog: "Browse the blog",
+      notes: "Browse the notes"
+    },
+    languageTitle: "Choose another language",
+    languageDescription:
+      "Each language link returns to a stable home page, so you can continue without another broken path."
+  },
+  vi: {
+    metaTitle: "Không tìm thấy trang | Nguyen Le Phong",
+    eyebrow: "Không tìm thấy trang",
+    title: "Trang này hiện không còn ở đây",
+    descriptions: {
+      blog: "Bài viết này có thể chưa có ở ngôn ngữ bạn đã chọn. Bạn có thể quay lại trang blog để tiếp tục đọc.",
+      notes:
+        "Ghi chú này có thể chưa có ở ngôn ngữ bạn đã chọn. Trang notes sẽ giúp bạn tiếp tục từ một đường dẫn ổn định.",
+      other:
+        "Địa chỉ này có thể đã cũ, chưa đầy đủ hoặc không còn thuộc website. Những liên kết bên dưới sẽ đưa bạn về nơi phù hợp."
+    },
+    recoveryLabel: "Các hướng để tiếp tục",
+    actions: {
+      home: "Về trang chủ",
+      blog: "Xem các bài blog",
+      notes: "Xem các ghi chú"
+    },
+    languageTitle: "Chọn ngôn ngữ khác",
+    languageDescription:
+      "Mỗi lựa chọn sẽ đưa bạn về một trang chủ ổn định để tránh gặp thêm đường dẫn hỏng."
+  },
+  zh: {
+    metaTitle: "找不到页面 | Nguyen Le Phong",
+    eyebrow: "找不到页面",
+    title: "这个页面目前不在这里",
+    descriptions: {
+      blog: "这篇文章可能还没有你所选择的语言版本。你可以回到博客归档，继续浏览其他内容。",
+      notes:
+        "这篇笔记可能还没有你所选择的语言版本。你可以回到笔记归档，从稳定的页面继续。",
+      other:
+        "这个地址可能已经过期、不完整，或不再属于本站。下面的链接可以带你回到可用的页面。"
+    },
+    recoveryLabel: "继续浏览",
+    actions: {
+      home: "返回首页",
+      blog: "浏览博客",
+      notes: "浏览笔记"
+    },
+    languageTitle: "选择其他语言",
+    languageDescription:
+      "每个语言链接都会返回稳定的首页，避免再次进入失效地址。"
+  },
+  ja: {
+    metaTitle: "ページが見つかりません | Nguyen Le Phong",
+    eyebrow: "ページが見つかりません",
+    title: "このページは現在ここにありません",
+    descriptions: {
+      blog: "この記事は、選択した言語ではまだ公開されていない可能性があります。ブログ一覧から、ほかの記事を落ち着いて探せます。",
+      notes:
+        "このノートは、選択した言語ではまだ公開されていない可能性があります。ノート一覧の安定したページから続けられます。",
+      other:
+        "このアドレスは古い、不完全、または現在のサイトに存在しない可能性があります。下のリンクから利用できるページへ戻れます。"
+    },
+    recoveryLabel: "次に進む方法",
+    actions: {
+      home: "ホームへ戻る",
+      blog: "ブログを見る",
+      notes: "ノートを見る"
+    },
+    languageTitle: "別の言語を選ぶ",
+    languageDescription:
+      "各言語のリンクは安定したホームページへ戻るため、別の壊れたリンクを避けられます。"
+  },
+  ko: {
+    metaTitle: "페이지를 찾을 수 없습니다 | Nguyen Le Phong",
+    eyebrow: "페이지를 찾을 수 없습니다",
+    title: "이 페이지는 현재 여기에 없습니다",
+    descriptions: {
+      blog: "이 글은 선택한 언어로 아직 제공되지 않을 수 있습니다. 블로그 목록으로 돌아가 다른 글을 천천히 살펴볼 수 있습니다.",
+      notes:
+        "이 노트는 선택한 언어로 아직 제공되지 않을 수 있습니다. 노트 목록의 안정적인 경로에서 계속 둘러볼 수 있습니다.",
+      other:
+        "주소가 오래되었거나 완전하지 않거나 현재 사이트에 없는 경로일 수 있습니다. 아래 링크에서 이용 가능한 페이지로 돌아갈 수 있습니다."
+    },
+    recoveryLabel: "계속 둘러보기",
+    actions: {
+      home: "홈으로 돌아가기",
+      blog: "블로그 보기",
+      notes: "노트 보기"
+    },
+    languageTitle: "다른 언어 선택",
+    languageDescription:
+      "각 언어 링크는 안정적인 홈으로 연결되어 또 다른 잘못된 경로를 피할 수 있습니다."
+  },
+  fr: {
+    metaTitle: "Page introuvable | Nguyen Le Phong",
+    eyebrow: "Page introuvable",
+    title: "Cette page n’est plus disponible ici",
+    descriptions: {
+      blog: "Cet article n’est peut-être pas encore disponible dans la langue choisie. Les archives du blog permettent de poursuivre la lecture simplement.",
+      notes:
+        "Cette note n’est peut-être pas encore disponible dans la langue choisie. Vous pouvez revenir aux archives des notes et continuer depuis une page stable.",
+      other:
+        "Cette adresse est peut-être ancienne, incomplète ou absente du site actuel. Les liens ci-dessous vous ramèneront vers une page utile."
+    },
+    recoveryLabel: "Continuer la visite",
+    actions: {
+      home: "Revenir à l’accueil",
+      blog: "Parcourir le blog",
+      notes: "Parcourir les notes"
+    },
+    languageTitle: "Choisir une autre langue",
+    languageDescription:
+      "Chaque langue renvoie vers une page d’accueil stable afin d’éviter un autre lien incomplet."
+  }
+};
+
+export function getNotFoundCopy(locale: Locale): NotFoundCopy {
+  return contentByLocale[locale];
+}

--- a/src/components/not-found/not-found-routing.ts
+++ b/src/components/not-found/not-found-routing.ts
@@ -1,0 +1,48 @@
+import { routing, type Locale } from "@/i18n/routing";
+
+export type NotFoundSurface = "blog" | "notes" | "other";
+export type RecoveryTarget = "home" | "blog" | "notes";
+
+export type NotFoundContext = {
+  locale: Locale;
+  surface: NotFoundSurface;
+};
+
+export const DEFAULT_NOT_FOUND_CONTEXT: NotFoundContext = {
+  locale: routing.defaultLocale,
+  surface: "other"
+};
+
+export function resolveNotFoundContext(pathname: string): NotFoundContext {
+  const [pathOnly] = pathname.split(/[?#]/, 1);
+  const segments = pathOnly.split("/").filter(Boolean);
+  const requestedLocale = segments[0];
+  const hasSupportedLocale = routing.locales.some(
+    (locale) => locale === requestedLocale
+  );
+  const locale = hasSupportedLocale
+    ? (requestedLocale as Locale)
+    : routing.defaultLocale;
+  const routeSegment = hasSupportedLocale ? segments[1] : segments[0];
+  const surface: NotFoundSurface =
+    routeSegment === "blog"
+      ? "blog"
+      : routeSegment === "notes"
+        ? "notes"
+        : "other";
+
+  return { locale, surface };
+}
+
+export function orderedRecoveryTargets(
+  surface: NotFoundSurface
+): RecoveryTarget[] {
+  if (surface === "blog") return ["blog", "notes", "home"];
+  if (surface === "notes") return ["notes", "blog", "home"];
+  return ["home", "blog", "notes"];
+}
+
+export function recoveryHref(locale: Locale, target: RecoveryTarget): string {
+  if (target === "home") return `/${locale}`;
+  return `/${locale}/${target}`;
+}

--- a/src/components/notes/NoteCard.tsx
+++ b/src/components/notes/NoteCard.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { LuEye } from "react-icons/lu";
-import { Link } from "@/i18n/navigation";
+import IntentPrefetchLink from "@/components/navigation/IntentPrefetchLink";
 import { track } from "@/lib/analytics";
 import { formatCount } from "@/lib/firebase/postStats";
 import type { NoteSearchItem } from "@/lib/content/search-index";
@@ -52,7 +52,7 @@ export default function NoteCard({
       className="blog-card"
       style={{ "--blog-accent": topicColor } as React.CSSProperties}
     >
-      <Link
+      <IntentPrefetchLink
         href={`/notes/${note.slug}`}
         locale={contentLocale}
         className="blog-card__link"
@@ -85,7 +85,7 @@ export default function NoteCard({
             )}
           </div>
         </div>
-      </Link>
+      </IntentPrefetchLink>
     </article>
   );
 }

--- a/src/components/studio-kit/shadow-island.tsx
+++ b/src/components/studio-kit/shadow-island.tsx
@@ -6,11 +6,12 @@ import { createPortal } from "react-dom";
 type ShadowIslandProps = {
   children: ReactNode;
   fallback?: ReactNode;
+  heading: ReactNode;
   styles: string;
   label?: string;
 };
 
-export function ShadowIsland({ children, fallback = null, styles, label }: ShadowIslandProps) {
+export function ShadowIsland({ children, fallback = null, heading, styles, label }: ShadowIslandProps) {
   const hostRef = useRef<HTMLDivElement>(null);
   const [root, setRoot] = useState<ShadowRoot | null>(null);
 
@@ -28,8 +29,10 @@ export function ShadowIsland({ children, fallback = null, styles, label }: Shado
       ref={hostRef}
       aria-label={label}
       data-studio-shadow-host=""
+      data-shadow-ready={root ? "true" : "false"}
       style={{ display: "block", minHeight: "100vh" }}
     >
+      {heading}
       {root
         ? createPortal(
             <>

--- a/src/lib/analytics.ts
+++ b/src/lib/analytics.ts
@@ -97,6 +97,9 @@ export type AnalyticsEvent =
   | 'offline_mode_ready'
   | 'offline_status_change'
   | 'offline_banner_dismiss'
+  // Not found recovery
+  | 'not_found_view'
+  | 'not_found_recovery_click'
   // Studio
   | 'studio_view'
   | 'studio_route_open'
@@ -128,9 +131,23 @@ export type AnalyticsEvent =
   // Outbound
   | 'outbound_click'
 
+export type WebVitalAnalyticsPayload = {
+  name: string
+  value: number
+  delta: number
+  rating: string
+  id: string
+  navigation_type: string
+  path: string
+  surface: 'site' | 'studio'
+  locale: string
+}
+
 export interface TrackOptions {
   /** When true, posthog will flush immediately (used for outbound nav). */
   beacon?: boolean
+  /** Omit the browser URL for surfaces where the requested path may contain secrets. */
+  omitLocation?: boolean
 }
 
 function safePath(): string {
@@ -157,8 +174,12 @@ export function track(
   try {
     const payload: Record<string, unknown> = {
       ts: Date.now(),
-      path: safePath(),
-      pathname: window.location.pathname,
+      ...(options?.omitLocation
+        ? {}
+        : {
+            path: safePath(),
+            pathname: window.location.pathname,
+          }),
       ...props,
     }
     if (options?.beacon) payload['$set_once'] = { last_outbound_ts: Date.now() }

--- a/src/lib/analytics.ts
+++ b/src/lib/analytics.ts
@@ -1,14 +1,18 @@
 declare global {
   interface Window {
-    posthog?: {
-      capture: (event: string, props?: Record<string, unknown>) => void
-      identify: (id: string, props?: Record<string, unknown>) => void
-      register: (props: Record<string, unknown>) => void
-      register_once?: (props: Record<string, unknown>) => void
-      set_config?: (props: Record<string, unknown>) => void
-    }
+    posthog?: PostHogClient
   }
 }
+
+type PostHogClient = {
+  capture: (event: string, props?: Record<string, unknown>) => void
+  identify: (id: string, props?: Record<string, unknown>) => void
+  register: (props: Record<string, unknown>) => void
+  register_once?: (props: Record<string, unknown>) => void
+  set_config?: (props: Record<string, unknown>) => void
+}
+
+type PostHogQueue = PostHogClient & Array<unknown>
 
 export type AnalyticsEvent =
   // CV (legacy + still in use)
@@ -164,10 +168,31 @@ function isDoNotTrack(): boolean {
   return dnt === '1' || dnt === 'yes'
 }
 
+/**
+ * Queue explicit events immediately, even when the lazy PostHog bootstrap has
+ * not run yet. The official loader consumes this same array once initialized.
+ */
+function ensurePostHogClient(): PostHogClient {
+  if (window.posthog) return window.posthog
+
+  const queue = [] as unknown as PostHogQueue
+  queue.capture = (event, props) => {
+    queue.push(['capture', event, props])
+  }
+  queue.identify = (id, props) => {
+    queue.push(['identify', id, props])
+  }
+  queue.register = (props) => {
+    queue.push(['register', props])
+  }
+  window.posthog = queue
+  return queue
+}
+
 export function track(
   event: AnalyticsEvent | string,
   props?: Record<string, unknown>,
-  options?: TrackOptions
+  options?: TrackOptions,
 ): void {
   if (typeof window === 'undefined') return
   if (isDoNotTrack()) return
@@ -183,7 +208,7 @@ export function track(
       ...props,
     }
     if (options?.beacon) payload['$set_once'] = { last_outbound_ts: Date.now() }
-    window.posthog?.capture(event, payload)
+    ensurePostHogClient().capture(event, payload)
   } catch {
     // swallow — analytics must never break UX
   }
@@ -193,7 +218,7 @@ export function track(
 export function registerPageContext(props: Record<string, unknown>): void {
   if (typeof window === 'undefined') return
   try {
-    window.posthog?.register(props)
+    ensurePostHogClient().register(props)
   } catch {
     // ignore
   }

--- a/src/lib/blog/data.ts
+++ b/src/lib/blog/data.ts
@@ -182,6 +182,21 @@ export function getPostContentLocales(slug: string): BlogPostMeta['locales'] {
   return post ? [...post.locales] : []
 }
 
+/** Authored article routes only; untranslated locale paths must not be exported. */
+export function listBlogPostParams(): Array<{
+  locale: Locale
+  category: string
+  slug: string
+}> {
+  return baseIndex().posts.flatMap((post) =>
+    post.locales.map((locale) => ({
+      locale,
+      category: post.category,
+      slug: post.slug,
+    })),
+  )
+}
+
 /** Canonical category slugs — drives static-param generation. */
 export function listCategorySlugs(): string[] {
   return baseIndex().categories.map((c) => c.slug)

--- a/src/lib/content/locale-navigation.ts
+++ b/src/lib/content/locale-navigation.ts
@@ -1,0 +1,23 @@
+import type { Locale } from "@/i18n/routing";
+
+export interface ContentLocaleRoute {
+  availableLocales: readonly Locale[];
+  fallbackPath: string;
+}
+
+/**
+ * Keep the article URL only when the selected locale has authored content.
+ * Otherwise, switch to that locale's collection instead of fabricating a
+ * non-canonical article route.
+ */
+export function localeSwitchPath(
+  pathname: string,
+  nextLocale: Locale,
+  contentRoute: ContentLocaleRoute | null
+): string {
+  if (!contentRoute || contentRoute.availableLocales.includes(nextLocale)) {
+    return pathname;
+  }
+
+  return contentRoute.fallbackPath;
+}

--- a/src/lib/notes/data.ts
+++ b/src/lib/notes/data.ts
@@ -1,5 +1,5 @@
 import path from "node:path";
-import { routing, type Locale } from "@/i18n/routing";
+import type { Locale } from "@/i18n/routing";
 import {
   byDateDesc,
   overlayByKey,
@@ -143,16 +143,13 @@ export function getTopicReadingContext(
 }
 
 /** (locale, slug) pairs for static generation — one per locale a note serves. */
-export function listNoteParams(): Array<{ locale: string; slug: string }> {
-  const posts = baseIndex().posts;
-  const out: Array<{ locale: string; slug: string }> = [];
-  for (const locale of routing.locales) {
-    const eff = contentLocale(locale);
-    for (const p of posts) {
-      if (noteLocales().includes(eff)) out.push({ locale, slug: p.slug });
-    }
-  }
-  return out;
+export function listNoteParams(): Array<{ locale: Locale; slug: string }> {
+  return baseIndex().posts.flatMap((note) =>
+    (note.locales ?? [note.baseLocale ?? "en"]).map((locale) => ({
+      locale,
+      slug: note.slug
+    }))
+  );
 }
 
 /** Loads a single note, overlaying the Vietnamese body when serving `vi`. */

--- a/tests/analytics-tracking.test.mjs
+++ b/tests/analytics-tracking.test.mjs
@@ -1,6 +1,19 @@
 import assert from "node:assert/strict";
 import { readFile } from "node:fs/promises";
 import test from "node:test";
+import ts from "typescript";
+
+async function importTypeScript(source) {
+  const output = ts.transpileModule(source, {
+    compilerOptions: {
+      module: ts.ModuleKind.ESNext,
+      target: ts.ScriptTarget.ES2022
+    }
+  }).outputText;
+  return import(
+    `data:text/javascript;base64,${Buffer.from(output).toString("base64")}`
+  );
+}
 
 test("posthog initialization uses the current sdk host contract", async () => {
   const [layout, bootstrap] = await Promise.all([
@@ -16,7 +29,54 @@ test("posthog initialization uses the current sdk host contract", async () => {
   assert.match(bootstrap, /autocapture:\s*false/);
   assert.match(bootstrap, /disable_session_recording:\s*true/);
   assert.match(bootstrap, /respect_dnt:\s*true/);
+  assert.match(bootstrap, /before_send:/);
+  assert.match(bootstrap, /normalized\.endsWith\('_url'\)/);
   assert.doesNotMatch(bootstrap, /api_host:'https:\/\/app\.posthog\.com'/);
+});
+
+test("analytics queues events before the lazy PostHog bootstrap", async () => {
+  const analyticsSource = await readFile("src/lib/analytics.ts", "utf8");
+  const originalWindow = Object.getOwnPropertyDescriptor(globalThis, "window");
+  const originalNavigator = Object.getOwnPropertyDescriptor(
+    globalThis,
+    "navigator"
+  );
+
+  Object.defineProperty(globalThis, "window", {
+    configurable: true,
+    value: {
+      location: { pathname: "/en/blog", search: "?page=2" }
+    }
+  });
+  Object.defineProperty(globalThis, "navigator", {
+    configurable: true,
+    value: { doNotTrack: "0" }
+  });
+
+  try {
+    const analytics = await importTypeScript(analyticsSource);
+    analytics.registerPageContext({ page_type: "blog" });
+    analytics.track("blog_view", { section: "index" });
+
+    assert.equal(Array.isArray(window.posthog), true);
+    assert.deepEqual(window.posthog[0], ["register", { page_type: "blog" }]);
+    assert.equal(window.posthog[1][0], "capture");
+    assert.equal(window.posthog[1][1], "blog_view");
+    assert.equal(window.posthog[1][2].path, "/en/blog?page=2");
+    assert.equal(window.posthog[1][2].pathname, "/en/blog");
+    assert.equal(window.posthog[1][2].section, "index");
+  } finally {
+    if (originalWindow) {
+      Object.defineProperty(globalThis, "window", originalWindow);
+    } else {
+      delete globalThis.window;
+    }
+    if (originalNavigator) {
+      Object.defineProperty(globalThis, "navigator", originalNavigator);
+    } else {
+      delete globalThis.navigator;
+    }
+  }
 });
 
 test("public content surfaces have explicit posthog page and interaction events", async () => {
@@ -107,11 +167,17 @@ test("public content surfaces have explicit posthog page and interaction events"
   assert.match(blogIndex, /BlogCollectionPage/);
   assert.match(blogCollection, /page="blog"/);
   assert.match(blogCollection, /eventName="blog_view"/);
-  assert.match(blogCategory, /PageTracker page="blog_category" eventName="blog_category_view"/);
+  assert.match(
+    blogCategory,
+    /PageTracker page="blog_category" eventName="blog_category_view"/
+  );
   assert.match(notesIndex, /NotesCollectionPage/);
   assert.match(notesCollection, /page="notes"/);
   assert.match(notesCollection, /eventName="notes_view"/);
-  assert.match(offlinePage, /PageTracker page="offline" eventName="offline_view"/);
+  assert.match(
+    offlinePage,
+    /PageTracker page="offline" eventName="offline_view"/
+  );
 
   assert.match(blogArticle, /surface="blog"/);
   assert.match(noteArticle, /surface="notes"/);
@@ -180,8 +246,14 @@ test("studio analytics and agent rules cover new workspace interactions", async 
     assert.match(adminShell, new RegExp(`"${eventName}"`));
   }
 
-  assert.match(adminShell, /onActivate\(subItem\.routeId \?\? DEFAULT_ROUTE, "sidebar"\)/);
-  assert.match(adminShell, /onActivate\(item\.routeId \?\? DEFAULT_ROUTE, "sidebar"\)/);
+  assert.match(
+    adminShell,
+    /onActivate\(subItem\.routeId \?\? DEFAULT_ROUTE, "sidebar"\)/
+  );
+  assert.match(
+    adminShell,
+    /onActivate\(item\.routeId \?\? DEFAULT_ROUTE, "sidebar"\)/
+  );
   assert.match(adminShell, /onActivate\(route\.id, "command"\)/);
   assert.match(adminShell, /source:\s*"route_actions"/);
   assert.match(adminShell, /source:\s*"sidebar_profile_grid"/);

--- a/tests/analytics-tracking.test.mjs
+++ b/tests/analytics-tracking.test.mjs
@@ -3,16 +3,20 @@ import { readFile } from "node:fs/promises";
 import test from "node:test";
 
 test("posthog initialization uses the current sdk host contract", async () => {
-  const layout = await readFile("src/app/[locale]/layout.tsx", "utf8");
+  const [layout, bootstrap] = await Promise.all([
+    readFile("src/app/[locale]/layout.tsx", "utf8"),
+    readFile("src/components/analytics/PostHogBootstrap.tsx", "utf8")
+  ]);
 
   assert.match(layout, /https:\/\/us\.i\.posthog\.com/);
   assert.match(layout, /https:\/\/us-assets\.i\.posthog\.com/);
-  assert.match(layout, /defaults:'2026-01-30'/);
-  assert.match(layout, /crossOrigin="anonymous"/);
-  assert.match(layout, /autocapture:\s*false/);
-  assert.match(layout, /disable_session_recording:\s*true/);
-  assert.match(layout, /respect_dnt:\s*true/);
-  assert.doesNotMatch(layout, /api_host:'https:\/\/app\.posthog\.com'/);
+  assert.match(layout, /<PostHogBootstrap locale=\{locale\} \/>/);
+  assert.match(bootstrap, /defaults:'2026-01-30'/);
+  assert.match(bootstrap, /crossOrigin="anonymous"/);
+  assert.match(bootstrap, /autocapture:\s*false/);
+  assert.match(bootstrap, /disable_session_recording:\s*true/);
+  assert.match(bootstrap, /respect_dnt:\s*true/);
+  assert.doesNotMatch(bootstrap, /api_host:'https:\/\/app\.posthog\.com'/);
 });
 
 test("public content surfaces have explicit posthog page and interaction events", async () => {

--- a/tests/authored-content-static-export.test.mjs
+++ b/tests/authored-content-static-export.test.mjs
@@ -137,7 +137,7 @@ test('locale switching never fabricates an untranslated article path', () => {
   assert.equal(localeSwitchPath('/about', 'zh', null), '/about')
 })
 
-test('article pages and locale control keep the static-routing contract wired', async () => {
+test('article pages keep production static params while development resolves them on demand', async () => {
   const [blogPage, notePage, localeSwitcher] = await Promise.all([
     readFile('src/app/[locale]/(site)/blog/[category]/[slug]/page.tsx', 'utf8'),
     readFile('src/app/[locale]/(site)/notes/[slug]/page.tsx', 'utf8'),
@@ -145,7 +145,11 @@ test('article pages and locale control keep the static-routing contract wired', 
   ])
 
   for (const page of [blogPage, notePage]) {
-    assert.match(page, /export const dynamicParams = false/)
+    assert.match(
+      page,
+      /generateStaticParams\(\) \{\s+if \(process\.env\.NODE_ENV === ["']development["']\) return \[\]/,
+    )
+    assert.doesNotMatch(page, /export const dynamicParams = false/)
     assert.match(page, /data-content-locales/)
     assert.match(page, /data-content-locale-fallback/)
   }

--- a/tests/authored-content-static-export.test.mjs
+++ b/tests/authored-content-static-export.test.mjs
@@ -1,0 +1,164 @@
+import assert from 'node:assert/strict'
+import { existsSync, readFileSync } from 'node:fs'
+import { readFile } from 'node:fs/promises'
+import { registerHooks } from 'node:module'
+import path from 'node:path'
+import test from 'node:test'
+import { fileURLToPath, pathToFileURL } from 'node:url'
+
+const extensionCandidates = ['.ts', '.tsx', '.js', '.mjs']
+
+function resolveWithProjectExtensions(url) {
+  const basePath = fileURLToPath(url)
+  if (existsSync(basePath)) return url.href
+
+  for (const extension of extensionCandidates) {
+    const candidate = `${basePath}${extension}`
+    if (existsSync(candidate)) return pathToFileURL(candidate).href
+  }
+
+  for (const extension of extensionCandidates) {
+    const candidate = path.join(basePath, `index${extension}`)
+    if (existsSync(candidate)) return pathToFileURL(candidate).href
+  }
+
+  return null
+}
+
+registerHooks({
+  resolve(specifier, context, nextResolve) {
+    if (specifier.startsWith('@/')) {
+      const resolved = resolveWithProjectExtensions(
+        new URL(`../src/${specifier.slice(2)}`, import.meta.url),
+      )
+      if (resolved) return { url: resolved, shortCircuit: true }
+    }
+
+    if (
+      context.parentURL?.startsWith('file:') &&
+      (specifier.startsWith('./') || specifier.startsWith('../'))
+    ) {
+      const resolved = resolveWithProjectExtensions(
+        new URL(specifier, context.parentURL),
+      )
+      if (resolved) return { url: resolved, shortCircuit: true }
+    }
+
+    return nextResolve(specifier, context)
+  },
+})
+
+const { getPostContentLocales, listBlogPostParams } = await import(
+  new URL('../src/lib/blog/data.ts', import.meta.url)
+)
+const { getNoteContentLocales, listNoteParams } = await import(
+  new URL('../src/lib/notes/data.ts', import.meta.url)
+)
+const { localeSwitchPath } = await import(
+  new URL('../src/lib/content/locale-navigation.ts', import.meta.url)
+)
+const { default: buildSitemap } = await import(
+  new URL('../src/app/sitemap.ts', import.meta.url)
+)
+
+function readJson(relativePath) {
+  return JSON.parse(readFileSync(new URL(relativePath, import.meta.url), 'utf8'))
+}
+
+test('article static params contain authored locale routes only', () => {
+  const blogIndex = readJson('../public/blog-data/_index.json')
+  const notesIndex = readJson('../public/notes-data/_index.json')
+  const blogParams = listBlogPostParams()
+  const noteParams = listNoteParams()
+  const expectedBlogRoutes = blogIndex.posts.reduce(
+    (total, post) => total + post.locales.length,
+    0,
+  )
+  const expectedNoteRoutes = notesIndex.posts.reduce(
+    (total, note) => total + note.locales.length,
+    0,
+  )
+
+  assert.equal(blogParams.length, expectedBlogRoutes)
+  assert.equal(noteParams.length, expectedNoteRoutes)
+  assert.equal(new Set(blogParams.map((param) => JSON.stringify(param))).size, blogParams.length)
+  assert.equal(new Set(noteParams.map((param) => JSON.stringify(param))).size, noteParams.length)
+
+  for (const param of blogParams) {
+    assert.ok(getPostContentLocales(param.slug).includes(param.locale))
+  }
+  for (const param of noteParams) {
+    assert.ok(getNoteContentLocales(param.slug).includes(param.locale))
+  }
+
+  assert.ok(blogParams.length < blogIndex.posts.length * 6)
+  assert.ok(noteParams.length < notesIndex.posts.length * 6)
+})
+
+test('sitemap article URLs equal generated authored routes', () => {
+  const sitemapUrls = new Set(buildSitemap().map((entry) => entry.url))
+
+  for (const param of listBlogPostParams()) {
+    assert.ok(
+      sitemapUrls.has(
+        `https://nguyenlephong.github.io/${param.locale}/blog/${param.category}/${param.slug}`,
+      ),
+    )
+  }
+
+  for (const param of listNoteParams()) {
+    assert.ok(
+      sitemapUrls.has(
+        `https://nguyenlephong.github.io/${param.locale}/notes/${param.slug}`,
+      ),
+    )
+  }
+
+  assert.equal(
+    sitemapUrls.has(
+      'https://nguyenlephong.github.io/zh/blog/architecture/rate-limiting-and-throttling',
+    ),
+    false,
+  )
+  assert.equal(
+    sitemapUrls.has(
+      'https://nguyenlephong.github.io/zh/notes/tri-tue-can-duc-hanh',
+    ),
+    false,
+  )
+})
+
+test('locale switching never fabricates an untranslated article path', () => {
+  const route = { availableLocales: ['en', 'vi'], fallbackPath: '/blog' }
+  const pathname = '/blog/architecture/rate-limiting-and-throttling'
+
+  assert.equal(localeSwitchPath(pathname, 'vi', route), pathname)
+  assert.equal(localeSwitchPath(pathname, 'zh', route), '/blog')
+  assert.equal(localeSwitchPath('/about', 'zh', null), '/about')
+})
+
+test('article pages and locale control keep the static-routing contract wired', async () => {
+  const [blogPage, notePage, localeSwitcher] = await Promise.all([
+    readFile('src/app/[locale]/(site)/blog/[category]/[slug]/page.tsx', 'utf8'),
+    readFile('src/app/[locale]/(site)/notes/[slug]/page.tsx', 'utf8'),
+    readFile('src/components/LocaleSwitcher.tsx', 'utf8'),
+  ])
+
+  for (const page of [blogPage, notePage]) {
+    assert.match(page, /export const dynamicParams = false/)
+    assert.match(page, /data-content-locales/)
+    assert.match(page, /data-content-locale-fallback/)
+  }
+  assert.match(blogPage, /return listBlogPostParams\(\)/)
+  assert.match(notePage, /return listNoteParams\(\)/)
+  assert.match(localeSwitcher, /localeSwitchPath/)
+  assert.match(localeSwitcher, /track\('locale_change'/)
+})
+
+test('artifact budgets are rebased below the previous near-limit output', () => {
+  const budget = readJson('../config/static-artifact-budgets.json')
+
+  assert.equal(budget.warnAtPercent, 75)
+  assert.equal(budget.limits.fileCount, 20_000)
+  assert.equal(budget.limits.totalBytes, 600 * 1024 * 1024)
+})

--- a/tests/content-list-loading-performance.test.mjs
+++ b/tests/content-list-loading-performance.test.mjs
@@ -1,0 +1,66 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import test from "node:test";
+import ts from "typescript";
+
+async function importTypeScriptModule(path) {
+  const source = await readFile(path, "utf8");
+  const { outputText } = ts.transpileModule(source, {
+    compilerOptions: {
+      module: ts.ModuleKind.ESNext,
+      target: ts.ScriptTarget.ES2022
+    }
+  });
+  const encoded = Buffer.from(outputText).toString("base64");
+  return import(`data:text/javascript;base64,${encoded}`);
+}
+
+test("intent prefetch stays disabled until a link receives intent", async () => {
+  const { resolveIntentPrefetch } = await importTypeScriptModule(
+    "src/components/navigation/intent-prefetch.ts"
+  );
+
+  assert.equal(resolveIntentPrefetch(false), false);
+  assert.equal(resolveIntentPrefetch(true), null);
+});
+
+test("article cards use the shared intent link without losing analytics", async () => {
+  const [link, blogCard, noteCard] = await Promise.all([
+    readFile("src/components/navigation/IntentPrefetchLink.tsx", "utf8"),
+    readFile("src/components/blog/BlogPostCard.tsx", "utf8"),
+    readFile("src/components/notes/NoteCard.tsx", "utf8")
+  ]);
+
+  assert.match(link, /ComponentProps<typeof Link>/);
+  assert.match(link, /"prefetch"/);
+  assert.match(link, /prefetch=\{resolveIntentPrefetch\(hasIntent\)\}/);
+  assert.match(link, /onFocus=\{\(event\) =>/);
+  assert.match(link, /onMouseEnter=\{\(event\) =>/);
+  assert.doesNotMatch(link, /onClick=/);
+  assert.doesNotMatch(link, /onTouchStart=/);
+
+  for (const [card, eventName] of [
+    [blogCard, "blog_card_click"],
+    [noteCard, "notes_card_click"]
+  ]) {
+    assert.match(card, /IntentPrefetchLink/);
+    assert.match(card, /onClick=\{\(\) =>/);
+    assert.match(card, new RegExp(`track\\(["']${eventName}["']`));
+  }
+});
+
+test("header eagerly loads the small display icon and preserves the app icon", async () => {
+  const [header, appIcon] = await Promise.all([
+    readFile("src/components/AppHeader.tsx", "utf8"),
+    readFile("src/app/icon.png")
+  ]);
+
+  assert.match(header, /src="\/favicon\/android-icon-72x72\.png"/);
+  assert.match(header, /width=\{36\}/);
+  assert.match(header, /height=\{36\}/);
+  assert.match(header, /sizes="36px"/);
+  assert.match(header, /loading="eager"/);
+  assert.match(header, /fetchPriority="high"/);
+  assert.doesNotMatch(header, /src="\/icon\.png"/);
+  assert.ok(appIcon.byteLength > 0);
+});

--- a/tests/deployment-workflow.test.mjs
+++ b/tests/deployment-workflow.test.mjs
@@ -85,6 +85,13 @@ test('CI verifies offline browser behavior after its single smoke build', () => 
   assert.match(ciWorkflow, /npx playwright install --with-deps chromium/)
 })
 
+test('CI and deploy workflows gate concurrent clean-cache development startup', () => {
+  assert.equal(pkg.scripts['verify:dev-concurrency'], 'node scripts/verify-dev-concurrency.mjs')
+  for (const currentWorkflow of [workflow, ciWorkflow]) {
+    assert.match(currentWorkflow, /run: npm run verify:dev-concurrency/)
+  }
+})
+
 test('workflows use Node 24 action majors instead of deprecated Node 20 runtimes', () => {
   for (const currentWorkflow of [workflow, ciWorkflow]) {
     assert.doesNotMatch(currentWorkflow, /uses: actions\/(?:checkout|setup-node)@v4/)

--- a/tests/not-found-recovery.test.mjs
+++ b/tests/not-found-recovery.test.mjs
@@ -1,0 +1,192 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import test from "node:test";
+import ts from "typescript";
+
+async function importTypeScript(source) {
+  const output = ts.transpileModule(source, {
+    compilerOptions: {
+      module: ts.ModuleKind.ESNext,
+      target: ts.ScriptTarget.ES2022
+    }
+  }).outputText;
+  return import(
+    `data:text/javascript;base64,${Buffer.from(output).toString("base64")}`
+  );
+}
+
+test("global not-found uses one static document with safe SEO metadata", async () => {
+  const [config, globalNotFound, recovery, routingSource, postbuild, spec] =
+    await Promise.all([
+      readFile("next.config.mjs", "utf8"),
+      readFile("src/app/global-not-found.tsx", "utf8"),
+      readFile("src/components/not-found/NotFoundRecovery.tsx", "utf8"),
+      readFile("src/components/not-found/not-found-routing.ts", "utf8"),
+      readFile("scripts/postbuild-offline.mjs", "utf8"),
+      readFile("specs/static-not-found-recovery.md", "utf8")
+    ]);
+
+  assert.match(config, /experimental:\s*\{[\s\S]*globalNotFound:\s*true/);
+  assert.match(globalNotFound, /<html lang="en" suppressHydrationWarning>/);
+  assert.match(globalNotFound, /metadataBase: new URL\(SITE_URL\)/);
+  assert.doesNotMatch(
+    globalNotFound,
+    /robots:\s*\{/,
+    'Next should emit its automatic noindex once for the 404 response',
+  );
+  assert.doesNotMatch(globalNotFound, /canonical|alternates/);
+  assert.match(
+    globalNotFound,
+    /<PostHogBootstrap locale="en" surface="not_found"/
+  );
+
+  assert.equal((recovery.match(/<h1\b/g) ?? []).length, 1);
+  assert.match(recovery, /window\.location\.pathname/);
+  assert.match(recovery, /document\.documentElement\.lang = context\.locale/);
+  assert.match(recovery, /page="not_found"/);
+  assert.match(recovery, /eventName="not_found_view"/);
+  assert.match(recovery, /omitLocation/);
+  assert.match(recovery, /track\(\s*"not_found_recovery_click"/);
+  assert.match(recovery, /routing\.locales\.map/);
+  assert.match(recovery, /aria-label=\{copy\.recoveryLabel\}/);
+  assert.doesNotMatch(recovery, /from ["']next\/link["']|prefetch=/);
+
+  assert.match(routingSource, /routing\.locales\.some/);
+  assert.match(routingSource, /routing\.defaultLocale/);
+  assert.match(routingSource, /return `\/\$\{locale\}`/);
+  assert.match(routingSource, /return `\/\$\{locale\}\/\$\{target\}`/);
+  assert.match(postbuild, /relativePath === '404\.html'/);
+  assert.match(spec, /AC-404-006/);
+});
+
+test("not-found route detection keeps locale and surface recovery bounded", async () => {
+  const source = await readFile(
+    "src/components/not-found/not-found-routing.ts",
+    "utf8"
+  );
+  const executable = source.replace(
+    /import \{ routing, type Locale \} from [^\n]+\n/,
+    "const routing = { locales: ['en', 'vi', 'zh', 'ja', 'ko', 'fr'], defaultLocale: 'en' }\n"
+  );
+  const routingModule = await importTypeScript(executable);
+
+  assert.deepEqual(routingModule.resolveNotFoundContext("/zh/blog/old-slug"), {
+    locale: "zh",
+    surface: "blog"
+  });
+  assert.deepEqual(routingModule.resolveNotFoundContext("/fr/notes/ancien"), {
+    locale: "fr",
+    surface: "notes"
+  });
+  assert.deepEqual(routingModule.resolveNotFoundContext("/es/blog/missing"), {
+    locale: "en",
+    surface: "other"
+  });
+  assert.deepEqual(routingModule.resolveNotFoundContext("/blog/missing?x=1"), {
+    locale: "en",
+    surface: "blog"
+  });
+  assert.deepEqual(routingModule.orderedRecoveryTargets("notes"), [
+    "notes",
+    "blog",
+    "home"
+  ]);
+
+  for (const locale of ["en", "vi", "zh", "ja", "ko", "fr"]) {
+    assert.equal(routingModule.recoveryHref(locale, "home"), `/${locale}`);
+    assert.equal(routingModule.recoveryHref(locale, "blog"), `/${locale}/blog`);
+    assert.equal(
+      routingModule.recoveryHref(locale, "notes"),
+      `/${locale}/notes`
+    );
+  }
+});
+
+test("every supported locale has calm and complete recovery copy", async () => {
+  const source = await readFile(
+    "src/components/not-found/not-found-content.ts",
+    "utf8"
+  );
+  const contentModule = await importTypeScript(source);
+
+  for (const locale of ["en", "vi", "zh", "ja", "ko", "fr"]) {
+    const copy = contentModule.getNotFoundCopy(locale);
+    assert.ok(copy.metaTitle.length > 12);
+    assert.ok(copy.title.length > 8);
+    assert.ok(copy.recoveryLabel.length > 2);
+    assert.ok(copy.languageTitle.length > 2);
+    assert.ok(copy.languageDescription.length > 12);
+    for (const surface of ["blog", "notes", "other"]) {
+      assert.ok(copy.descriptions[surface].length > 24);
+    }
+    for (const target of ["home", "blog", "notes"]) {
+      assert.ok(copy.actions[target].length > 3);
+    }
+  }
+
+  assert.doesNotMatch(source, /oops|uh[- ]oh|you entered|your mistake/i);
+});
+
+test("not-found analytics shares the existing privacy-safe bootstrap", async () => {
+  const [layout, globalNotFound, bootstrap, tracker, analytics] =
+    await Promise.all([
+      readFile("src/app/[locale]/layout.tsx", "utf8"),
+      readFile("src/app/global-not-found.tsx", "utf8"),
+      readFile("src/components/analytics/PostHogBootstrap.tsx", "utf8"),
+      readFile("src/components/analytics/PageTracker.tsx", "utf8"),
+      readFile("src/lib/analytics.ts", "utf8")
+    ]);
+
+  assert.match(layout, /<PostHogBootstrap locale=\{locale\} \/>/);
+  assert.match(
+    globalNotFound,
+    /<PostHogBootstrap locale="en" surface="not_found" \/>/
+  );
+  assert.equal((layout.match(/posthog\.init/g) ?? []).length, 0);
+  assert.equal((globalNotFound.match(/posthog\.init/g) ?? []).length, 0);
+  assert.equal((bootstrap.match(/posthog\.init/g) ?? []).length, 1);
+  assert.match(bootstrap, /defaults:'2026-01-30'/);
+  assert.match(bootstrap, /autocapture:\s*false/);
+  assert.match(bootstrap, /disable_session_recording:\s*true/);
+  assert.match(bootstrap, /respect_dnt:\s*true/);
+  assert.match(bootstrap, /persistence:\s*'localStorage\+cookie'/);
+  assert.match(
+    bootstrap,
+    /captureAutomaticPageLifecycle = surface !== "not_found"/
+  );
+  assert.match(
+    bootstrap,
+    /capture_pageview: \$\{JSON\.stringify\(captureAutomaticPageLifecycle\)\}/
+  );
+  assert.match(
+    bootstrap,
+    /capture_pageleave: \$\{JSON\.stringify\(captureAutomaticPageLifecycle\)\}/
+  );
+  assert.match(tracker, /\| 'not_found'/);
+  assert.match(tracker, /\| 'not_found_view'/);
+  assert.match(tracker, /context\?: Readonly<Record<string, unknown>>/);
+  assert.match(tracker, /omitLocation\?: boolean/);
+  assert.match(tracker, /const trackOptions = omitLocation/);
+  assert.match(analytics, /\| 'not_found_view'/);
+  assert.match(analytics, /\| 'not_found_recovery_click'/);
+  assert.match(analytics, /omitLocation\?: boolean/);
+  assert.match(analytics, /options\?\.omitLocation/);
+});
+
+test("CI verifies the generated not-found document in a browser", async () => {
+  const [packageJson, deployWorkflow, ciWorkflow] = await Promise.all([
+    readFile("package.json", "utf8"),
+    readFile(".github/workflows/nextjs.yml", "utf8"),
+    readFile(".github/workflows/ci-frontend.yml", "utf8")
+  ]);
+  const scripts = JSON.parse(packageJson).scripts;
+
+  assert.equal(
+    scripts["verify:not-found"],
+    "node scripts/verify-static-not-found.mjs"
+  );
+  for (const workflow of [deployWorkflow, ciWorkflow]) {
+    assert.match(workflow, /Verify localized 404 recovery/);
+    assert.match(workflow, /npm run verify:not-found/);
+  }
+});

--- a/tests/not-found-recovery.test.mjs
+++ b/tests/not-found-recovery.test.mjs
@@ -26,7 +26,10 @@ test("global not-found uses one static document with safe SEO metadata", async (
       readFile("specs/static-not-found-recovery.md", "utf8")
     ]);
 
-  assert.match(config, /experimental:\s*\{[\s\S]*globalNotFound:\s*true/);
+  assert.match(
+    config,
+    /experimental:\s*\{[\s\S]*globalNotFound:\s*!isDevelopment/
+  );
   assert.match(globalNotFound, /<html lang="en" suppressHydrationWarning>/);
   assert.match(globalNotFound, /metadataBase: new URL\(SITE_URL\)/);
   assert.doesNotMatch(

--- a/tests/seo-field-data-monitoring.test.mjs
+++ b/tests/seo-field-data-monitoring.test.mjs
@@ -9,6 +9,7 @@ import {
   collectCrux,
   collectSearchConsole,
   collectSeoFieldData,
+  compareCanonicalUrls,
   compareSearchAnalytics,
   evaluateSeoHealth,
   exchangeServiceAccountToken,
@@ -135,6 +136,7 @@ test("Search Console requests stay aggregate and reports discard sensitive dimen
       });
     }
     if (url === ENDPOINTS.urlInspection) {
+      const { inspectionUrl } = JSON.parse(init.body);
       return jsonResponse({
         inspectionResult: {
           indexStatusResult: {
@@ -144,8 +146,8 @@ test("Search Console requests stay aggregate and reports discard sensitive dimen
             pageFetchState: "SUCCESSFUL",
             robotsTxtState: "ALLOWED",
             lastCrawlTime: "2026-07-12T01:02:03Z",
-            googleCanonical: "https://nguyenlephong.github.io/en",
-            userCanonical: "https://nguyenlephong.github.io/en",
+            googleCanonical: inspectionUrl,
+            userCanonical: inspectionUrl,
             referringUrls: ["https://private.example/referrer"]
           }
         }
@@ -184,6 +186,15 @@ test("Search Console requests stay aggregate and reports discard sensitive dimen
   assert.equal(report.inspections.length, 4);
   assert.equal(
     report.inspections.every((item) => item.canonicalMatches),
+    true
+  );
+  assert.equal(
+    report.inspections.every(
+      (item) =>
+        item.canonicalAgreement &&
+        item.googleMatchesExpected &&
+        item.userMatchesExpected
+    ),
     true
   );
 
@@ -358,6 +369,22 @@ test("health is action-required for aggregate drops, sitemap defects, URL failur
   );
 });
 
+test("matching Google and user canonicals still fail when they target the wrong page", () => {
+  assert.deepEqual(
+    compareCanonicalUrls(
+      "https://nguyenlephong.github.io/en",
+      "https://nguyenlephong.github.io/en/",
+      "https://nguyenlephong.github.io/en/blog"
+    ),
+    {
+      canonicalAgreement: true,
+      googleMatchesExpected: false,
+      userMatchesExpected: false,
+      canonicalMatches: false
+    }
+  );
+});
+
 test("missing page-level CrUX stays unknown without becoming healthy or actionable", () => {
   const { searchConsole, crux } = healthyObservedData();
   crux.availability = "partial";
@@ -486,6 +513,7 @@ test("workflow is standalone, weekly, manual, read-only, and action-requiring", 
   assert.match(workflow, /schedule:/);
   assert.match(workflow, /cron: '17 5 \* \* 2'/);
   assert.match(workflow, /workflow_dispatch:/);
+  assert.match(workflow, /if: github\.ref == 'refs\/heads\/main'/);
   assert.match(workflow, /permissions:\n  contents: read/);
   assert.match(workflow, /persist-credentials: false/);
   assert.doesNotMatch(workflow, /continue-on-error/);

--- a/tests/seo-field-data-monitoring.test.mjs
+++ b/tests/seo-field-data-monitoring.test.mjs
@@ -1,0 +1,508 @@
+import assert from "node:assert/strict";
+import { generateKeyPairSync } from "node:crypto";
+import { readFile } from "node:fs/promises";
+import { spawnSync } from "node:child_process";
+import test from "node:test";
+
+import {
+  ENDPOINTS,
+  collectCrux,
+  collectSearchConsole,
+  collectSeoFieldData,
+  compareSearchAnalytics,
+  evaluateSeoHealth,
+  exchangeServiceAccountToken,
+  renderMarkdown,
+  searchDateRange
+} from "../scripts/monitor-seo-field-data.mjs";
+
+const config = JSON.parse(
+  await readFile("config/seo-field-monitoring.json", "utf8")
+);
+
+function jsonResponse(value, status = 200) {
+  return new Response(JSON.stringify(value), {
+    status,
+    headers: { "content-type": "application/json" }
+  });
+}
+
+function historyRecord({ lcp = "2400", inp = "180", cls = "0.08" } = {}) {
+  return {
+    record: {
+      collectionPeriods: [
+        {
+          firstDate: { year: 2026, month: 6, day: 12 },
+          lastDate: { year: 2026, month: 7, day: 9 }
+        }
+      ],
+      metrics: {
+        largest_contentful_paint: {
+          percentilesTimeseries: { p75s: [lcp] }
+        },
+        interaction_to_next_paint: {
+          percentilesTimeseries: { p75s: [inp] }
+        },
+        cumulative_layout_shift: {
+          percentilesTimeseries: { p75s: [cls] }
+        }
+      }
+    }
+  };
+}
+
+function healthyObservedData() {
+  return {
+    searchConsole: {
+      availability: "observed",
+      analytics: {
+        availability: "observed",
+        current: { availability: "observed", impressions: 900 },
+        prior: { availability: "observed", impressions: 1_000 },
+        comparison: { status: "within_threshold" }
+      },
+      sitemap: {
+        availability: "observed",
+        errors: 0,
+        warnings: 0,
+        pending: false
+      },
+      inspections: [
+        {
+          label: "home",
+          availability: "observed",
+          verdict: "PASS",
+          pageFetchState: "SUCCESSFUL",
+          indexingState: "INDEXING_ALLOWED",
+          robotsTxtState: "ALLOWED",
+          canonicalMatches: true
+        }
+      ]
+    },
+    crux: {
+      availability: "observed",
+      targets: [
+        {
+          label: "origin",
+          kind: "origin",
+          availability: "observed",
+          metrics: {
+            lcp: { p75: 2_400, rating: "good" },
+            inp: { p75: 180, rating: "good" },
+            cls: { p75: 0.08, rating: "good" }
+          }
+        }
+      ]
+    }
+  };
+}
+
+test("Search Console requests stay aggregate and reports discard sensitive dimensions", async () => {
+  const calls = [];
+  const fetchImpl = async (input, init = {}) => {
+    const url = String(input);
+    calls.push({ url, init });
+
+    if (url.endsWith("/searchAnalytics/query")) {
+      const body = JSON.parse(init.body);
+      const currentWindow = body.endDate === "2026-07-14";
+      return jsonResponse({
+        rows: [
+          {
+            keys: ["private-query-that-must-not-survive"],
+            clicks: currentWindow ? 42 : 60,
+            impressions: currentWindow ? 900 : 1_400,
+            ctr: currentWindow ? 0.0467 : 0.0429,
+            position: currentWindow ? 8.25 : 7.8
+          }
+        ],
+        responseAggregationType: "byProperty"
+      });
+    }
+    if (url.endsWith("/sitemaps")) {
+      return jsonResponse({
+        sitemap: [
+          {
+            path: config.searchConsole.sitemapUrl,
+            isPending: false,
+            errors: null,
+            warnings: "1",
+            lastSubmitted: "2026-07-10T01:02:03Z",
+            lastDownloaded: "2026-07-11T01:02:03Z",
+            contents: [{ type: "web", submitted: "904", indexed: "700" }]
+          }
+        ]
+      });
+    }
+    if (url === ENDPOINTS.urlInspection) {
+      return jsonResponse({
+        inspectionResult: {
+          indexStatusResult: {
+            verdict: "PASS",
+            coverageState: "Submitted and indexed",
+            indexingState: "INDEXING_ALLOWED",
+            pageFetchState: "SUCCESSFUL",
+            robotsTxtState: "ALLOWED",
+            lastCrawlTime: "2026-07-12T01:02:03Z",
+            googleCanonical: "https://nguyenlephong.github.io/en",
+            userCanonical: "https://nguyenlephong.github.io/en",
+            referringUrls: ["https://private.example/referrer"]
+          }
+        }
+      });
+    }
+    throw new Error(`Unexpected mocked URL: ${url}`);
+  };
+
+  const report = await collectSearchConsole(config.searchConsole, {
+    fetchImpl,
+    accessToken: "access-token-secret",
+    now: new Date("2026-07-17T05:17:00Z")
+  });
+
+  assert.equal(report.availability, "observed");
+  assert.deepEqual(
+    {
+      startDate: report.analytics.current.startDate,
+      endDate: report.analytics.current.endDate
+    },
+    { startDate: "2026-06-17", endDate: "2026-07-14" }
+  );
+  assert.deepEqual(
+    {
+      startDate: report.analytics.prior.startDate,
+      endDate: report.analytics.prior.endDate
+    },
+    { startDate: "2026-05-20", endDate: "2026-06-16" }
+  );
+  assert.equal(report.analytics.current.impressions, 900);
+  assert.equal(report.analytics.prior.impressions, 1_400);
+  assert.equal(report.analytics.comparison.status, "drop_detected");
+  assert.equal(report.analytics.comparison.impressionDropPercent, 35.7);
+  assert.equal(report.sitemap.errors, null);
+  assert.equal(report.sitemap.warnings, 1);
+  assert.equal(report.inspections.length, 4);
+  assert.equal(
+    report.inspections.every((item) => item.canonicalMatches),
+    true
+  );
+
+  const analyticsCalls = calls.filter((call) =>
+    call.url.endsWith("/searchAnalytics/query")
+  );
+  assert.equal(analyticsCalls.length, 2);
+  assert.deepEqual(
+    analyticsCalls
+      .map((call) => JSON.parse(call.init.body))
+      .map((body) => ({
+        startDate: body.startDate,
+        endDate: body.endDate
+      })),
+    [
+      { startDate: "2026-06-17", endDate: "2026-07-14" },
+      { startDate: "2026-05-20", endDate: "2026-06-16" }
+    ]
+  );
+  for (const analyticsCall of analyticsCalls) {
+    assert.equal(
+      analyticsCall.url,
+      `${ENDPOINTS.searchConsole}/sites/${encodeURIComponent(config.searchConsole.property)}/searchAnalytics/query`
+    );
+    const analyticsBody = JSON.parse(analyticsCall.init.body);
+    assert.deepEqual(
+      {
+        type: analyticsBody.type,
+        dataState: analyticsBody.dataState,
+        aggregationType: analyticsBody.aggregationType,
+        rowLimit: analyticsBody.rowLimit
+      },
+      {
+        type: "web",
+        dataState: "final",
+        aggregationType: "byProperty",
+        rowLimit: 1
+      }
+    );
+    assert.equal(Object.hasOwn(analyticsBody, "dimensions"), false);
+    assert.equal(Object.hasOwn(analyticsBody, "dimensionFilterGroups"), false);
+    assert.equal(
+      analyticsCall.init.headers.authorization,
+      "Bearer access-token-secret"
+    );
+  }
+
+  const serialized = JSON.stringify(report);
+  assert.doesNotMatch(
+    serialized,
+    /private-query|private\.example|access-token-secret/
+  );
+  assert.doesNotMatch(
+    serialized,
+    /googleCanonical|userCanonical|referringUrls/
+  );
+});
+
+test("CrUX History observes origin and pages while preserving missing data as unknown", async () => {
+  const apiKey = "crux-api-key-secret";
+  const calls = [];
+  const fetchImpl = async (input, init = {}) => {
+    const url = String(input);
+    const body = JSON.parse(init.body);
+    calls.push({ url, body });
+    if (body.url === config.crux.pages[1].url) {
+      return jsonResponse({ error: { message: "not found" } }, 404);
+    }
+    if (body.url === config.crux.pages[0].url) {
+      return jsonResponse(historyRecord({ inp: null }));
+    }
+    return jsonResponse(historyRecord());
+  };
+
+  const report = await collectCrux(config.crux, { fetchImpl, apiKey });
+
+  assert.equal(report.availability, "partial");
+  assert.equal(report.targets.length, 1 + config.crux.pages.length);
+  assert.equal(report.targets[0].kind, "origin");
+  assert.equal(report.targets[0].metrics.lcp.rating, "good");
+  assert.equal(report.targets[0].metrics.inp.rating, "good");
+  assert.equal(report.targets[0].metrics.cls.rating, "good");
+  assert.deepEqual(report.targets[1].metrics.inp, {
+    p75: null,
+    rating: "unknown"
+  });
+  assert.equal(report.targets[1].availability, "partial");
+  assert.equal(report.targets[2].availability, "unknown");
+  assert.equal(report.targets[2].reason, "no_data");
+
+  for (const call of calls) {
+    const url = new URL(call.url);
+    assert.equal(url.origin + url.pathname, ENDPOINTS.cruxHistory);
+    assert.equal(url.searchParams.get("key"), apiKey);
+    assert.equal(call.body.formFactor, "PHONE");
+    assert.equal(call.body.collectionPeriodCount, 8);
+    assert.deepEqual(call.body.metrics, config.crux.metrics);
+    assert.equal(
+      Object.hasOwn(call.body, "origin") !== Object.hasOwn(call.body, "url"),
+      true
+    );
+  }
+  assert.doesNotMatch(JSON.stringify(report), new RegExp(apiKey));
+});
+
+test("service-account exchange uses readonly JWT OAuth without exposing credentials", async () => {
+  const { privateKey } = generateKeyPairSync("rsa", { modulusLength: 2048 });
+  const serviceAccountJson = JSON.stringify({
+    client_email: "seo-monitor@example.iam.gserviceaccount.com",
+    private_key: privateKey.export({ format: "pem", type: "pkcs8" })
+  });
+  let tokenRequest;
+  const fetchImpl = async (input, init) => {
+    tokenRequest = { url: String(input), init };
+    return jsonResponse({ access_token: "short-lived-token" });
+  };
+
+  const token = await exchangeServiceAccountToken(serviceAccountJson, {
+    fetchImpl,
+    now: new Date("2026-07-17T05:17:00Z")
+  });
+
+  assert.equal(token, "short-lived-token");
+  assert.equal(tokenRequest.url, ENDPOINTS.oauthToken);
+  const form = new URLSearchParams(tokenRequest.init.body);
+  assert.equal(
+    form.get("grant_type"),
+    "urn:ietf:params:oauth:grant-type:jwt-bearer"
+  );
+  const assertion = form.get("assertion");
+  assert.equal(assertion.split(".").length, 3);
+  const claims = JSON.parse(
+    Buffer.from(assertion.split(".")[1], "base64url").toString("utf8")
+  );
+  assert.equal(
+    claims.scope,
+    "https://www.googleapis.com/auth/webmasters.readonly"
+  );
+  assert.equal(claims.aud, ENDPOINTS.oauthToken);
+  assert.equal(claims.exp - claims.iat, 3600);
+});
+
+test("health is action-required for aggregate drops, sitemap defects, URL failures, and poor CWV", () => {
+  const { searchConsole, crux } = healthyObservedData();
+  searchConsole.analytics.comparison.status = "drop_detected";
+  searchConsole.sitemap.errors = 2;
+  searchConsole.sitemap.warnings = 1;
+  Object.assign(searchConsole.inspections[0], {
+    verdict: "FAIL",
+    pageFetchState: "SERVER_ERROR",
+    indexingState: "BLOCKED_BY_META_TAG",
+    canonicalMatches: false
+  });
+  crux.targets[0].metrics.lcp = { p75: 4_500, rating: "poor" };
+
+  const health = evaluateSeoHealth(searchConsole, crux);
+
+  assert.equal(health.status, "action_required");
+  assert.equal(health.actionRequired, true);
+  assert.deepEqual(
+    [
+      "search_analytics_impressions_drop",
+      "sitemap_errors_present",
+      "sitemap_warnings_present",
+      "url_inspection_home_index_verdict",
+      "url_inspection_home_fetch",
+      "url_inspection_home_indexing",
+      "url_inspection_home_canonical_mismatch",
+      "crux_origin_lcp_poor"
+    ].every((issue) => health.issues.includes(issue)),
+    true
+  );
+});
+
+test("missing page-level CrUX stays unknown without becoming healthy or actionable", () => {
+  const { searchConsole, crux } = healthyObservedData();
+  crux.availability = "partial";
+  crux.targets.push({
+    label: "studio",
+    kind: "url",
+    availability: "unknown",
+    reason: "no_data"
+  });
+
+  const health = evaluateSeoHealth(searchConsole, crux);
+
+  assert.equal(health.status, "unknown");
+  assert.equal(health.actionRequired, false);
+  assert.deepEqual(health.issues, []);
+  assert.deepEqual(health.unknowns, ["crux_url_studio_no_data"]);
+});
+
+test("CrUX authentication or API failures are action-required and sanitized", async () => {
+  const apiKey = "must-not-survive";
+  const { searchConsole } = healthyObservedData();
+  const crux = await collectCrux(config.crux, {
+    apiKey,
+    fetchImpl: async () => jsonResponse({ error: "credential detail" }, 403)
+  });
+
+  const health = evaluateSeoHealth(searchConsole, crux);
+
+  assert.equal(health.status, "action_required");
+  assert.equal(health.actionRequired, true);
+  assert.equal(
+    health.issues.some((issue) => issue.endsWith("http_403")),
+    true
+  );
+  assert.doesNotMatch(
+    JSON.stringify({ crux, health }),
+    /must-not-survive|credential detail/
+  );
+});
+
+test("impression drops below the documented prior-volume baseline are not alerts", () => {
+  const comparison = compareSearchAnalytics(
+    { availability: "observed", impressions: 0 },
+    { availability: "observed", impressions: 199 },
+    config.searchConsole
+  );
+
+  assert.equal(comparison.status, "insufficient_baseline");
+  assert.equal(comparison.impressionChangePercent, null);
+  assert.equal(comparison.minimumPriorImpressions, 200);
+
+  const boundary = compareSearchAnalytics(
+    { availability: "observed", impressions: 700 },
+    { availability: "observed", impressions: 1_000 },
+    config.searchConsole
+  );
+  assert.equal(boundary.impressionDropPercent, 30);
+  assert.equal(boundary.status, "drop_detected");
+});
+
+test("missing required credentials are action-required without making requests", async () => {
+  let requested = false;
+  const report = await collectSeoFieldData(config, {
+    env: {},
+    now: new Date("2026-07-17T05:17:00Z"),
+    fetchImpl: async () => {
+      requested = true;
+      throw new Error("should not be called");
+    }
+  });
+
+  assert.equal(requested, false);
+  assert.equal(report.availability, "unknown");
+  assert.equal(report.health.status, "action_required");
+  assert.equal(report.health.actionRequired, true);
+  assert.equal(
+    report.health.issues.includes("search_console_credentials_missing"),
+    true
+  );
+  assert.equal(report.health.issues.includes("crux_api_key_missing"), true);
+  assert.deepEqual(report.searchConsole, {
+    availability: "skipped",
+    reason: "credentials_missing"
+  });
+  assert.deepEqual(report.crux, {
+    availability: "skipped",
+    reason: "api_key_missing"
+  });
+  assert.match(renderMarkdown(report), /SEO health: \*\*action_required\*\*/);
+  assert.match(renderMarkdown(report), /Action required: \*\*yes\*\*/);
+});
+
+test("CLI exits non-zero with a sanitized action-required report when secrets are missing", () => {
+  const env = { ...process.env };
+  delete env.GOOGLE_SEARCH_CONSOLE_SERVICE_ACCOUNT_JSON;
+  delete env.CRUX_API_KEY;
+  delete env.GITHUB_STEP_SUMMARY;
+
+  const run = spawnSync(
+    process.execPath,
+    ["scripts/monitor-seo-field-data.mjs"],
+    {
+      cwd: process.cwd(),
+      env,
+      encoding: "utf8"
+    }
+  );
+  const report = JSON.parse(run.stdout);
+
+  assert.equal(run.status, 1);
+  assert.equal(run.stderr, "");
+  assert.equal(report.availability, "unknown");
+  assert.equal(report.health.status, "action_required");
+  assert.doesNotMatch(
+    run.stdout,
+    /private_key|client_email|BEGIN PRIVATE KEY/i
+  );
+});
+
+test("workflow is standalone, weekly, manual, read-only, and action-requiring", async () => {
+  const workflow = await readFile(
+    ".github/workflows/seo-field-monitoring.yml",
+    "utf8"
+  );
+
+  assert.match(workflow, /schedule:/);
+  assert.match(workflow, /cron: '17 5 \* \* 2'/);
+  assert.match(workflow, /workflow_dispatch:/);
+  assert.match(workflow, /permissions:\n  contents: read/);
+  assert.match(workflow, /persist-credentials: false/);
+  assert.doesNotMatch(workflow, /continue-on-error/);
+  assert.match(workflow, /GOOGLE_SEARCH_CONSOLE_SERVICE_ACCOUNT_JSON:/);
+  assert.match(workflow, /CRUX_API_KEY:/);
+  assert.match(workflow, /node scripts\/monitor-seo-field-data\.mjs/);
+  assert.doesNotMatch(workflow, /upload-artifact|upload-pages-artifact/);
+  assert.doesNotMatch(
+    workflow,
+    /contents: write|issues: write|pull-requests: write/
+  );
+  assert.doesNotMatch(workflow, /^\s*(push|pull_request):/m);
+});
+
+test("date range keeps an inclusive finalized window", () => {
+  assert.deepEqual(searchDateRange(new Date("2026-07-17T23:59:00Z"), 28, 3), {
+    startDate: "2026-06-17",
+    endDate: "2026-07-14"
+  });
+});

--- a/tests/static-artifact-cleanup.test.mjs
+++ b/tests/static-artifact-cleanup.test.mjs
@@ -1,0 +1,28 @@
+import assert from "node:assert/strict";
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  rmSync,
+  writeFileSync
+} from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import test from "node:test";
+
+import { pruneBuildOnlyExportAssets } from "../scripts/postbuild-offline.mjs";
+
+test("postbuild prunes OG input cache without removing deployable files", async (t) => {
+  const outDir = mkdtempSync(path.join(tmpdir(), "static-artifact-cleanup-"));
+  t.after(() => rmSync(outDir, { recursive: true, force: true }));
+
+  mkdirSync(path.join(outDir, "og-cache"), { recursive: true });
+  writeFileSync(path.join(outDir, "og-cache", "generated.png"), "build input");
+  writeFileSync(path.join(outDir, "index.html"), "<main>keep</main>");
+
+  await pruneBuildOnlyExportAssets(outDir);
+
+  assert.equal(existsSync(path.join(outDir, "og-cache")), false);
+  assert.equal(existsSync(path.join(outDir, "index.html")), true);
+  assert.equal(existsSync("public/assets/full-bg.svg"), false);
+});

--- a/tests/static-content-pagination.test.mjs
+++ b/tests/static-content-pagination.test.mjs
@@ -160,9 +160,20 @@ test('archive routes and explorers keep pagination crawlable and search progress
   ])
 
   for (const route of [blogRoute, notesRoute]) {
-    assert.match(route, /export const dynamicParams = false/)
-    assert.match(route, /generateStaticParams/)
+    assert.match(
+      route,
+      /generateStaticParams\(\) \{\s+if \(process\.env\.NODE_ENV === ["']development["']\) return \[\]/,
+    )
+    assert.doesNotMatch(route, /export const dynamicParams = false/)
     assert.match(route, /parsePageNumber/)
+  }
+
+  for (const route of [blogSearchRoute, notesSearchRoute]) {
+    assert.match(
+      route,
+      /generateStaticParams\(\) \{\s+if \(process\.env\.NODE_ENV === ["']development["']\) return \[\]/,
+    )
+    assert.doesNotMatch(route, /export const dynamicParams = false/)
   }
 
   for (const collection of [blogCollection, notesCollection]) {

--- a/tests/static-runtime-boundaries.test.mjs
+++ b/tests/static-runtime-boundaries.test.mjs
@@ -118,3 +118,28 @@ test("nested localized layouts bind translations to static locale params", () =>
     }
   }
 });
+
+test("development renders static params on demand without concurrent manifest writes", () => {
+  const config = readFileSync("next.config.mjs", "utf8");
+  const verifier = readFileSync("scripts/verify-dev-concurrency.mjs", "utf8");
+  const staticParamEntries = walk(localeRoot).filter((path) =>
+    /export function generateStaticParams/.test(readFileSync(path, "utf8"))
+  );
+
+  assert.match(config, /output: isDevelopment \? undefined : ["']export["']/);
+  assert.match(config, /globalNotFound: !isDevelopment/);
+  assert.ok(staticParamEntries.length > 0);
+  for (const entry of staticParamEntries) {
+    const source = readFileSync(entry, "utf8");
+    assert.match(
+      source,
+      /generateStaticParams\(\) \{\s+if \(process\.env\.NODE_ENV === ["']development["']\) return \[\]/
+    );
+    assert.doesNotMatch(source, /dynamicParams\s*=\s*false/);
+  }
+
+  assert.match(verifier, /Promise\.all/);
+  assert.match(verifier, /\["\/__dev-concurrency-missing__", 404\]/);
+  assert.match(verifier, /prerender-manifest\.json/);
+  assert.match(verifier, /JSON\.parse/);
+});

--- a/tests/static-runtime-boundaries.test.mjs
+++ b/tests/static-runtime-boundaries.test.mjs
@@ -77,7 +77,6 @@ test("public runtime and chrome stay outside the Studio layout boundary", () => 
     "RouteProgressBar",
     "OfflineNavigationCapture",
     "OfflineStatusBanner",
-    "WebVitalsReporter",
     "BlogReaderTools",
     "ThemeSync",
   ];
@@ -88,7 +87,10 @@ test("public runtime and chrome stay outside the Studio layout boundary", () => 
     assert.doesNotMatch(studioPage, new RegExp(`\\b${component}\\b`));
   }
 
-  assert.match(rootLayout, /<NextIntlClientProvider>\{children\}<\/NextIntlClientProvider>/);
+  assert.match(rootLayout, /<WebVitalsReporter locale=\{locale\} \/>/);
+  assert.doesNotMatch(siteLayout, /\bWebVitalsReporter\b/);
+  assert.doesNotMatch(studioPage, /\bWebVitalsReporter\b/);
+  assert.match(rootLayout, /<NextIntlClientProvider>[\s\S]*\{children\}[\s\S]*<\/NextIntlClientProvider>/);
   assert.doesNotMatch(studioPage, /\.app-nav|\.app-footer|\.blog-reader-tools/);
 });
 

--- a/tests/studio-route.test.mjs
+++ b/tests/studio-route.test.mjs
@@ -191,6 +191,8 @@ test("studio route is wired into routing, seo, navigation, analytics, and invent
   assert.doesNotMatch(page, /"@type":\s*"TechArticle"/);
   assert.doesNotMatch(page, /getLocalizedStudioNotes|getLocalizedStudioFlows/);
   assert.match(page, /StudioWorkspace/);
+  assert.match(page, /data-studio-page-heading="true"/);
+  assert.match(page, /<h1 className="studio-page-heading__title">\{staticContent\.title\}<\/h1>/);
   assert.match(page, /studio-route-shell/);
   assert.match(page, /<div className="studio-route-shell">/);
   assert.doesNotMatch(page, /<main className="studio-route-shell">/);
@@ -206,8 +208,9 @@ test("studio route is wired into routing, seo, navigation, analytics, and invent
   assert.match(workspace, /studioShadowStyles/);
   assert.match(page, /fallback=\{<StudioStaticOverview locale=\{locale\} \/>\}/);
   assert.match(workspace, /fallback=\{fallback\}/);
+  assert.match(workspace, /heading=\{heading\}/);
   assert.match(staticOverview, /data-studio-static-overview="true"/);
-  assert.match(staticOverview, /<h1>\{content\.title\}<\/h1>/);
+  assert.doesNotMatch(staticOverview, /<h1\b/);
   assert.match(staticOverview, /data-studio-module-link=\{module\.id\}/);
   assert.match(staticContent, /en:\s*\{/);
   assert.match(staticContent, /vi:\s*\{/);

--- a/tests/studio-semantic-rum.test.mjs
+++ b/tests/studio-semantic-rum.test.mjs
@@ -1,0 +1,85 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import test from "node:test";
+import ts from "typescript";
+
+async function importTypeScriptModule(path) {
+  const source = await readFile(path, "utf8");
+  const { outputText } = ts.transpileModule(source, {
+    compilerOptions: {
+      module: ts.ModuleKind.ESNext,
+      target: ts.ScriptTarget.ES2022
+    }
+  });
+  const encoded = Buffer.from(outputText).toString("base64");
+  return import(`data:text/javascript;base64,${encoded}`);
+}
+
+test("Studio keeps one localized light-DOM H1 through the shadow lifecycle", async () => {
+  const [page, workspace, overview, shadowIsland, adminShell, shadowStyles, staticContent] =
+    await Promise.all([
+      readFile("src/app/[locale]/studio/page.tsx", "utf8"),
+      readFile("src/app/[locale]/studio/StudioWorkspace.tsx", "utf8"),
+      readFile("src/app/[locale]/studio/StudioStaticOverview.tsx", "utf8"),
+      readFile("src/components/studio-kit/shadow-island.tsx", "utf8"),
+      readFile("src/app/[locale]/studio/studio-admin-shell.tsx", "utf8"),
+      readFile("src/app/[locale]/studio/studio.shadow-styles.ts", "utf8"),
+      importTypeScriptModule("src/app/[locale]/studio/studio-static-content.ts")
+    ]);
+
+  assert.equal(page.match(/<h1\b/g)?.length, 1);
+  assert.match(page, /data-studio-page-heading="true"/);
+  assert.match(page, /slot="studio-page-heading"/);
+  assert.match(page, /\{staticContent\.title\}<\/h1>/);
+  assert.doesNotMatch(page, /studio-page-heading__title[^}]*display:\s*none/);
+
+  assert.match(workspace, /heading=\{heading\}/);
+  assert.match(shadowIsland, /data-shadow-ready=\{root \? "true" : "false"\}/);
+  assert.match(shadowIsland, /\{heading\}[\s\S]*\{root[\s\S]*createPortal/);
+  assert.match(adminShell, /<slot name="studio-page-heading" \/>/);
+  assert.match(adminShell, /<h2>\{route\.title\}<\/h2>/);
+
+  for (const shadowSource of [overview, shadowIsland, adminShell]) {
+    assert.doesNotMatch(shadowSource, /<h1\b/);
+  }
+  assert.doesNotMatch(shadowStyles, /route-heading h1|welcome-intro h1|auth-card h1/);
+
+  for (const locale of ["en", "vi", "zh", "ja", "ko", "fr"]) {
+    const content = staticContent.getStudioStaticContent(locale);
+    assert.ok(content.title.trim().length > 0, `${locale} Studio title must be localized`);
+  }
+});
+
+test("one root RUM reporter covers site and Studio without losing metric precision", async () => {
+  const [reporter, contextModule, rootLayout, siteLayout, analytics] = await Promise.all([
+    readFile("src/components/analytics/WebVitalsReporter.tsx", "utf8"),
+    importTypeScriptModule("src/components/analytics/web-vitals-context.ts"),
+    readFile("src/app/[locale]/layout.tsx", "utf8"),
+    readFile("src/app/[locale]/(site)/layout.tsx", "utf8"),
+    readFile("src/lib/analytics.ts", "utf8")
+  ]);
+
+  assert.equal(contextModule.resolveWebVitalSurface("/en/studio"), "studio");
+  assert.equal(contextModule.resolveWebVitalSurface("/vi/studio?route=ai-skills"), "studio");
+  assert.equal(contextModule.resolveWebVitalSurface("/en/blog"), "site");
+  assert.equal(contextModule.resolveWebVitalSurface("/fr"), "site");
+
+  assert.match(rootLayout, /<WebVitalsReporter locale=\{locale\} \/>/);
+  assert.equal(rootLayout.match(/<WebVitalsReporter\b/g)?.length, 1);
+  assert.doesNotMatch(siteLayout, /\bWebVitalsReporter\b/);
+
+  assert.match(reporter, /useCallback<ReportWebVitalsCallback>/);
+  assert.match(reporter, /useReportWebVitals\(reportWebVitals\)/);
+  assert.match(reporter, /value:\s*metric\.value/);
+  assert.match(reporter, /delta:\s*metric\.delta/);
+  assert.match(reporter, /rating:\s*metric\.rating/);
+  assert.match(reporter, /navigation_type:\s*metric\.navigationType/);
+  assert.match(reporter, /path,/);
+  assert.match(reporter, /surface:\s*resolveWebVitalSurface/);
+  assert.match(reporter, /locale:\s*context\.locale/);
+  assert.doesNotMatch(reporter, /Math\.round/);
+
+  assert.match(analytics, /\| 'web_vital'/);
+  assert.match(analytics, /export type WebVitalAnalyticsPayload/);
+  assert.match(analytics, /if \(isDoNotTrack\(\)\) return/);
+});


### PR DESCRIPTION
## Summary

- Generate article routes only for authored locales and prune dead/build-only assets, reducing the static export from 26,463 to 11,696 files and from 671.1 MiB to 337.5 MiB.
- Defer article-card prefetch until user intent, serve a right-sized header icon, and preserve one semantic Studio H1 across hydration with complete Web Vitals context.
- Add a localized privacy-safe static 404 plus fail-closed Search Console/CrUX field-data monitoring.
- Close all review findings around secret-bearing workflow refs, PostHog URL leakage/event loss, canonical false positives, and concurrent Next development startup.

## Scope

- [x] UI / UX
- [x] Content / SEO
- [x] Data / locale behavior
- [x] Build / deployment
- [x] Tests / tooling
- [x] Documentation

## Review remediation

- [x] Restrict the secret-bearing SEO observation job to refs/heads/main.
- [x] Strip SDK-added URL, path, and referrer properties from not-found analytics.
- [x] Queue analytics emitted before the lazy PostHog bootstrap.
- [x] Compare both Google and user canonicals with the expected canary URL.
- [x] Keep static export/global not-found production-only and gate 19 concurrent clean-cache dev first hits, including a 404.

## Verification

- [x] npm run check — 150 passed, 1 expected Firestore launcher skip
- [x] npm run verify:dev-concurrency — 19 concurrent first hits, valid manifest
- [x] npm run build:fast — 980 static pages
- [x] npm run verify:not-found
- [x] npm run verify:artifact — 11,696 files / 337.5 MiB; 904 sitemap URLs
- [x] npm run verify:pagination — 756 indexable articles have inlinks
- [x] npm run verify:offline
- [x] npm run test:firestore-rules — 6 passed

## Screenshots

Not applicable. The visible layout is unchanged; browser verification covers semantic headings, navigation, localized 404 recovery, privacy filtering, and hydration behavior.

## Risk And Rollback

- Risk level: medium
- Rollback plan: revert this PR. The Search Console/CrUX workflow is standalone and does not block deployment.
- Residual risk: live Search Console/CrUX data still requires production credentials and traffic; GitHub Pages edge behavior is confirmed only after deployment. The service-account JSON remains a long-lived secret and third-party action tags remain mutable.

## Notes For Reviewer

- Default assignee: nguyenlephong
- Deployment impact: export remains GitHub Pages compatible at 11,696 files / 337.5 MiB. The production publish path remains unchanged.
- Monitoring requires GOOGLE_SEARCH_CONSOLE_SERVICE_ACCOUNT_JSON, CRUX_API_KEY, Search Console property access, and both APIs enabled. Missing credentials fail closed as action_required.
- The existing local AGENTS.md change is not part of this PR.