### PR TITLE
perf(navigation): eliminate page-back speculation

### DIFF
--- a/scripts/verify-runtime-boundaries.mjs
+++ b/scripts/verify-runtime-boundaries.mjs
@@ -57,10 +57,14 @@ const ARTICLE_HUB_CASES = [
     sources: ["notes_article_breadcrumb"]
   }
 ];
-const PAGE_BACK_PREFETCH_CASES = [
-  { name: "gallery", path: "/en/gallery", homePath: "/en", intent: "focus" },
-  { name: "apps", path: "/vi/apps", homePath: "/vi", intent: "hover" }
+const PAGE_BACK_NAVIGATION_CASES = [
+  { name: "gallery-focus", surface: "gallery", path: "/en/gallery", homePath: "/en", intent: "focus" },
+  { name: "gallery-hover", surface: "gallery", path: "/en/gallery", homePath: "/en", intent: "hover" },
+  { name: "apps-focus", surface: "apps", path: "/vi/apps", homePath: "/vi", intent: "focus" },
+  { name: "apps-hover", surface: "apps", path: "/vi/apps", homePath: "/vi", intent: "hover" }
 ];
+const PAGE_BACK_REQUEST_QUIET_MS = 500;
+const PAGE_BACK_REQUEST_TIMEOUT_MS = 10_000;
 const PUBLIC_CSS_RUNTIME_CASES = [
   { name: "home", path: "/en", selector: ".hero", property: "position", value: "relative", stylesheets: 3 },
   { name: "about", path: "/en/about", selector: ".about-page-v2", property: "paddingBottom", notValue: "0px", stylesheets: 3 },
@@ -213,6 +217,64 @@ function localRequestPath(url, origin) {
   return decodeURIComponent(parsed.pathname).replace(/^\/+/, "");
 }
 
+export function rscDestinationFromPath(localPath) {
+  if (!localPath.endsWith(".txt")) return null;
+  const stem = localPath.slice(0, -4);
+  const segmentMarker = stem.indexOf("/__next.");
+  const destinationStem = segmentMarker === -1 ? stem : stem.slice(0, segmentMarker);
+  return destinationStem ? `/${destinationStem}` : "/";
+}
+
+async function waitForRequestQuietPeriod(
+  page,
+  origin,
+  label,
+  trigger,
+  {
+    quietMs = PAGE_BACK_REQUEST_QUIET_MS,
+    timeoutMs = PAGE_BACK_REQUEST_TIMEOUT_MS
+  } = {}
+) {
+  const activeRequests = new Set();
+  let lastActivityAt = Date.now();
+
+  const onRequest = (request) => {
+    if (localRequestPath(request.url(), origin) === null) return;
+    activeRequests.add(request);
+    lastActivityAt = Date.now();
+  };
+  const onRequestSettled = (request) => {
+    if (!activeRequests.delete(request)) return;
+    lastActivityAt = Date.now();
+  };
+
+  page.on("request", onRequest);
+  page.on("requestfinished", onRequestSettled);
+  page.on("requestfailed", onRequestSettled);
+
+  try {
+    await trigger();
+    lastActivityAt = Date.now();
+    const deadline = lastActivityAt + timeoutMs;
+    while (Date.now() < deadline) {
+      if (
+        activeRequests.size === 0 &&
+        Date.now() - lastActivityAt >= quietMs
+      ) {
+        return;
+      }
+      await page.waitForTimeout(Math.min(quietMs, 50));
+    }
+    throw new Error(
+      `${label} did not reach a ${quietMs}ms local-request quiet window within ${timeoutMs}ms`
+    );
+  } finally {
+    page.off("request", onRequest);
+    page.off("requestfinished", onRequestSettled);
+    page.off("requestfailed", onRequestSettled);
+  }
+}
+
 function isRscRequestForDestination(request, origin, destination) {
   const localPath = localRequestPath(request.url(), origin);
   if (!localPath || !localPath.endsWith(".txt")) return false;
@@ -259,10 +321,10 @@ async function routeStylesheetPaths(routePath, origin) {
   return stylesheetPaths;
 }
 
-async function verifyPageBackPrefetchBoundaries(browser, origin) {
+async function verifyPageBackNavigationBoundaries(browser, origin) {
   const results = [];
 
-  for (const scenario of PAGE_BACK_PREFETCH_CASES) {
+  for (const scenario of PAGE_BACK_NAVIGATION_CASES) {
     const homeStylesheets = await routeStylesheetPaths(
       scenario.homePath,
       origin
@@ -283,7 +345,7 @@ async function verifyPageBackPrefetchBoundaries(browser, origin) {
 
     try {
       await installExternalRuntimeStubs(context, {
-        stubGalleryImages: scenario.name === "gallery"
+        stubGalleryImages: scenario.surface === "gallery"
       });
       const page = await context.newPage();
       page.on("pageerror", (error) => pageErrors.push(error.message));
@@ -292,6 +354,7 @@ async function verifyPageBackPrefetchBoundaries(browser, origin) {
         if (!localPath) return;
         requests.push({
           localPath,
+          method: request.method(),
           phase,
           resourceType: request.resourceType()
         });
@@ -328,6 +391,12 @@ async function verifyPageBackPrefetchBoundaries(browser, origin) {
           request.phase === "initial" &&
           homeOnlyStylesheets.has(request.localPath)
       );
+      const initialHomeProbes = requests.filter(
+        (request) =>
+          request.phase === "initial" &&
+          request.method === "HEAD" &&
+          request.localPath === scenario.homePath.replace(/^\/+/, "")
+      );
       assert.deepEqual(
         initialHomeRsc,
         [],
@@ -338,64 +407,132 @@ async function verifyPageBackPrefetchBoundaries(browser, origin) {
         [],
         `${scenario.name} prefetched Home CSS before page-back intent`
       );
+      assert.deepEqual(
+        initialHomeProbes,
+        [],
+        `${scenario.name} probed Home before page-back intent`
+      );
 
       phase = "page-back-intent";
-      const intentRequest = page.waitForRequest((request) => {
-        const localPath = localRequestPath(request.url(), origin);
-        return Boolean(
-          localPath &&
-            isRscPathForExactDestination(localPath, scenario.homePath)
-        );
-      });
-      if (scenario.intent === "focus") {
-        await pageBack.focus();
-      } else {
-        await pageBack.hover();
-      }
-      await intentRequest;
-      await page.waitForLoadState("networkidle");
+      await waitForRequestQuietPeriod(
+        page,
+        origin,
+        `${scenario.name} page-back intent`,
+        async () => {
+          if (scenario.intent === "focus") {
+            await pageBack.focus();
+          } else {
+            await pageBack.hover();
+          }
+        }
+      );
 
-      const intentRsc = requests.filter(
+      const intentLocalRequests = requests.filter(
+        (request) => request.phase === "page-back-intent"
+      );
+      const intentHomeRsc = intentLocalRequests.filter(
         (request) =>
-          request.phase === "page-back-intent" &&
-          request.localPath.endsWith(".txt")
-      );
-      const intentCss = requests.filter(
-        (request) =>
-          request.phase === "page-back-intent" &&
-          request.resourceType === "stylesheet"
-      );
-      assert.ok(
-        intentRsc.length > 0,
-        `${scenario.name} page-back intent did not prefetch Home RSC`
-      );
-      assert.ok(
-        intentRsc.every((request) =>
           isRscPathForExactDestination(request.localPath, scenario.homePath)
-        ),
-        `${scenario.name} page-back intent prefetched another RSC destination: ${JSON.stringify(intentRsc)}`
       );
-      assert.ok(
-        intentCss.every((request) => homeStylesheets.has(request.localPath)),
-        `${scenario.name} page-back intent fetched non-Home CSS: ${JSON.stringify(intentCss)}`
+      const intentHomeCss = intentLocalRequests.filter(
+        (request) =>
+          request.resourceType === "stylesheet" &&
+          homeOnlyStylesheets.has(request.localPath)
       );
+      const intentHomeProbes = intentLocalRequests.filter(
+        (request) =>
+          request.method === "HEAD" &&
+          request.localPath === scenario.homePath.replace(/^\/+/, "")
+      );
+      assert.deepEqual(intentHomeRsc, []);
+      assert.deepEqual(intentHomeCss, []);
+      assert.deepEqual(intentHomeProbes, []);
       assert.deepEqual(pageErrors, []);
 
       phase = "navigation";
-      await Promise.all([
-        page.waitForURL(`${origin}${scenario.homePath}`),
-        pageBack.click()
-      ]);
-      await page.waitForLoadState("networkidle");
+      await waitForRequestQuietPeriod(
+        page,
+        origin,
+        `${scenario.name} page-back navigation`,
+        () =>
+          Promise.all([
+            page.waitForURL(`${origin}${scenario.homePath}`),
+            pageBack.click()
+          ])
+      );
       const navigationDocuments = requests.filter(
         (request) =>
           request.phase === "navigation" &&
           request.resourceType === "document"
       );
+      const navigationRsc = requests.filter(
+        (request) =>
+          request.phase === "navigation" &&
+          request.localPath.endsWith(".txt")
+      );
+      const navigationRscDestinations = [
+        ...new Set(
+          navigationRsc.map((request) =>
+            rscDestinationFromPath(request.localPath)
+          )
+        )
+      ];
+      const navigationCss = requests.filter(
+        (request) =>
+          request.phase === "navigation" &&
+          request.resourceType === "stylesheet"
+      );
+      const navigationHomeCss = navigationCss.filter((request) =>
+        homeOnlyStylesheets.has(request.localPath)
+      );
+      const navigationSegmentedRsc = navigationRsc.filter((request) =>
+        request.localPath.includes("/__next.")
+      );
+      const navigationHomeProbes = requests.filter(
+        (request) =>
+          request.phase === "navigation" &&
+          request.method === "HEAD" &&
+          request.localPath === scenario.homePath.replace(/^\/+/, "")
+      );
       assert.deepEqual(
         navigationDocuments,
         [],
         `${scenario.name} page-back used a full document navigation`
+      );
+      assert.deepEqual(
+        navigationRscDestinations,
+        [scenario.homePath],
+        `${scenario.name} page-back requested another RSC destination`
+      );
+      assert.equal(
+        navigationRsc.length,
+        1,
+        `${scenario.name} page-back navigation must request one full Home RSC payload`
+      );
+      assert.equal(
+        navigationRsc[0].localPath,
+        `${scenario.homePath.replace(/^\/+/, "")}.txt`
+      );
+      assert.equal(navigationRsc[0].method, "GET");
+      assert.deepEqual(
+        navigationSegmentedRsc,
+        [],
+        `${scenario.name} page-back navigation fetched segmented Home RSC payloads`
+      );
+      assert.equal(
+        navigationCss.length,
+        1,
+        `${scenario.name} page-back navigation must load one stylesheet`
+      );
+      assert.equal(
+        navigationHomeCss.length,
+        navigationCss.length,
+        `${scenario.name} page-back navigation loaded CSS outside Home ownership`
+      );
+      assert.deepEqual(
+        navigationHomeProbes,
+        [],
+        `${scenario.name} page-back navigation made a speculative Home probe`
       );
       assert.equal(
         await page.evaluate(() => window.__pageBackDocumentIdentity),
@@ -403,6 +540,7 @@ async function verifyPageBackPrefetchBoundaries(browser, origin) {
         `${scenario.name} page-back replaced the active document`
       );
       assert.equal(new URL(page.url()).pathname, scenario.homePath);
+      assert.deepEqual(pageErrors, []);
 
       results.push({
         accessibleName,
@@ -410,9 +548,18 @@ async function verifyPageBackPrefetchBoundaries(browser, origin) {
         intent: scenario.intent,
         path: scenario.path,
         initialHomeCss: initialHomeCss.length,
+        initialHomeProbes: initialHomeProbes.length,
         initialHomeRsc: initialHomeRsc.length,
-        intentCss: intentCss.length,
-        intentRsc: intentRsc.length,
+        intentHomeCss: intentHomeCss.length,
+        intentHomeProbes: intentHomeProbes.length,
+        intentHomeRsc: intentHomeRsc.length,
+        intentLocalRequests: intentLocalRequests.length,
+        navigationHomeCss: navigationHomeCss.length,
+        navigationHomeProbes: navigationHomeProbes.length,
+        navigationRscDestinations,
+        navigationRscRequests: navigationRsc.length,
+        navigationSegmentedRsc: navigationSegmentedRsc.length,
+        navigationStylesheets: navigationCss.length,
         navigationDocuments: navigationDocuments.length
       });
     } finally {
@@ -1721,7 +1868,7 @@ async function main() {
       browser,
       origin
     );
-    const pageBackPrefetch = await verifyPageBackPrefetchBoundaries(
+    const pageBackNavigation = await verifyPageBackNavigationBoundaries(
       browser,
       origin
     );
@@ -1750,7 +1897,7 @@ async function main() {
           publicToStudio,
           publicCss,
           galleryPreloadAndLcp,
-          pageBackPrefetch,
+          pageBackNavigation,
           persistedReadingFont,
           readerRemount,
           contentHubAnalytics,

--- a/specs/content-list-loading-performance.md
+++ b/specs/content-list-loading-performance.md
@@ -19,9 +19,11 @@ The public header displays the existing 72 px favicon asset at 36 CSS pixels.
 That small asset is loaded eagerly with high fetch priority; the 512 px app
 icon remains unchanged for Next metadata and install/icon consumers.
 
-The above-fold Gallery and Apps page-back links use the same intent boundary.
-A direct visit does not speculate on Home; keyboard focus or pointer hover can
-restore Next's native prefetch for that single localized destination.
+The above-fold Gallery and Apps page-back links use a stricter boundary than
+content discovery links. They keep Next prefetch disabled through keyboard
+focus and pointer hover, then use normal App Router client navigation only when
+the reader clicks the localized Home link. The shared header and content-card
+intent-prefetch behavior remains unchanged.
 
 ## Why
 
@@ -31,6 +33,13 @@ header also transferred a 512 px image for a 36 px slot, increasing critical
 image bytes without improving visual quality. Loading the Firestore SDK and
 opening provider channels before browsing intent creates a larger avoidable
 network cost than the visible counters themselves.
+
+Production measurement showed that native Home prefetch for either page-back
+link issued a clean-URL probe, six segmented RSC requests, and one stylesheet
+before navigation. Keeping prefetch disabled reduced the chosen navigation to
+one full localized RSC request and one stylesheet while preserving soft client
+navigation. For these low-frequency back links, the request and byte reduction
+outweighs hover or focus warm-up.
 
 ## Acceptance criteria
 
@@ -79,3 +88,13 @@ number when later loading boundaries are added.
     existing crawlable `href`, copy, class, accessibility, analytics, and client
     navigation contract. AppHeader keeps its intentional per-link intent
     prefetch behavior unchanged.
+14. Production request measurement supersedes only the focus/hover prefetch
+    clause of criterion 13 for Gallery and Apps page-back links. Those two links
+    keep `prefetch={false}` during direct load, keyboard focus, and pointer
+    hover, issuing no Home clean-URL probe, RSC payload, or Home-owned CSS. A
+    click remains a soft App Router navigation and requests only the full
+    localized Home RSC payload plus Home-owned styles, with no clean-URL probe
+    or document reload. Runtime verification waits for a request-scoped quiet
+    window so delayed segmented requests cannot escape the intent phase. Shared
+    header, category, article-card, and footer intent-prefetch behavior is
+    unchanged.

--- a/src/components/apps/AppsConsole.tsx
+++ b/src/components/apps/AppsConsole.tsx
@@ -19,7 +19,6 @@ import {
 } from 'react-icons/lu'
 import { APP_ROUTE } from '@/app/app.const'
 import type { AppShowcaseItem } from '@/app/[locale]/(site)/apps/apps.data'
-import IntentPrefetchLink from '@/components/navigation/IntentPrefetchLink'
 import { Link } from '@/i18n/navigation'
 import { track } from '@/lib/analytics'
 import EnglishVisual from './EnglishVisual'
@@ -302,15 +301,16 @@ export default function AppsConsole({ apps, locale }: AppsConsoleProps) {
           </h1>
           <p className="apps-hero-sub">{t.intro}</p>
           <div className="apps-hero-actions">
-            <IntentPrefetchLink
+            <Link
               href={APP_ROUTE.HOME}
+              prefetch={false}
               className="page-back"
               data-track="cv_nav_click"
               data-track-target="home"
               data-track-source="apps_page_back"
             >
               {t.back}
-            </IntentPrefetchLink>
+            </Link>
             <Link
               href="https://github.com/nguyenlephong"
               target="_blank"

--- a/src/components/gallery/GalleryPageBackLink.tsx
+++ b/src/components/gallery/GalleryPageBackLink.tsx
@@ -2,7 +2,7 @@
 
 import type { ReactNode } from 'react'
 import { APP_ROUTE } from '@/app/app.const'
-import IntentPrefetchLink from '@/components/navigation/IntentPrefetchLink'
+import { Link } from '@/i18n/navigation'
 import { track } from '@/lib/analytics'
 
 type Props = {
@@ -11,8 +11,9 @@ type Props = {
 
 export default function GalleryPageBackLink({ children }: Props) {
   return (
-    <IntentPrefetchLink
+    <Link
       href={APP_ROUTE.HOME}
+      prefetch={false}
       className="page-back"
       onClick={() =>
         track('cv_nav_click', {
@@ -22,6 +23,6 @@ export default function GalleryPageBackLink({ children }: Props) {
       }
     >
       {children}
-    </IntentPrefetchLink>
+    </Link>
   )
 }

--- a/tests/analytics-tracking.test.mjs
+++ b/tests/analytics-tracking.test.mjs
@@ -385,9 +385,10 @@ test("Gallery and Apps page-back links keep the existing CV navigation analytics
     galleryPage,
     /<GalleryPageBackLink>\s*\{t\('back'\)\}\s*<\/GalleryPageBackLink>/
   );
-  assert.match(galleryBackLink, /<IntentPrefetchLink/);
-  assert.match(galleryBackLink, /href=\{APP_ROUTE\.HOME\}/);
-  assert.match(galleryBackLink, /className="page-back"/);
+  assert.match(
+    galleryBackLink,
+    /<Link\s+href=\{APP_ROUTE\.HOME\}\s+prefetch=\{false\}\s+className="page-back"/
+  );
   assert.match(
     galleryBackLink,
     /track\('cv_nav_click',\s*\{\s*target: 'home',\s*source: 'gallery_page_back',?\s*\}\)/
@@ -396,7 +397,7 @@ test("Gallery and Apps page-back links keep the existing CV navigation analytics
   assert.match(appsPage, /<AppsLinkTracker \/>/);
   assert.match(
     appsConsole,
-    /<IntentPrefetchLink\s+href=\{APP_ROUTE\.HOME\}\s+className="page-back"\s+data-track="cv_nav_click"\s+data-track-target="home"\s+data-track-source="apps_page_back"\s*>/
+    /<Link\s+href=\{APP_ROUTE\.HOME\}\s+prefetch=\{false\}\s+className="page-back"\s+data-track="cv_nav_click"\s+data-track-target="home"\s+data-track-source="apps_page_back"\s*>/
   );
   assert.match(appsLinkTracker, /target\.closest<HTMLElement>\('\[data-track\]'\)/);
   assert.match(appsLinkTracker, /track\(name, props\)/);

--- a/tests/content-list-loading-performance.test.mjs
+++ b/tests/content-list-loading-performance.test.mjs
@@ -61,7 +61,7 @@ test("public navigation and archive links use shared intent prefetch without los
   assert.match(footer, /data-document-navigation="studio"/);
 });
 
-test("Gallery and Apps page-back links wait for navigation intent before prefetching Home", async () => {
+test("Gallery and Apps page-back links keep speculative Home prefetch disabled", async () => {
   const [galleryPage, galleryBackLink, appsConsole, header] = await Promise.all([
     readFile("src/app/[locale]/(site)/gallery/page.tsx", "utf8"),
     readFile("src/components/gallery/GalleryPageBackLink.tsx", "utf8"),
@@ -70,19 +70,23 @@ test("Gallery and Apps page-back links wait for navigation intent before prefetc
   ]);
 
   assert.match(galleryPage, /<GalleryPageBackLink>/);
-  assert.match(galleryBackLink, /<IntentPrefetchLink/);
-  assert.match(galleryBackLink, /href=\{APP_ROUTE\.HOME\}/);
-  assert.match(galleryBackLink, /className="page-back"/);
+  assert.match(galleryBackLink, /import \{ Link \} from ['"]@\/i18n\/navigation['"]/);
+  assert.doesNotMatch(galleryBackLink, /IntentPrefetchLink/);
+  assert.match(
+    galleryBackLink,
+    /<Link\s+href=\{APP_ROUTE\.HOME\}\s+prefetch=\{false\}\s+className="page-back"/
+  );
   assert.match(
     appsConsole,
-    /<IntentPrefetchLink\s+href=\{APP_ROUTE\.HOME\}\s+className="page-back"/
+    /<Link\s+href=\{APP_ROUTE\.HOME\}\s+prefetch=\{false\}\s+className="page-back"/
   );
+  assert.doesNotMatch(appsConsole, /IntentPrefetchLink/);
 
   assert.equal((header.match(/<IntentPrefetchLink/g) ?? []).length, 3);
   assert.match(header, /<IntentPrefetchLink\s+href=\{APP_ROUTE\.HOME\}/);
 });
 
-test("runtime verification rejects eager Home payloads from Gallery and Apps", async () => {
+test("runtime verification rejects Gallery and Apps Home payloads before click", async () => {
   const runtimeVerifier = await readFile(
     "scripts/verify-runtime-boundaries.mjs",
     "utf8"
@@ -90,23 +94,56 @@ test("runtime verification rejects eager Home payloads from Gallery and Apps", a
 
   assert.match(
     runtimeVerifier,
-    /verifyPageBackPrefetchBoundaries\(browser, origin\)/
+    /verifyPageBackNavigationBoundaries\(browser, origin\)/
   );
   assert.match(
     runtimeVerifier,
-    /path: "\/en\/gallery", homePath: "\/en", intent: "focus"/
+    /name: "gallery-focus", surface: "gallery", path: "\/en\/gallery", homePath: "\/en", intent: "focus"/
   );
   assert.match(
     runtimeVerifier,
-    /path: "\/vi\/apps", homePath: "\/vi", intent: "hover"/
+    /name: "gallery-hover", surface: "gallery", path: "\/en\/gallery", homePath: "\/en", intent: "hover"/
+  );
+  assert.match(
+    runtimeVerifier,
+    /name: "apps-focus", surface: "apps", path: "\/vi\/apps", homePath: "\/vi", intent: "focus"/
+  );
+  assert.match(
+    runtimeVerifier,
+    /name: "apps-hover", surface: "apps", path: "\/vi\/apps", homePath: "\/vi", intent: "hover"/
   );
   assert.match(runtimeVerifier, /initialHomeRsc/);
   assert.match(runtimeVerifier, /initialHomeCss/);
-  assert.match(runtimeVerifier, /intentRsc/);
+  assert.match(runtimeVerifier, /initialHomeProbes/);
+  assert.match(runtimeVerifier, /intentHomeRsc/);
+  assert.match(runtimeVerifier, /intentHomeCss/);
+  assert.match(runtimeVerifier, /intentHomeProbes/);
+  assert.match(runtimeVerifier, /navigationRscDestinations/);
+  assert.match(runtimeVerifier, /navigationSegmentedRsc/);
+  assert.match(runtimeVerifier, /navigationStylesheets/);
+  assert.match(runtimeVerifier, /waitForRequestQuietPeriod/);
   assert.match(runtimeVerifier, /accessibleName/);
   assert.match(runtimeVerifier, /__pageBackDocumentIdentity/);
   assert.match(runtimeVerifier, /navigationDocuments/);
-  assert.match(runtimeVerifier, /pageBackPrefetch/);
+  assert.match(runtimeVerifier, /pageBackNavigation/);
+});
+
+test("runtime verification groups full and segmented RSC files by logical destination", async () => {
+  const { rscDestinationFromPath } = await import(
+    "../scripts/verify-runtime-boundaries.mjs"
+  );
+
+  assert.equal(rscDestinationFromPath("en.txt"), "/en");
+  assert.equal(rscDestinationFromPath("en/__next._tree.txt"), "/en");
+  assert.equal(
+    rscDestinationFromPath("vi/__next.$d$locale.!KHNpdGUp.__PAGE__.txt"),
+    "/vi"
+  );
+  assert.equal(
+    rscDestinationFromPath("en/blog/__next.$d$locale.!KHNpdGUp.__PAGE__.txt"),
+    "/en/blog"
+  );
+  assert.equal(rscDestinationFromPath("en.html"), null);
 });
 
 test("archive post stats stay provider-free until browsing intent", async () => {

--- a/tests/helpers/client-message-contract-config.mjs
+++ b/tests/helpers/client-message-contract-config.mjs
@@ -43,6 +43,7 @@ const CLIENT_PROVIDER_CONSUMER_ROUTES = {
   "src/components/cv/Summary.tsx": "home",
   "src/components/font/FontSwitcher.tsx": "site",
   "src/components/gallery/GalleryGrid.tsx": "gallery",
+  "src/components/gallery/GalleryPageBackLink.tsx": "site",
   "src/components/notes/NotesExplorer.tsx": "notes",
   "src/components/navigation/IntentPrefetchLink.tsx": "site",
   "src/components/offline/OfflineStatusBanner.tsx": "site",


### PR DESCRIPTION
## Summary

- Production smoke after #52 showed that native page-back intent prefetch issues one clean-URL probe, six segmented RSC requests, and one Home stylesheet on focus/hover; a direct soft navigation needs only one full localized Home RSC plus one stylesheet.
- Keep prefetch permanently disabled only for the Gallery and Apps page-back links, preserving localized crawlable hrefs, keyboard/link semantics, soft App Router navigation, and the existing `cv_nav_click` analytics contract.
- Append AC14 and harden the browser gate with request-scoped quiescence across Gallery/Apps × focus/hover so delayed HEAD/segmented requests cannot be undercounted.

## Scope

- [x] UI / UX
- [ ] Content / SEO
- [ ] Data / locale behavior
- [x] Build / deployment
- [x] Tests / tooling
- [x] Documentation

No public copy, canonical/hreflang path, backend, database, locale data, shared header/card intent-prefetch behavior, or analytics taxonomy change.

## Verification

- [x] `npm run typecheck`
- [x] `npm run lint`
- [x] `npm test` — 484 passed, 1 intentional emulator skip
- [x] `npm run build` — 1,045 / 1,045 static pages
- [ ] `npm run build:fast` (not run; the deployable full build passed)
- [x] Manual browser check

Additional verification:

- Node 22.22.1 clean install.
- Focused analytics/performance/provider tests: 35 / 35 passed.
- Runtime gate: all 4 Gallery/Apps × focus/hover cases passed.
- Before click in every case: Home HEAD / RSC / CSS = 0 / 0 / 0.
- Click in every case: 1 GET full localized Home RSC + 1 Home-owned stylesheet; 0 segmented RSC, 0 HEAD, 0 document reload, 0 page errors; document identity and accessible link semantics preserved.
- Artifact: 11,408 files / 209.9 MiB; 941 sitemap URLs; 11,343 public text files secret-scanned.
- Static artifact, performance, pagination, Studio, localized not-found, offline browser, lint, typecheck, and diff-check gates passed.
- Independent fixed-point review: no remaining Blocker/Major/Minor/Nit findings.

## Screenshots

Not applicable — no visual change.

## Risk And Rollback

- Risk level: low
- Trade-off: Home starts loading on click instead of hover/focus; production sampling measured roughly 60–125 ms less warm-up in exchange for eliminating eight speculative requests when intent does not become navigation.
- Rollback plan: revert commit `179ec2faaf` and redeploy the previous intent-prefetch behavior.

## Notes For Reviewer

- Default assignee: `nguyenlephong`
- Deployment impact: merging to `main` triggers the verified GitHub Pages build/deploy workflow.
- SEO impact: neutral; rendered anchors, localized hrefs, metadata, canonicals, hreflang and indexability are unchanged.
- Analytics impact: existing `cv_nav_click` names and Gallery/Apps source/target properties are unchanged.
- Follow-up to production finding on #52; the PWA hydration fix, offline behavior and shared intent-prefetch component are untouched.