### PR TITLE
fix(pwa): stabilize offline hydration and page-back prefetch

### DIFF
--- a/.github/workflows/auto-assign-pr.yml
+++ b/.github/workflows/auto-assign-pr.yml
@@ -5,8 +5,7 @@ on:
     types: [opened, reopened, ready_for_review]
 
 permissions:
-  issues: write
-  pull-requests: read
+  pull-requests: write
 
 jobs:
   assign:
@@ -20,16 +19,48 @@ jobs:
           script: |
             const defaultAssignee = 'nguyenlephong'
             const { owner, repo } = context.repo
-            const issue_number = context.payload.pull_request.number
-            const existingAssignees = context.payload.pull_request.assignees.map(
-              (assignee) => assignee.login,
-            )
+            const pullNumber = context.payload.pull_request.number
+            const hasDefaultAssignee = async () => {
+              const { data: pullRequest } = await github.rest.pulls.get({
+                owner,
+                repo,
+                pull_number: pullNumber,
+              })
 
-            if (!existingAssignees.includes(defaultAssignee)) {
+              return pullRequest.assignees.some(
+                (assignee) => assignee.login === defaultAssignee,
+              )
+            }
+
+            if (await hasDefaultAssignee()) return
+
+            let assignmentError
+            try {
               await github.rest.issues.addAssignees({
                 owner,
                 repo,
-                issue_number,
+                issue_number: pullNumber,
                 assignees: [defaultAssignee],
               })
+            } catch (error) {
+              assignmentError = error
             }
+
+            let assignmentConfirmed
+            try {
+              assignmentConfirmed = await hasDefaultAssignee()
+            } catch (verificationError) {
+              if (assignmentError) {
+                throw new AggregateError(
+                  [assignmentError, verificationError],
+                  'Assignment failed and live pull request verification also failed',
+                )
+              }
+              throw verificationError
+            }
+
+            if (assignmentConfirmed) return
+            if (assignmentError) throw assignmentError
+            throw new Error(
+              'Assignment request completed but the repository owner is still unassigned',
+            )

--- a/scripts/verify-offline.mjs
+++ b/scripts/verify-offline.mjs
@@ -260,12 +260,200 @@ async function verifyBrowserFlow(setOriginOffline) {
   const { chromium } = await import('playwright')
   const browser = await chromium.launch({ headless: true })
   const context = await browser.newContext()
+  // Keep the production PostHog loader stub as the observable provider seam.
+  // Blocking only the external SDK prevents it from draining the stub queue.
+  await context.route(
+    /^https:\/\/us-assets\.i\.posthog\.com\/static\/array\.js(?:\?|$)/,
+    (route) => route.abort(),
+  )
   const page = await context.newPage()
+  const browserErrors = []
   const baseUrl = `http://${HOST}:${PORT}`
   const startPath = `/${LOCALE}/blog`
   const warmPath = `/${LOCALE}/notes`
   const fallbackPath = `/${LOCALE}/apps/english`
   const siblingPath = '/dom-pub/offline-probe'
+
+  page.on('pageerror', (error) => {
+    browserErrors.push(`pageerror: ${error.message}`)
+  })
+  page.on('console', (message) => {
+    if (message.type() !== 'error') return
+    const text = message.text()
+    if (/hydration|hydrated|react(?:\.dev\/errors\/| error #)418/i.test(text)) {
+      browserErrors.push(`console: ${text}`)
+    }
+  })
+
+  const assertNoBrowserErrors = () => {
+    assert.deepEqual(browserErrors, [], 'offline navigation must not emit page or hydration errors')
+  }
+
+  const waitForBrowserFrames = () =>
+    page.evaluate(
+      () =>
+        new Promise((resolve) => {
+          requestAnimationFrame(() => requestAnimationFrame(resolve))
+        }),
+    )
+
+  const readOfflineStatusAnalytics = () =>
+    page.evaluate(() => window.__offlineStatusAnalytics ?? [])
+
+  const waitForProductionAnalyticsProvider = () =>
+    page.waitForFunction(
+      () =>
+        Array.isArray(window.posthog) &&
+        window.posthog.__SV === 1 &&
+        typeof window.posthog.capture === 'function',
+      null,
+      { timeout: 10000 },
+    )
+
+  const readQueuedOfflineStatusAnalytics = () =>
+    page.evaluate(() => {
+      const provider = window.posthog
+      if (!Array.isArray(provider)) return null
+
+      return provider
+        .filter(
+          (entry) =>
+            Array.isArray(entry) &&
+            entry[0] === 'capture' &&
+            entry[1] === 'offline_status_change',
+        )
+        .map((entry) => ({
+          event: entry[1],
+          locale: entry[2]?.locale ?? null,
+          status: entry[2]?.status ?? null,
+        }))
+    })
+
+  const assertNoMountOfflineStatusAnalytics = async () => {
+    await waitForProductionAnalyticsProvider()
+    assert.deepEqual(
+      await readQueuedOfflineStatusAnalytics(),
+      [],
+      'hydrated document mount must seed offline status without capturing a transition',
+    )
+  }
+
+  const assertOfflineStatusAnalyticsTransitions = async () => {
+    await waitForProductionAnalyticsProvider()
+    assert.deepEqual(
+      await readQueuedOfflineStatusAnalytics(),
+      [],
+      'initial mount must seed network status without capturing a transition',
+    )
+
+    await page.evaluate(() => {
+      const provider = window.posthog
+      if (!Array.isArray(provider) || typeof provider.capture !== 'function') {
+        throw new Error('production PostHog provider is unavailable')
+      }
+
+      window.__offlineStatusAnalytics = []
+      const originalCapture = provider.capture.bind(provider)
+      provider.capture = (event, properties, options) => {
+        if (event === 'offline_status_change') {
+          window.__offlineStatusAnalytics.push({
+            event,
+            locale: properties?.locale ?? null,
+            status: properties?.status ?? null,
+          })
+        }
+        return originalCapture(event, properties, options)
+      }
+    })
+
+    const waitForCaptureCount = (expected) =>
+      page.waitForFunction(
+        (count) => window.__offlineStatusAnalytics?.length === count,
+        expected,
+        { timeout: 5000 },
+      )
+    const dispatchRepeatedStatus = async (status) => {
+      await page.evaluate((eventName) => {
+        window.dispatchEvent(new Event(eventName))
+        window.dispatchEvent(new Event(eventName))
+      }, status)
+      await waitForBrowserFrames()
+    }
+
+    await context.setOffline(true)
+    await page.waitForFunction(() => navigator.onLine === false)
+    await waitForCaptureCount(1)
+    await dispatchRepeatedStatus('offline')
+    assert.deepEqual(await readOfflineStatusAnalytics(), [
+      { event: 'offline_status_change', locale: LOCALE, status: 'offline' },
+    ])
+
+    await context.setOffline(false)
+    await page.waitForFunction(() => navigator.onLine === true)
+    await waitForCaptureCount(2)
+    await dispatchRepeatedStatus('online')
+    assert.deepEqual(await readOfflineStatusAnalytics(), [
+      { event: 'offline_status_change', locale: LOCALE, status: 'offline' },
+      { event: 'offline_status_change', locale: LOCALE, status: 'online' },
+    ])
+  }
+
+  const readRuntimeVersionState = () =>
+    page.evaluate(async () => {
+      const cachedManifest = await caches
+        .match('/offline-manifest.json')
+        .then((response) => response?.json())
+      const registration = await navigator.serviceWorker.getRegistration('/')
+      const controllerUrl = navigator.serviceWorker.controller?.scriptURL ?? null
+      const workerUrls = [
+        registration?.active?.scriptURL,
+        registration?.waiting?.scriptURL,
+        registration?.installing?.scriptURL,
+      ].filter((value) => typeof value === 'string')
+      const queryVersion = (value) =>
+        value ? new URL(value, window.location.origin).searchParams.get('v') : null
+
+      return {
+        cachedManifestVersion: cachedManifest?.version ?? null,
+        domMetaVersion:
+          document
+            .querySelector('meta[name="offline-manifest-version"]')
+            ?.getAttribute('content')
+            ?.trim() || null,
+        controllerUrl,
+        controllerVersion: queryVersion(controllerUrl),
+        workerUrls,
+        workerVersions: workerUrls.map(queryVersion),
+      }
+    })
+
+  const assertRuntimeVersionContract = async () => {
+    const state = await readRuntimeVersionState()
+    assert.equal(typeof state.cachedManifestVersion, 'string')
+    assert.equal(
+      state.domMetaVersion,
+      state.cachedManifestVersion,
+      `hydration must preserve the offline manifest version meta; received ${JSON.stringify(state)}`,
+    )
+    assert.equal(
+      state.controllerVersion,
+      state.cachedManifestVersion,
+      `the controlling worker must use the cached manifest version; received ${JSON.stringify(state)}`,
+    )
+    assert.ok(
+      state.workerVersions.length > 0 &&
+        state.workerVersions.every((version) => version === state.cachedManifestVersion),
+      `every registered worker must use the cached manifest version; received ${JSON.stringify(state)}`,
+    )
+  }
+
+  const assertHydratedOfflineRuntime = async () => {
+    await page.locator('.offline-banner').waitFor({ state: 'visible', timeout: 10000 })
+    await waitForBrowserFrames()
+    assertNoBrowserErrors()
+    await assertRuntimeVersionContract()
+    await assertNoMountOfflineStatusAnalytics()
+  }
 
   const waitForCachedNavigation = (pathname) =>
     page.waitForFunction(
@@ -308,6 +496,8 @@ async function verifyBrowserFlow(setOriginOffline) {
       timeout: 30000,
     })
     await waitForCachedNavigation(startPath)
+    await assertOfflineStatusAnalyticsTransitions()
+    assertNoBrowserErrors()
 
     const allowlistedRemoteUrl = await page.evaluate(async () => {
       const manifest = await fetch('/offline-manifest.json', { cache: 'no-store' }).then((response) => response.json())
@@ -395,6 +585,11 @@ async function verifyBrowserFlow(setOriginOffline) {
       })
       await page.waitForFunction(() => document.title.length > 0, null, { timeout: 10000 })
     }
+
+    await page.reload({ waitUntil: 'commit', timeout: 15000 })
+    await page.waitForFunction(() => document.title.length > 0, null, { timeout: 10000 })
+    await assertHydratedOfflineRuntime()
+    assert.equal(await page.title(), onlineTitle, 'offline hard reload should retain the cached page')
 
     const siblingAssetAvailableOffline = await page.evaluate(async (siblingAssetPath) => {
       try {
@@ -499,6 +694,7 @@ async function verifyBrowserFlow(setOriginOffline) {
       `expected an owned but uncached page to fall back to the offline route; received ${JSON.stringify(fallbackState)}`,
     )
     assert.match(await page.title(), /offline|ngoại tuyến|hors ligne/i)
+    await assertHydratedOfflineRuntime()
 
     const siblingPage = await context.newPage()
     let siblingNavigationFailed = false

--- a/scripts/verify-runtime-boundaries.mjs
+++ b/scripts/verify-runtime-boundaries.mjs
@@ -57,6 +57,10 @@ const ARTICLE_HUB_CASES = [
     sources: ["notes_article_breadcrumb"]
   }
 ];
+const PAGE_BACK_PREFETCH_CASES = [
+  { name: "gallery", path: "/en/gallery", homePath: "/en", intent: "focus" },
+  { name: "apps", path: "/vi/apps", homePath: "/vi", intent: "hover" }
+];
 const PUBLIC_CSS_RUNTIME_CASES = [
   { name: "home", path: "/en", selector: ".hero", property: "position", value: "relative", stylesheets: 3 },
   { name: "about", path: "/en/about", selector: ".about-page-v2", property: "paddingBottom", notValue: "0px", stylesheets: 3 },
@@ -218,6 +222,205 @@ function isRscRequestForDestination(request, origin, destination) {
     requestedStem === destinationStem ||
     requestedStem.startsWith(`${destinationStem}/`)
   );
+}
+
+function isRscPathForExactDestination(localPath, destination) {
+  if (!localPath.endsWith(".txt")) return false;
+  const destinationStem = destination.replace(/^\/+|\/+$/g, "");
+  return (
+    localPath === `${destinationStem}.txt` ||
+    localPath.startsWith(`${destinationStem}/__next.`)
+  );
+}
+
+function htmlAttribute(tag, name) {
+  const match = tag.match(
+    new RegExp(`\\b${name}\\s*=\\s*(?:"([^"]*)"|'([^']*)'|([^\\s>]+))`, "i")
+  );
+  return match?.[1] ?? match?.[2] ?? match?.[3] ?? null;
+}
+
+async function routeStylesheetPaths(routePath, origin) {
+  const routeStem = routePath.replace(/^\/+|\/+$/g, "");
+  const html = await fs.readFile(path.join(OUT_DIR, `${routeStem}.html`), "utf8");
+  const stylesheetPaths = new Set();
+
+  for (const [tag] of html.matchAll(/<link\b[^>]*>/gi)) {
+    const rel = htmlAttribute(tag, "rel")
+      ?.toLowerCase()
+      .split(/[\t\n\f\r ]+/);
+    if (!rel?.includes("stylesheet")) continue;
+    const href = htmlAttribute(tag, "href");
+    if (!href) continue;
+    const localPath = localRequestPath(new URL(href, origin).href, origin);
+    if (localPath) stylesheetPaths.add(localPath);
+  }
+
+  return stylesheetPaths;
+}
+
+async function verifyPageBackPrefetchBoundaries(browser, origin) {
+  const results = [];
+
+  for (const scenario of PAGE_BACK_PREFETCH_CASES) {
+    const homeStylesheets = await routeStylesheetPaths(
+      scenario.homePath,
+      origin
+    );
+    const routeStylesheets = await routeStylesheetPaths(scenario.path, origin);
+    const homeOnlyStylesheets = new Set(
+      [...homeStylesheets].filter((stylesheet) => !routeStylesheets.has(stylesheet))
+    );
+    assert.ok(
+      homeOnlyStylesheets.size > 0,
+      `${scenario.name} has no distinguishable Home stylesheet boundary`
+    );
+
+    const context = await browser.newContext({ serviceWorkers: "block" });
+    const pageErrors = [];
+    const requests = [];
+    let phase = "initial";
+
+    try {
+      await installExternalRuntimeStubs(context, {
+        stubGalleryImages: scenario.name === "gallery"
+      });
+      const page = await context.newPage();
+      page.on("pageerror", (error) => pageErrors.push(error.message));
+      page.on("request", (request) => {
+        const localPath = localRequestPath(request.url(), origin);
+        if (!localPath) return;
+        requests.push({
+          localPath,
+          phase,
+          resourceType: request.resourceType()
+        });
+      });
+
+      const response = await page.goto(`${origin}${scenario.path}`, {
+        waitUntil: "domcontentloaded"
+      });
+      assert.equal(response?.status(), 200);
+      const pageBack = page.locator("a.page-back", { hasText: /.+/ }).first();
+      await pageBack.waitFor({ state: "visible" });
+      const accessibleName = (await pageBack.innerText()).trim();
+      assert.ok(accessibleName, `${scenario.name} page-back has no accessible name`);
+      assert.match(
+        await pageBack.ariaSnapshot(),
+        /link "[^"]+"/,
+        `${scenario.name} page-back is missing link semantics`
+      );
+      assert.equal(await pageBack.getAttribute("href"), scenario.homePath);
+      await page.waitForLoadState("networkidle");
+
+      const documentIdentity = `${scenario.name}-page-back-document`;
+      await page.evaluate((identity) => {
+        window.__pageBackDocumentIdentity = identity;
+      }, documentIdentity);
+
+      const initialHomeRsc = requests.filter(
+        (request) =>
+          request.phase === "initial" &&
+          isRscPathForExactDestination(request.localPath, scenario.homePath)
+      );
+      const initialHomeCss = requests.filter(
+        (request) =>
+          request.phase === "initial" &&
+          homeOnlyStylesheets.has(request.localPath)
+      );
+      assert.deepEqual(
+        initialHomeRsc,
+        [],
+        `${scenario.name} prefetched Home RSC before page-back intent`
+      );
+      assert.deepEqual(
+        initialHomeCss,
+        [],
+        `${scenario.name} prefetched Home CSS before page-back intent`
+      );
+
+      phase = "page-back-intent";
+      const intentRequest = page.waitForRequest((request) => {
+        const localPath = localRequestPath(request.url(), origin);
+        return Boolean(
+          localPath &&
+            isRscPathForExactDestination(localPath, scenario.homePath)
+        );
+      });
+      if (scenario.intent === "focus") {
+        await pageBack.focus();
+      } else {
+        await pageBack.hover();
+      }
+      await intentRequest;
+      await page.waitForLoadState("networkidle");
+
+      const intentRsc = requests.filter(
+        (request) =>
+          request.phase === "page-back-intent" &&
+          request.localPath.endsWith(".txt")
+      );
+      const intentCss = requests.filter(
+        (request) =>
+          request.phase === "page-back-intent" &&
+          request.resourceType === "stylesheet"
+      );
+      assert.ok(
+        intentRsc.length > 0,
+        `${scenario.name} page-back intent did not prefetch Home RSC`
+      );
+      assert.ok(
+        intentRsc.every((request) =>
+          isRscPathForExactDestination(request.localPath, scenario.homePath)
+        ),
+        `${scenario.name} page-back intent prefetched another RSC destination: ${JSON.stringify(intentRsc)}`
+      );
+      assert.ok(
+        intentCss.every((request) => homeStylesheets.has(request.localPath)),
+        `${scenario.name} page-back intent fetched non-Home CSS: ${JSON.stringify(intentCss)}`
+      );
+      assert.deepEqual(pageErrors, []);
+
+      phase = "navigation";
+      await Promise.all([
+        page.waitForURL(`${origin}${scenario.homePath}`),
+        pageBack.click()
+      ]);
+      await page.waitForLoadState("networkidle");
+      const navigationDocuments = requests.filter(
+        (request) =>
+          request.phase === "navigation" &&
+          request.resourceType === "document"
+      );
+      assert.deepEqual(
+        navigationDocuments,
+        [],
+        `${scenario.name} page-back used a full document navigation`
+      );
+      assert.equal(
+        await page.evaluate(() => window.__pageBackDocumentIdentity),
+        documentIdentity,
+        `${scenario.name} page-back replaced the active document`
+      );
+      assert.equal(new URL(page.url()).pathname, scenario.homePath);
+
+      results.push({
+        accessibleName,
+        homePath: scenario.homePath,
+        intent: scenario.intent,
+        path: scenario.path,
+        initialHomeCss: initialHomeCss.length,
+        initialHomeRsc: initialHomeRsc.length,
+        intentCss: intentCss.length,
+        intentRsc: intentRsc.length,
+        navigationDocuments: navigationDocuments.length
+      });
+    } finally {
+      await context.close();
+    }
+  }
+
+  return results;
 }
 
 async function findEngagementProviderChunks() {
@@ -1518,6 +1721,10 @@ async function main() {
       browser,
       origin
     );
+    const pageBackPrefetch = await verifyPageBackPrefetchBoundaries(
+      browser,
+      origin
+    );
     const persistedReadingFont = await verifyPersistedReadingFont(browser, origin);
     const readerRemount = await verifyReaderPathnameRemount(browser, origin);
     const contentHubAnalytics = await verifyContentHubAnalytics(browser, origin);
@@ -1543,6 +1750,7 @@ async function main() {
           publicToStudio,
           publicCss,
           galleryPreloadAndLcp,
+          pageBackPrefetch,
           persistedReadingFont,
           readerRemount,
           contentHubAnalytics,

--- a/specs/content-list-loading-performance.md
+++ b/specs/content-list-loading-performance.md
@@ -19,6 +19,10 @@ The public header displays the existing 72 px favicon asset at 36 CSS pixels.
 That small asset is loaded eagerly with high fetch priority; the 512 px app
 icon remains unchanged for Next metadata and install/icon consumers.
 
+The above-fold Gallery and Apps page-back links use the same intent boundary.
+A direct visit does not speculate on Home; keyboard focus or pointer hover can
+restore Next's native prefetch for that single localized destination.
+
 ## Why
 
 Content archives can render dozens of links at once. Automatic viewport
@@ -69,3 +73,9 @@ number when later loading boundaries are added.
     deferred counters. Under `Save-Data`, the same query may load only its search
     index. These checks use observable state rather than timeout-based byte
     assertions.
+13. Direct Gallery and Apps loads request neither Home RSC payloads nor
+    Home-owned CSS through their above-fold page-back links. Keyboard focus or
+    pointer hover enables prefetch only for localized Home while preserving the
+    existing crawlable `href`, copy, class, accessibility, analytics, and client
+    navigation contract. AppHeader keeps its intentional per-link intent
+    prefetch behavior unchanged.

--- a/specs/static-runtime-boundaries.md
+++ b/specs/static-runtime-boundaries.md
@@ -182,6 +182,15 @@ existing IDs must not be renamed or renumbered.
   rules owned by a route.
 - **AC-SRB-020:** Type-only CSS imports fail the source boundary and do not count
   as runtime stylesheet importers; type-only non-CSS imports remain valid.
+- **AC-SRB-021:** An offline hard reload and an owned-route fallback hydrate the
+  offline status runtime without page or hydration errors. After hydration, the
+  injected offline-manifest version meta remains in the DOM and equals both the
+  cached manifest version and every controlling or registered service worker's
+  `v` query.
+- **AC-SRB-022:** Mounting the offline status runtime emits no
+  `offline_status_change`. Each real online-to-offline or offline-to-online
+  transition emits the existing event exactly once, while repeated same-state
+  browser signals emit no duplicate.
 
 ## Verification
 
@@ -196,6 +205,13 @@ existing IDs must not be renamed or renumbered.
 - Confirm representative public routes remain within their configured initial
   stylesheet-request and Brotli budgets and expose only their required
   normalized route-owner selectors.
+- Run `npm run verify:offline` against the complete export. The browser gate
+  hard-reloads a warmed route offline and hydrates an owned-route fallback with
+  no page error or React #418, preserves the manifest-version meta, matches it
+  to the cached manifest and controlling/registered worker query, and verifies
+  through the PostHog provider seam that the initial online mount, offline hard
+  reload, and fallback hydration emit no status transition while real
+  transitions remain exact-once and same-state signals remain deduplicated.
 - Run `npm run typecheck` and `npm run lint`.
 - Do not require a runtime backend or server-only route for this boundary.
 

--- a/src/app/[locale]/(site)/gallery/page.tsx
+++ b/src/app/[locale]/(site)/gallery/page.tsx
@@ -1,10 +1,9 @@
 import { Metadata } from 'next'
-import { Link } from '@/i18n/navigation'
 import { setRequestLocale, getTranslations } from 'next-intl/server'
 import { hasLocale } from 'next-intl'
 import { notFound } from 'next/navigation'
 import { routing } from '@/i18n/routing'
-import { profileInfo, APP_ROUTE } from '@/app/app.const'
+import { profileInfo } from '@/app/app.const'
 import GalleryGrid from '@/components/gallery/GalleryGrid'
 import PageTracker from '@/components/analytics/PageTracker'
 import { serializeJsonLd } from '@/lib/seo/json-ld'
@@ -14,6 +13,7 @@ import {
 } from '@/lib/seo/static-page-localization'
 import ScopedIntlProvider from '@/i18n/ScopedIntlProvider'
 import MotionProvider from '@/components/motion/MotionProvider'
+import GalleryPageBackLink from '@/components/gallery/GalleryPageBackLink'
 import './gallery.css'
 
 export function generateStaticParams() {
@@ -84,9 +84,9 @@ export default async function GalleryPage({ params }: Props) {
             </span>
             <h1 className="page-title">{t('title')}</h1>
             <p className="page-sub">{t('sub')}</p>
-            <Link href={APP_ROUTE.HOME} className="page-back">
+            <GalleryPageBackLink>
               {t('back')}
-            </Link>
+            </GalleryPageBackLink>
           </header>
 
           <ScopedIntlProvider scope="gallery">

--- a/src/components/apps/AppsConsole.tsx
+++ b/src/components/apps/AppsConsole.tsx
@@ -19,6 +19,7 @@ import {
 } from 'react-icons/lu'
 import { APP_ROUTE } from '@/app/app.const'
 import type { AppShowcaseItem } from '@/app/[locale]/(site)/apps/apps.data'
+import IntentPrefetchLink from '@/components/navigation/IntentPrefetchLink'
 import { Link } from '@/i18n/navigation'
 import { track } from '@/lib/analytics'
 import EnglishVisual from './EnglishVisual'
@@ -301,9 +302,15 @@ export default function AppsConsole({ apps, locale }: AppsConsoleProps) {
           </h1>
           <p className="apps-hero-sub">{t.intro}</p>
           <div className="apps-hero-actions">
-            <Link href={APP_ROUTE.HOME} className="page-back">
+            <IntentPrefetchLink
+              href={APP_ROUTE.HOME}
+              className="page-back"
+              data-track="cv_nav_click"
+              data-track-target="home"
+              data-track-source="apps_page_back"
+            >
               {t.back}
-            </Link>
+            </IntentPrefetchLink>
             <Link
               href="https://github.com/nguyenlephong"
               target="_blank"

--- a/src/components/gallery/GalleryPageBackLink.tsx
+++ b/src/components/gallery/GalleryPageBackLink.tsx
@@ -1,0 +1,27 @@
+'use client'
+
+import type { ReactNode } from 'react'
+import { APP_ROUTE } from '@/app/app.const'
+import IntentPrefetchLink from '@/components/navigation/IntentPrefetchLink'
+import { track } from '@/lib/analytics'
+
+type Props = {
+  children: ReactNode
+}
+
+export default function GalleryPageBackLink({ children }: Props) {
+  return (
+    <IntentPrefetchLink
+      href={APP_ROUTE.HOME}
+      className="page-back"
+      onClick={() =>
+        track('cv_nav_click', {
+          target: 'home',
+          source: 'gallery_page_back',
+        })
+      }
+    >
+      {children}
+    </IntentPrefetchLink>
+  )
+}

--- a/src/components/offline/OfflineStatusBanner.tsx
+++ b/src/components/offline/OfflineStatusBanner.tsx
@@ -22,6 +22,10 @@ const LEGACY_STORAGE_PREFIX = 'offline-locale-phase:v1:'
 const DISMISS_STORAGE_PREFIX = 'offline-banner-dismissed:v1:'
 const SERVICE_WORKER_VERSION_META = 'offline-manifest-version'
 const FALLBACK_APP_VERSION = process.env['NEXT_PUBLIC_APP_VERSION'] ?? 'dev'
+const SSR_OFFLINE_STATE = {
+  phase: 'idle',
+  completeness: 'unknown',
+} satisfies OfflineState
 
 function serviceWorkerUrl(): string {
   const version =
@@ -130,14 +134,9 @@ function OfflineStatusBannerInner({
   pathname,
 }: OfflineStatusBannerInnerProps) {
   const t = useTranslations('Offline.banner')
-  const [offlineState, setOfflineState] = useState<OfflineState>(() => readStoredState(locale))
-  const [isDismissed, setIsDismissed] = useState(() => {
-    if (typeof window !== 'undefined' && window.navigator.onLine) return false
-    return readDismissed(locale)
-  })
-  const [isOnline, setIsOnline] = useState(() =>
-    typeof window === 'undefined' ? true : window.navigator.onLine,
-  )
+  const [offlineState, setOfflineState] = useState<OfflineState>(SSR_OFFLINE_STATE)
+  const [isDismissed, setIsDismissed] = useState(false)
+  const [isOnline, setIsOnline] = useState(true)
   const lastTrackedStatusRef = useRef<string | null>(null)
   const completeness = offlineState.completeness
 
@@ -167,6 +166,17 @@ function OfflineStatusBannerInner({
       report(false)
     }
 
+    const initialOnline = window.navigator.onLine
+    lastTrackedStatusRef.current = initialOnline ? 'online' : 'offline'
+    setOfflineState(readStoredState(locale))
+    setIsOnline(initialOnline)
+    if (initialOnline) {
+      setIsDismissed(false)
+      persistDismissed(locale, false)
+    } else {
+      setIsDismissed(readDismissed(locale))
+    }
+
     window.addEventListener('online', onOnline)
     window.addEventListener('offline', onOffline)
     return () => {
@@ -174,11 +184,6 @@ function OfflineStatusBannerInner({
       window.removeEventListener('offline', onOffline)
     }
   }, [locale])
-
-  useEffect(() => {
-    if (!isOnline) return
-    persistDismissed(locale, false)
-  }, [isOnline, locale])
 
   useEffect(() => {
     if (!('serviceWorker' in navigator)) return

--- a/tests/analytics-tracking.test.mjs
+++ b/tests/analytics-tracking.test.mjs
@@ -363,6 +363,45 @@ test("PageTracker wires the same final reporter to all three exit paths", async 
   assert.match(pageTracker, /return \(\) => \{\s*reportTime\(\)/);
 });
 
+test("Gallery and Apps page-back links keep the existing CV navigation analytics contract", async () => {
+  const [
+    analytics,
+    galleryPage,
+    galleryBackLink,
+    appsPage,
+    appsConsole,
+    appsLinkTracker
+  ] = await Promise.all([
+    readFile("src/lib/analytics.ts", "utf8"),
+    readFile("src/app/[locale]/(site)/gallery/page.tsx", "utf8"),
+    readFile("src/components/gallery/GalleryPageBackLink.tsx", "utf8"),
+    readFile("src/app/[locale]/(site)/apps/page.tsx", "utf8"),
+    readFile("src/components/apps/AppsConsole.tsx", "utf8"),
+    readFile("src/components/analytics/AppsLinkTracker.tsx", "utf8")
+  ]);
+
+  assert.match(analytics, /'cv_nav_click'/);
+  assert.match(
+    galleryPage,
+    /<GalleryPageBackLink>\s*\{t\('back'\)\}\s*<\/GalleryPageBackLink>/
+  );
+  assert.match(galleryBackLink, /<IntentPrefetchLink/);
+  assert.match(galleryBackLink, /href=\{APP_ROUTE\.HOME\}/);
+  assert.match(galleryBackLink, /className="page-back"/);
+  assert.match(
+    galleryBackLink,
+    /track\('cv_nav_click',\s*\{\s*target: 'home',\s*source: 'gallery_page_back',?\s*\}\)/
+  );
+
+  assert.match(appsPage, /<AppsLinkTracker \/>/);
+  assert.match(
+    appsConsole,
+    /<IntentPrefetchLink\s+href=\{APP_ROUTE\.HOME\}\s+className="page-back"\s+data-track="cv_nav_click"\s+data-track-target="home"\s+data-track-source="apps_page_back"\s*>/
+  );
+  assert.match(appsLinkTracker, /target\.closest<HTMLElement>\('\[data-track\]'\)/);
+  assert.match(appsLinkTracker, /track\(name, props\)/);
+});
+
 test("public content surfaces have explicit posthog page and interaction events", async () => {
   const [
     analytics,
@@ -386,7 +425,8 @@ test("public content surfaces have explicit posthog page and interaction events"
     explorerShell,
     blogExplorer,
     notesExplorer,
-    offlineBanner
+    offlineBanner,
+    offlineVerifier
   ] = await Promise.all([
     readFile("src/lib/analytics.ts", "utf8"),
     readFile("src/components/analytics/PageTracker.tsx", "utf8"),
@@ -409,7 +449,8 @@ test("public content surfaces have explicit posthog page and interaction events"
     readFile("src/components/explorer/ExplorerShell.tsx", "utf8"),
     readFile("src/components/blog/BlogExplorer.tsx", "utf8"),
     readFile("src/components/notes/NotesExplorer.tsx", "utf8"),
-    readFile("src/components/offline/OfflineStatusBanner.tsx", "utf8")
+    readFile("src/components/offline/OfflineStatusBanner.tsx", "utf8"),
+    readFile("scripts/verify-offline.mjs", "utf8")
   ]);
 
   for (const eventName of [
@@ -487,6 +528,18 @@ test("public content surfaces have explicit posthog page and interaction events"
   assert.match(offlineBanner, /offline_mode_ready/);
   assert.match(offlineBanner, /offline_status_change/);
   assert.match(offlineBanner, /offline_banner_dismiss/);
+  assert.match(offlineVerifier, /provider\.capture =/);
+  assert.match(offlineVerifier, /initial mount must seed network status/);
+  assert.match(offlineVerifier, /context\.setOffline\(true\)/);
+  assert.match(offlineVerifier, /context\.setOffline\(false\)/);
+  assert.match(offlineVerifier, /event: 'offline_status_change'/);
+  assert.match(offlineVerifier, /dispatchRepeatedStatus\('offline'\)/);
+  assert.match(offlineVerifier, /dispatchRepeatedStatus\('online'\)/);
+  assert.match(offlineVerifier, /assertNoMountOfflineStatusAnalytics/);
+  assert.match(
+    offlineVerifier,
+    /const assertHydratedOfflineRuntime[\s\S]*await assertNoMountOfflineStatusAnalytics\(\)/
+  );
 });
 
 test("content hub hierarchy links reuse existing client boundaries without eager prefetch", async () => {

--- a/tests/content-list-loading-performance.test.mjs
+++ b/tests/content-list-loading-performance.test.mjs
@@ -61,6 +61,54 @@ test("public navigation and archive links use shared intent prefetch without los
   assert.match(footer, /data-document-navigation="studio"/);
 });
 
+test("Gallery and Apps page-back links wait for navigation intent before prefetching Home", async () => {
+  const [galleryPage, galleryBackLink, appsConsole, header] = await Promise.all([
+    readFile("src/app/[locale]/(site)/gallery/page.tsx", "utf8"),
+    readFile("src/components/gallery/GalleryPageBackLink.tsx", "utf8"),
+    readFile("src/components/apps/AppsConsole.tsx", "utf8"),
+    readFile("src/components/AppHeader.tsx", "utf8")
+  ]);
+
+  assert.match(galleryPage, /<GalleryPageBackLink>/);
+  assert.match(galleryBackLink, /<IntentPrefetchLink/);
+  assert.match(galleryBackLink, /href=\{APP_ROUTE\.HOME\}/);
+  assert.match(galleryBackLink, /className="page-back"/);
+  assert.match(
+    appsConsole,
+    /<IntentPrefetchLink\s+href=\{APP_ROUTE\.HOME\}\s+className="page-back"/
+  );
+
+  assert.equal((header.match(/<IntentPrefetchLink/g) ?? []).length, 3);
+  assert.match(header, /<IntentPrefetchLink\s+href=\{APP_ROUTE\.HOME\}/);
+});
+
+test("runtime verification rejects eager Home payloads from Gallery and Apps", async () => {
+  const runtimeVerifier = await readFile(
+    "scripts/verify-runtime-boundaries.mjs",
+    "utf8"
+  );
+
+  assert.match(
+    runtimeVerifier,
+    /verifyPageBackPrefetchBoundaries\(browser, origin\)/
+  );
+  assert.match(
+    runtimeVerifier,
+    /path: "\/en\/gallery", homePath: "\/en", intent: "focus"/
+  );
+  assert.match(
+    runtimeVerifier,
+    /path: "\/vi\/apps", homePath: "\/vi", intent: "hover"/
+  );
+  assert.match(runtimeVerifier, /initialHomeRsc/);
+  assert.match(runtimeVerifier, /initialHomeCss/);
+  assert.match(runtimeVerifier, /intentRsc/);
+  assert.match(runtimeVerifier, /accessibleName/);
+  assert.match(runtimeVerifier, /__pageBackDocumentIdentity/);
+  assert.match(runtimeVerifier, /navigationDocuments/);
+  assert.match(runtimeVerifier, /pageBackPrefetch/);
+});
+
 test("archive post stats stay provider-free until browsing intent", async () => {
   const [hook, store, facade, provider, ids, blogExplorer, notesExplorer, shell] =
     await Promise.all([

--- a/tests/deployment-workflow.test.mjs
+++ b/tests/deployment-workflow.test.mjs
@@ -4,9 +4,154 @@ import test from 'node:test'
 
 const workflow = readFileSync(new URL('../.github/workflows/nextjs.yml', import.meta.url), 'utf8')
 const ciWorkflow = readFileSync(new URL('../.github/workflows/ci-frontend.yml', import.meta.url), 'utf8')
+const autoAssignWorkflow = readFileSync(
+  new URL('../.github/workflows/auto-assign-pr.yml', import.meta.url),
+  'utf8',
+)
 const pkg = JSON.parse(readFileSync(new URL('../package.json', import.meta.url), 'utf8'))
 const lock = JSON.parse(readFileSync(new URL('../package-lock.json', import.meta.url), 'utf8'))
 const nodeVersion = readFileSync(new URL('../.nvmrc', import.meta.url), 'utf8').trim()
+
+const AsyncFunction = Object.getPrototypeOf(async function () {}).constructor
+
+function extractGithubScript(source) {
+  const lines = source.split('\n')
+  const scriptMarkerIndex = lines.findIndex((line) => /^\s+script: \|\s*$/.test(line))
+  assert.notEqual(scriptMarkerIndex, -1, 'workflow must contain an inline github-script')
+
+  const markerIndent = lines[scriptMarkerIndex].match(/^\s*/)[0].length
+  const scriptLines = []
+  for (const line of lines.slice(scriptMarkerIndex + 1)) {
+    const indent = line.match(/^\s*/)[0].length
+    if (line.trim() && indent <= markerIndent) break
+    scriptLines.push(line.slice(markerIndent + 2))
+  }
+
+  return scriptLines.join('\n').trimEnd()
+}
+
+const autoAssignScript = extractGithubScript(autoAssignWorkflow)
+
+async function runAutoAssignScript({ liveAssigneeResponses, postError } = {}) {
+  const getCalls = []
+  const postCalls = []
+  const responses = [...(liveAssigneeResponses ?? [[]])]
+  const github = {
+    rest: {
+      pulls: {
+        get: async (parameters) => {
+          getCalls.push(parameters)
+          const assignees = responses.shift()
+          assert.notEqual(assignees, undefined, 'test must provide one live response per GET')
+          if (assignees instanceof Error) throw assignees
+          return { data: { assignees: assignees.map((login) => ({ login })) } }
+        },
+      },
+      issues: {
+        addAssignees: async (parameters) => {
+          postCalls.push(parameters)
+          if (postError) throw postError
+        },
+      },
+    },
+  }
+  const context = {
+    repo: { owner: 'site-owner', repo: 'portfolio' },
+    payload: {
+      pull_request: {
+        number: 42,
+        assignees: [],
+        head: { ref: 'untrusted-${{ github.token }}' },
+      },
+    },
+  }
+
+  const execute = new AsyncFunction('github', 'context', autoAssignScript)
+  await execute(github, context)
+  return { getCalls, postCalls }
+}
+
+test('auto-assign workflow keeps pull_request_target privileged execution constrained', () => {
+  assert.match(
+    autoAssignWorkflow,
+    /^on:\n  pull_request_target:\n    types: \[opened, reopened, ready_for_review\]$/m,
+  )
+  assert.match(autoAssignWorkflow, /^permissions:\n  pull-requests: write\n$/m)
+  assert.equal(autoAssignWorkflow.match(/^  [a-z-]+: (?:read|write)$/gm)?.length, 1)
+  assert.match(autoAssignWorkflow, /if: \$\{\{ github\.event\.pull_request\.draft == false \}\}/)
+  assert.equal(autoAssignWorkflow.match(/uses: actions\/github-script@v7/g)?.length, 1)
+  assert.doesNotMatch(autoAssignWorkflow, /actions\/checkout|^\s*run:/m)
+  assert.doesNotMatch(autoAssignScript, /\$\{\{|\.pull_request\.(?:head|base)/)
+  assert.doesNotMatch(autoAssignScript, /context\.payload\.pull_request\.assignees/)
+})
+
+test('auto-assign skips the POST when the live pull request already has the owner', async () => {
+  const calls = await runAutoAssignScript({ liveAssigneeResponses: [['nguyenlephong']] })
+
+  assert.deepEqual(calls.getCalls, [{ owner: 'site-owner', repo: 'portfolio', pull_number: 42 }])
+  assert.equal(calls.postCalls.length, 0)
+})
+
+test('auto-assign adds the owner once when the live pull request is missing it', async () => {
+  const calls = await runAutoAssignScript({ liveAssigneeResponses: [[], ['nguyenlephong']] })
+
+  assert.equal(calls.getCalls.length, 2)
+  assert.deepEqual(calls.postCalls, [
+    {
+      owner: 'site-owner',
+      repo: 'portfolio',
+      issue_number: 42,
+      assignees: ['nguyenlephong'],
+    },
+  ])
+})
+
+test('auto-assign fails explicitly when a resolved POST leaves the owner unassigned', async () => {
+  await assert.rejects(
+    runAutoAssignScript({ liveAssigneeResponses: [[], []] }),
+    {
+      name: 'Error',
+      message: 'Assignment request completed but the repository owner is still unassigned',
+    },
+  )
+})
+
+test('auto-assign accepts a concurrent successful assignment after its POST fails', async () => {
+  const calls = await runAutoAssignScript({
+    liveAssigneeResponses: [[], ['nguyenlephong']],
+    postError: new Error('assignment raced'),
+  })
+
+  assert.equal(calls.getCalls.length, 2)
+  assert.equal(calls.postCalls.length, 1)
+})
+
+test('auto-assign rethrows a POST failure when the owner remains unassigned', async () => {
+  const postError = new Error('assignment rejected')
+
+  await assert.rejects(
+    runAutoAssignScript({ liveAssigneeResponses: [[], []], postError }),
+    (error) => error === postError,
+  )
+})
+
+test('auto-assign preserves POST and verification failures when reconciliation is unavailable', async () => {
+  const postError = new Error('assignment rejected')
+  const verificationError = new Error('live pull request unavailable')
+
+  await assert.rejects(
+    runAutoAssignScript({
+      liveAssigneeResponses: [[], verificationError],
+      postError,
+    }),
+    (error) => {
+      assert.ok(error instanceof AggregateError)
+      assert.equal(error.message, 'Assignment failed and live pull request verification also failed')
+      assert.deepEqual(error.errors, [postError, verificationError])
+      return true
+    },
+  )
+})
 
 test('workflows, package metadata, lockfile, and Node types share the Node 22 runtime contract', () => {
   assert.equal(nodeVersion, '22')

--- a/tests/helpers/client-message-contract-config.mjs
+++ b/tests/helpers/client-message-contract-config.mjs
@@ -24,7 +24,6 @@ const SCOPED_PROVIDER_PLACEMENTS = {
 const CLIENT_PROVIDER_CONSUMER_ROUTES = {
   "src/app/[locale]/(site)/blog/[category]/[slug]/page.tsx": "site",
   "src/app/[locale]/(site)/blog/[category]/page.tsx": "blog",
-  "src/app/[locale]/(site)/gallery/page.tsx": "gallery",
   "src/app/[locale]/(site)/notes/[slug]/page.tsx": "site",
   "src/app/[locale]/(site)/offline/page.tsx": "site",
   "src/components/AppFooter.tsx": "site",


### PR DESCRIPTION
## Summary

- Production smoke after #51 reproduced deterministic React hydration error #418 on an offline hard reload; the mismatch discarded the postbuild version meta and forced the service-worker URL fallback to `v1.1.60`.
- Make `OfflineStatusBanner` render an SSR-stable initial state, then synchronize network/storage state only after mount; add a real-browser regression for offline hard reload, fallback, version provenance, and analytics transition behavior.
- Replace only Gallery and Apps page-back eager prefetch with intent-prefetch while preserving the existing `cv_nav_click` analytics contract.
- Make the repository-owner auto-assignment workflow use live PR state, reconcile every write, preserve concurrent success, and fail explicitly when GitHub accepts but does not apply an assignee.

## Scope

- [x] UI / UX
- [ ] Content / SEO
- [ ] Data / locale behavior
- [x] Build / deployment
- [x] Tests / tooling
- [x] Documentation

No content, locale-data, backend, database, or migration change.

## Verification

- [x] `npm run typecheck`
- [x] `npm run lint`
- [x] `npm test` — 483 passed, 1 intentional emulator skip
- [x] `npm run build` — 1,045 / 1,045 static pages generated
- [x] Manual browser check

Additional verification:

- Production reproduction was RED 3 / 3; the one-variable causal control was GREEN 3 / 3.
- Focused PWA/navigation regression suite: 44 / 44 passed.
- Auto-assignment behavior branches: 7 / 7 passed; deployment workflow tests: 21 / 21 passed.
- Firestore emulator: 6 / 6 passed.
- `git diff --check` and YAML 1.2 parsing passed.
- All artifact, runtime-boundary, SEO, performance, Studio, OG, pagination, localized-404, and offline gates passed.
- Offline browser evidence: no React #418; version meta, manifest, and controlling service-worker registrations agree; zero status events on mount, exactly one event for a real network transition, and no duplicate events.
- Prefetch browser evidence at merge time: Gallery focus toward `/en` and Apps hover toward `/vi` kept initial Home RSC/CSS at 0 / 0 and preserved soft navigation. A deeper 2.5-second observation after deploy found one logical Home destination represented by one HEAD probe plus six segmented RSC requests; follow-up #54 permanently disables prefetch for these two page-back links.
- The CI-only workflow patch does not alter runtime/source/build inputs, so the previously verified static artifact remains applicable.

## Screenshots

Not applicable — there is no intended visual change.

## Risk And Rollback

- Risk level: medium-low
- Rollback plan: revert the hotfix merge commit and let the main-branch Pages workflow rebuild and redeploy the prior static artifact.

There is no persistent-data, backend, or migration impact.

## Notes For Reviewer

- Default assignee: `nguyenlephong`
- Deployment impact: merging to `main` triggers the verified GitHub Pages build and deployment workflow.
- Post-deploy requirement: repeat the offline hard-reload smoke in a fresh browser profile and confirm version provenance, fallback rendering, service-worker control, analytics event cardinality, and run a disposable auto-assignment canary against the default-branch workflow.